### PR TITLE
Set correct options in MUMPS to better detect null pivots (singular matrices)

### DIFF
--- a/uno/solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/solvers/MUMPS/MUMPSSolver.cpp
@@ -28,6 +28,8 @@ namespace uno {
       this->mumps_structure.icntl[1] = -1;
       this->mumps_structure.icntl[2] = -1;
       this->mumps_structure.icntl[3] = 0;
+      this->mumps_structure.icntl[12] = 1;
+      this->mumps_structure.icntl[23] = 1; // ICNTL(24) controls the detection of “null pivot rows”
    }
 
    MUMPSSolver::~MUMPSSolver() {


### PR DESCRIPTION
Correct options set in MUMPS to better detect null pivots (singular matrices).
This should fix #58 and fix #59.