### PR TITLE
Safeguard in ConvexifiedHessian if regularization fails

### DIFF
--- a/uno/ingredients/hessian_models/ConvexifiedHessian.hpp
+++ b/uno/ingredients/hessian_models/ConvexifiedHessian.hpp
@@ -22,6 +22,7 @@ namespace uno {
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<size_t, double>> linear_solver; /*!< Solver that computes the inertia */
       const double regularization_initial_value{};
       const double regularization_increase_factor{};
+      const double regularization_failure_threshold{};
 
       void regularize(Statistics& statistics, SymmetricMatrix<size_t, double>& hessian, size_t number_original_variables);
    };

--- a/uno/ingredients/hessian_models/UnstableRegularization.hpp
+++ b/uno/ingredients/hessian_models/UnstableRegularization.hpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2024 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_UNSTABLEREGULARIZATION_H
+#define UNO_UNSTABLEREGULARIZATION_H
+
+#include <exception>
+
+namespace uno {
+   struct UnstableRegularization : public std::exception {
+
+      [[nodiscard]] const char* what() const noexcept override {
+         return "The inertia correction got unstable (delta_w > threshold)";
+      }
+   };
+} // namespace
+
+#endif // UNO_UNSTABLEREGULARIZATION_H

--- a/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
+++ b/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
@@ -8,19 +8,13 @@
 #include "SymmetricMatrix.hpp"
 #include "SparseStorageFactory.hpp"
 #include "RectangularMatrix.hpp"
+#include "ingredients/hessian_models/UnstableRegularization.hpp"
 #include "model/Model.hpp"
 #include "solvers/DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "options/Options.hpp"
 #include "tools/Statistics.hpp"
 
 namespace uno {
-   struct UnstableRegularization : public std::exception {
-
-      [[nodiscard]] const char* what() const noexcept override {
-         return "The inertia correction got unstable (delta_w > threshold)";
-      }
-   };
-
    template <typename ElementType>
    class SymmetricIndefiniteLinearSystem {
    public:
@@ -158,7 +152,7 @@ namespace uno {
             this->previous_primal_regularization = this->primal_regularization;
          }
          else {
-            auto [number_pos_eigenvalues, number_neg_eigenvalues, number_zero_eigenvalues] = linear_solver.get_inertia();
+            std::tie(number_pos_eigenvalues, number_neg_eigenvalues, number_zero_eigenvalues) = linear_solver.get_inertia();
             DEBUG << "Expected inertia (" << size_primal_block << ", " << size_dual_block << ", 0), ";
             DEBUG << "got (" << number_pos_eigenvalues << ", " << number_neg_eigenvalues << ", " << number_zero_eigenvalues << ")\n";
             DEBUG << "Number of attempts: " << number_attempts << "\n";


### PR DESCRIPTION
Throw an exception of type UnstableRegularization in ConvexifiedHessian if regularization factor becomes too large.
UnstableRegularization moved to its own file.