### PR TITLE
Set print_solution=no in default options

### DIFF
--- a/uno/options/DefaultOptions.cpp
+++ b/uno/options/DefaultOptions.cpp
@@ -22,7 +22,7 @@ namespace uno {
       // CPU time limit (in seconds)
       options["time_limit"] = "inf";
       // print optimal solution (yes|no)
-      options["print_solution"] = "yes";
+      options["print_solution"] = "no";
       // threshold on objective to declare unbounded NLP
       options["unbounded_objective_threshold"] = "-1e20";
       // enforce linear constraints at the initial point (yes|no)


### PR DESCRIPTION
The options file says no
https://github.com/cvanaret/Uno/blob/950c0fe0285ecb2f4ed3d6c67fad072c43e81856/uno.options#L18

If I solve a problem with a large (e.g., 10^6) number of variables or constraints, this is just going to flood the terminal with numbers. I don't think we want that as a default:

![image](https://github.com/user-attachments/assets/8acc8329-5037-4dbb-ad15-b806d9739415)
