### PR TITLE
Improve the switch to optimality phase in FeasibilityRestoration

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -50,7 +50,7 @@ namespace uno {
 
       // trial iterate acceptance
       [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
-            double step_length) = 0;
+            double step_length, WarmstartInformation& warmstart_information) = 0;
       [[nodiscard]] TerminationStatus check_termination(Iterate& iterate);
 
       // primal-dual residuals

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -29,7 +29,7 @@ namespace uno {
 
       // trial iterate acceptance
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
-            double step_length) override;
+            double step_length, WarmstartInformation& warmstart_information) override;
 
       // primal-dual residuals
       void compute_primal_dual_residuals(Iterate& iterate) override;
@@ -41,7 +41,6 @@ namespace uno {
       Phase current_phase{Phase::OPTIMALITY};
       const double linear_feasibility_tolerance;
       const bool switch_to_optimality_requires_linearized_feasibility;
-      bool switching_to_optimality_phase{false};
       ProgressMeasures reference_optimality_progress{};
       Vector<double> reference_optimality_primals{};
 
@@ -51,7 +50,7 @@ namespace uno {
       [[nodiscard]] const OptimizationProblem& current_problem() const;
       void solve_subproblem(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate, const Multipliers& current_multipliers,
             Direction& direction, WarmstartInformation& warmstart_information);
-      void switch_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate);
+      void switch_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate, WarmstartInformation& warmstart_information);
 
       void evaluate_progress_measures(Iterate& iterate) const override;
       [[nodiscard]] ProgressMeasures compute_predicted_reduction_models(Iterate& current_iterate, const Direction& direction, double step_length);

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
@@ -232,7 +232,7 @@ namespace uno {
    }
 
    bool l1Relaxation::is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
-         double step_length) {
+         double step_length, WarmstartInformation& /*warmstart_information*/) {
       this->subproblem->postprocess_iterate(this->l1_relaxed_problem, trial_iterate);
       this->compute_progress_measures(current_iterate, trial_iterate);
       trial_iterate.objective_multiplier = this->l1_relaxed_problem.get_objective_multiplier();

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
@@ -36,7 +36,7 @@ namespace uno {
 
       // trial iterate acceptance
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
-            double step_length) override;
+            double step_length, WarmstartInformation& warmstart_information) override;
 
       // primal-dual residuals
       void compute_primal_dual_residuals(Iterate& iterate) override;

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -59,7 +59,8 @@ namespace uno {
                   // scale or not the constraint dual direction with the LS step length
                   this->scale_duals_with_step_length ? step_length : 1.);
 
-            is_acceptable = this->constraint_relaxation_strategy.is_iterate_acceptable(statistics, current_iterate, trial_iterate, this->direction, step_length);
+            is_acceptable = this->constraint_relaxation_strategy.is_iterate_acceptable(statistics, current_iterate, trial_iterate, this->direction,
+                  step_length, warmstart_information);
             this->set_statistics(statistics, trial_iterate, this->direction, step_length, number_iterations);
          }
          catch (const EvaluationError& e) {

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -78,7 +78,7 @@ namespace uno {
                GlobalizationMechanism::assemble_trial_iterate(model, current_iterate, trial_iterate, this->direction, 1., 1.);
                this->reset_active_trust_region_multipliers(model, this->direction, trial_iterate);
 
-               is_acceptable = this->is_iterate_acceptable(statistics, current_iterate, trial_iterate, this->direction);
+               is_acceptable = this->is_iterate_acceptable(statistics, current_iterate, trial_iterate, this->direction, warmstart_information);
                if (is_acceptable) {
                   this->constraint_relaxation_strategy.set_dual_residuals_statistics(statistics, trial_iterate);
                   this->reset_radius();
@@ -124,9 +124,10 @@ namespace uno {
 
    // the trial iterate is accepted by the constraint relaxation strategy or if the step is small and we cannot switch to solving the feasibility problem
    bool TrustRegionStrategy::is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate,
-         const Direction& direction) {
+         const Direction& direction, WarmstartInformation& warmstart_information) {
       // direction.primal_dual_step_length is usually 1, can be lower if reduced by fraction-to-boundary rule
-      bool accept_iterate = this->constraint_relaxation_strategy.is_iterate_acceptable(statistics, current_iterate, trial_iterate, direction, 1.);
+      bool accept_iterate = this->constraint_relaxation_strategy.is_iterate_acceptable(statistics, current_iterate, trial_iterate, direction, 1.,
+            warmstart_information);
       this->set_statistics(statistics, trial_iterate, direction);
       if (accept_iterate) {
          trial_iterate.status = this->constraint_relaxation_strategy.check_termination(trial_iterate);

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
@@ -24,7 +24,8 @@ namespace uno {
       const double radius_reset_threshold;
       const double tolerance;
 
-      bool is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction);
+      bool is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
+            WarmstartInformation& warmstart_information);
       void possibly_increase_radius(double step_norm);
       void decrease_radius(double step_norm);
       void decrease_radius();


### PR DESCRIPTION
The warm-start information object is now passed to `is_iterate_acceptable()`, so we can set a cold start when switching back to the optimality phase without using an extra flag.