### PR TITLE
Automatically find gomp on Ubuntu 22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ set(SRC_FILES
 # find libraries
 set(LIBS "")
 set(OPTIONAL_LIBS amplsolver ma57 metis bqpd CACHE STRING "Optional libraries")
-set(REQUIRED_LIBS dl blas lapack gomp)
+set(REQUIRED_LIBS dl blas lapack)
 
 # automatic detection of optional libraries
 foreach(library_name IN LISTS OPTIONAL_LIBS)
@@ -123,6 +123,8 @@ foreach(library_name IN LISTS REQUIRED_LIBS)
 		list(APPEND LIBS ${${library_name}})
 	endif()
 endforeach(library_name)
+find_package(OpenMP REQUIRED)
+list(APPEND LIBS OpenMP::OpenMP_CXX)
 
 #######
 # Uno #


### PR DESCRIPTION
While compilation on Ubuntu 22.04 is possible by specifying the location of `gomp` manually, it is not user-friendly. As an alternative solution that works out of the box on Ubuntu 22.04, I tought we could use the official CMake's `FindOpenMP` modules, and link the `OpenMP::OpenMP_CXX` imported target. Note that this also adds the `-fopenmp` to compilation, I am not sure if this is problematic. If that is problematic, we can substitute:
~~~cmake
list(APPEND LIBS OpenMP::OpenMP_CXX)
~~~
with:
~~~cmake
list(APPEND LIBS ${OpenMP_gomp_LIBRARY})
~~~
