### PR TITLE
TR strategy: properly reset the bounds duals and set the warm-start information

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -46,7 +46,7 @@ namespace uno {
       void compute_feasible_direction(Statistics& statistics, Iterate& current_iterate, Direction& direction,
             const Vector<double>& initial_point, WarmstartInformation& warmstart_information);
       [[nodiscard]] virtual bool solving_feasibility_problem() const = 0;
-      virtual void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate) = 0;
+      virtual void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, WarmstartInformation& warmstart_information) = 0;
 
       // trial iterate acceptance
       [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -25,7 +25,7 @@ namespace uno {
       // direction computation
       void compute_feasible_direction(Statistics& statistics, Iterate& current_iterate, Direction& direction, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
-      void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate) override;
+      void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, WarmstartInformation& warmstart_information) override;
 
       // trial iterate acceptance
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
@@ -79,7 +79,8 @@ namespace uno {
       return (this->penalty_parameter == 0.);
    }
 
-   void l1Relaxation::switch_to_feasibility_problem(Statistics& /*statistics*/, Iterate& /*current_iterate*/) {
+   void l1Relaxation::switch_to_feasibility_problem(Statistics& /*statistics*/, Iterate& /*current_iterate*/,
+         WarmstartInformation& /*warmstart_information*/) {
       throw std::runtime_error("l1Relaxation::switch_to_feasibility_problem is not implemented");
    }
 

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
@@ -32,7 +32,7 @@ namespace uno {
       void compute_feasible_direction(Statistics& statistics, Iterate& current_iterate, Direction& direction,
             WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
-      void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate) override;
+      void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, WarmstartInformation& warmstart_information) override;
 
       // trial iterate acceptance
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
@@ -15,7 +15,8 @@ namespace uno {
       BacktrackingLineSearch(ConstraintRelaxationStrategy& constraint_relaxation_strategy, const Options& options);
 
       void initialize(Statistics& statistics, Iterate& initial_iterate, const Options& options) override;
-      void compute_next_iterate(Statistics& statistics, const Model& model, Iterate& current_iterate, Iterate& trial_iterate) override;
+      void compute_next_iterate(Statistics& statistics, const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
+            WarmstartInformation& warmstart_information) override;
 
    private:
       const double backtracking_ratio;

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
@@ -13,7 +13,7 @@ namespace uno {
    class Model;
    class Options;
    class Statistics;
-   class WarmstartInformation;
+   struct WarmstartInformation;
 
    class GlobalizationMechanism {
    public:

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
@@ -13,6 +13,7 @@ namespace uno {
    class Model;
    class Options;
    class Statistics;
+   class WarmstartInformation;
 
    class GlobalizationMechanism {
    public:
@@ -20,7 +21,8 @@ namespace uno {
       virtual ~GlobalizationMechanism() = default;
 
       virtual void initialize(Statistics& statistics, Iterate& initial_iterate, const Options& options) = 0;
-      virtual void compute_next_iterate(Statistics& statistics, const Model& model, Iterate& current_iterate, Iterate& trial_iterate) = 0;
+      virtual void compute_next_iterate(Statistics& statistics, const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
+            WarmstartInformation& warmstart_information) = 0;
 
       [[nodiscard]] size_t get_hessian_evaluation_count() const;
       [[nodiscard]] size_t get_number_subproblems_solved() const;

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -78,6 +78,9 @@ namespace uno {
                GlobalizationMechanism::assemble_trial_iterate(model, current_iterate, trial_iterate, this->direction, 1., 1.);
                this->reset_active_trust_region_multipliers(model, this->direction, trial_iterate);
 
+               // let the constraint relaxation strategy and the radius update rule determine which quantities change
+               warmstart_information.reset();
+
                is_acceptable = this->is_iterate_acceptable(statistics, current_iterate, trial_iterate, this->direction, warmstart_information);
                if (is_acceptable) {
                   this->constraint_relaxation_strategy.set_dual_residuals_statistics(statistics, trial_iterate);
@@ -86,8 +89,7 @@ namespace uno {
                }
                else {
                   this->decrease_radius(this->direction.norm);
-                  // after the first iteration, only the variable bounds are updated
-                  warmstart_information.only_variable_bounds_changed();
+                  warmstart_information.variable_bounds_changed = true;
                }
                if (Logger::level == INFO) statistics.print_current_line();
             }

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -107,17 +107,17 @@ namespace uno {
 
    void TrustRegionStrategy::reset_active_trust_region_multipliers(const Model& model, const Direction& direction, Iterate& trial_iterate) const {
       assert(0 < this->radius && "The trust-region radius should be positive");
-      // set multipliers for bound constraints active at trust region to 0 (except if one of the original bounds is active)
-      for (size_t variable_index: direction.active_bounds.at_lower_bound) {
-         if (variable_index < model.number_variables && std::abs(direction.primals[variable_index] + this->radius) <= this->activity_tolerance &&
-             this->activity_tolerance < std::abs(trial_iterate.primals[variable_index] - model.variable_lower_bound(variable_index))) {
+      // reset multipliers for bound constraints active at trust region (except if one of the original bounds is active)
+      for (size_t variable_index: Range(model.number_variables)) {
+         if (std::abs(direction.primals[variable_index] + this->radius) <= this->activity_tolerance &&
+               this->activity_tolerance < std::abs(trial_iterate.primals[variable_index] - model.variable_lower_bound(variable_index))) {
             trial_iterate.multipliers.lower_bounds[variable_index] = 0.;
+            trial_iterate.feasibility_multipliers.lower_bounds[variable_index] = 0.;
          }
-      }
-      for (size_t variable_index: direction.active_bounds.at_upper_bound) {
-         if (variable_index < model.number_variables && std::abs(direction.primals[variable_index] - this->radius) <= this->activity_tolerance &&
-             this->activity_tolerance < std::abs(model.variable_upper_bound(variable_index) - trial_iterate.primals[variable_index])) {
+         if (std::abs(direction.primals[variable_index] - this->radius) <= this->activity_tolerance &&
+               this->activity_tolerance < std::abs(model.variable_upper_bound(variable_index) - trial_iterate.primals[variable_index])) {
             trial_iterate.multipliers.upper_bounds[variable_index] = 0.;
+            trial_iterate.feasibility_multipliers.upper_bounds[variable_index] = 0.;
          }
       }
    }

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
@@ -12,7 +12,8 @@ namespace uno {
       TrustRegionStrategy(ConstraintRelaxationStrategy& constraint_relaxation_strategy, const Options& options);
 
       void initialize(Statistics& statistics, Iterate& initial_iterate, const Options& options) override;
-      void compute_next_iterate(Statistics& statistics, const Model& model, Iterate& current_iterate, Iterate& trial_iterate) override;
+      void compute_next_iterate(Statistics& statistics, const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
+            WarmstartInformation& warmstart_information) override;
 
    private:
       double radius; /*!< Current trust region radius */

--- a/uno/optimization/WarmstartInformation.cpp
+++ b/uno/optimization/WarmstartInformation.cpp
@@ -13,28 +13,28 @@ namespace uno {
       std::cout << "Problem: " << std::boolalpha << this->problem_changed << '\n';
    }
 
-   void WarmstartInformation::reset() {
-      this->objective_changed = true;
-      this->constraints_changed = true;
-      this->constraint_bounds_changed = true;
-      this->variable_bounds_changed = true;
-      this->problem_changed = true;
+   void WarmstartInformation::no_changes() {
+      this->objective_changed = false;
+      this->constraints_changed = false;
+      this->constraint_bounds_changed = false;
+      this->variable_bounds_changed = false;
+      this->problem_changed = false;
    }
 
-   void WarmstartInformation::set_cold_start() {
-      this->objective_changed = true;
-      this->constraints_changed = true;
-      this->constraint_bounds_changed = true;
-      this->variable_bounds_changed = true;
-      this->problem_changed = true;
-   }
-
-   void WarmstartInformation::set_hot_start() {
+   void WarmstartInformation::iterate_changed() {
       this->objective_changed = true;
       this->constraints_changed = true;
       this->constraint_bounds_changed = true;
       this->variable_bounds_changed = true;
       this->problem_changed = false;
+   }
+
+   void WarmstartInformation::whole_problem_changed() {
+      this->objective_changed = true;
+      this->constraints_changed = true;
+      this->constraint_bounds_changed = true;
+      this->variable_bounds_changed = true;
+      this->problem_changed = true;
    }
 
    void WarmstartInformation::only_objective_changed() {
@@ -42,14 +42,6 @@ namespace uno {
       this->constraints_changed = false;
       this->constraint_bounds_changed = false;
       this->variable_bounds_changed = false;
-      this->problem_changed = false;
-   }
-
-   void WarmstartInformation::only_variable_bounds_changed() {
-      this->objective_changed = false;
-      this->constraints_changed = false;
-      this->constraint_bounds_changed = false;
-      this->variable_bounds_changed = true;
       this->problem_changed = false;
    }
 } // namespace

--- a/uno/optimization/WarmstartInformation.cpp
+++ b/uno/optimization/WarmstartInformation.cpp
@@ -13,6 +13,14 @@ namespace uno {
       std::cout << "Problem: " << std::boolalpha << this->problem_changed << '\n';
    }
 
+   void WarmstartInformation::reset() {
+      this->objective_changed = true;
+      this->constraints_changed = true;
+      this->constraint_bounds_changed = true;
+      this->variable_bounds_changed = true;
+      this->problem_changed = true;
+   }
+
    void WarmstartInformation::set_cold_start() {
       this->objective_changed = true;
       this->constraints_changed = true;

--- a/uno/optimization/WarmstartInformation.hpp
+++ b/uno/optimization/WarmstartInformation.hpp
@@ -13,6 +13,7 @@ namespace uno {
       bool problem_changed{false};
 
       void display() const;
+      void reset();
       void set_cold_start();
       void set_hot_start();
       void only_objective_changed();

--- a/uno/optimization/WarmstartInformation.hpp
+++ b/uno/optimization/WarmstartInformation.hpp
@@ -13,11 +13,10 @@ namespace uno {
       bool problem_changed{false};
 
       void display() const;
-      void reset();
-      void set_cold_start();
-      void set_hot_start();
+      void no_changes();
+      void iterate_changed();
+      void whole_problem_changed();
       void only_objective_changed();
-      void only_variable_bounds_changed();
    };
 } // namespace
 

--- a/uno/preprocessing/Preprocessing.hpp
+++ b/uno/preprocessing/Preprocessing.hpp
@@ -25,7 +25,7 @@ namespace uno {
       static void compute_least_square_multipliers(const Model& model, SymmetricMatrix<size_t, double>& matrix, Vector<double>& rhs,
             DirectSymmetricIndefiniteLinearSolver<size_t, double>& linear_solver, Iterate& current_iterate, Vector<double>& multipliers,
             double multiplier_max_norm);
-      static void enforce_linear_constraints(const Model& model, Vector<double>& x, Multipliers& multipliers, QPSolver& qp_solver);
+      static void enforce_linear_constraints(const Model& model, Vector<double>& primals, Multipliers& multipliers, QPSolver& qp_solver);
    };
 } // namespace
 

--- a/uno/solvers/BQPD/BQPDSolver.cpp
+++ b/uno/solvers/BQPD/BQPDSolver.cpp
@@ -169,7 +169,7 @@ namespace uno {
       if (warmstart_information.problem_changed) {
          mode = BQPDMode::ACTIVE_SET_EQUALITIES;
       }
-         // if only the variable bounds changed, reuse the active set estimate and the Jacobian information
+      // if only the variable bounds changed, reuse the active set estimate and the Jacobian information
       else if (warmstart_information.variable_bounds_changed && not warmstart_information.objective_changed &&
                not warmstart_information.constraints_changed && not warmstart_information.constraint_bounds_changed) {
          mode = BQPDMode::UNCHANGED_ACTIVE_SET_AND_JACOBIAN;

--- a/uno/symbolic/VectorView.hpp
+++ b/uno/symbolic/VectorView.hpp
@@ -58,6 +58,15 @@ namespace uno {
    VectorView<Expression> view(Expression&& expression, size_t start, size_t end) {
       return {std::forward<Expression>(expression), start, end};
    }
+
+   template <typename Expression>
+   std::ostream& operator<<(std::ostream& stream, const VectorView<Expression>& view) {
+      for (size_t index: Range(view.size())) {
+         stream << view[index] << " ";
+      }
+      stream << '\n';
+      return stream;
+   }
 } // namespace
 
 #endif //UNO_VECTORVIEW_H


### PR DESCRIPTION
Properly update the WarmstartInformation object: handle phase switches, errors, etc.
Two fixes in TrustRegionStrategy:
- loop over all variables to reset the multipliers when TR constraints are active;
- reset the feasibility multipliers as well;