### PR TITLE
Bugfixes in WarmstartInformation and termination criteria

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -206,7 +206,7 @@ namespace uno {
 
       const bool feasibility_stationarity = (current_iterate.feasibility_residuals.stationarity <= tolerance);
       const bool feasibility_complementarity = (current_iterate.feasibility_residuals.complementarity <= tolerance);
-      const bool no_trivial_duals = current_iterate.multipliers.not_all_zero(this->model.number_variables, tolerance);
+      const bool no_trivial_duals = current_iterate.feasibility_multipliers.not_all_zero(this->model.number_variables, tolerance);
 
       DEBUG << "\nTermination criteria for tolerance = " << tolerance << ":\n";
       DEBUG << "Stationarity: " << std::boolalpha << stationarity << '\n';
@@ -221,7 +221,7 @@ namespace uno {
          // feasible regular stationary point
          return TerminationStatus::FEASIBLE_KKT_POINT;
       }
-      else if (this->model.is_constrained() && feasibility_stationarity && not primal_feasibility && feasibility_complementarity) {
+      else if (this->model.is_constrained() && feasibility_stationarity && not primal_feasibility && feasibility_complementarity && no_trivial_duals) {
          // no primal feasibility, stationary point of constraint violation
          return TerminationStatus::INFEASIBLE_STATIONARY_POINT;
       }

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -58,9 +58,6 @@ namespace uno {
                   // scale or not the constraint dual direction with the LS step length
                   this->scale_duals_with_step_length ? step_length : 1.);
 
-            // let the constraint relaxation strategy determine which quantities change
-            warmstart_information.no_changes();
-
             is_acceptable = this->constraint_relaxation_strategy.is_iterate_acceptable(statistics, current_iterate, trial_iterate, this->direction,
                   step_length, warmstart_information);
             this->set_statistics(statistics, trial_iterate, this->direction, step_length, number_iterations);

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -77,9 +77,6 @@ namespace uno {
                GlobalizationMechanism::assemble_trial_iterate(model, current_iterate, trial_iterate, this->direction, 1., 1.);
                this->reset_active_trust_region_multipliers(model, this->direction, trial_iterate);
 
-               // let the constraint relaxation strategy and the radius update rule determine which quantities change
-               warmstart_information.no_changes();
-
                is_acceptable = this->is_iterate_acceptable(statistics, current_iterate, trial_iterate, this->direction, warmstart_information);
                if (is_acceptable) {
                   this->constraint_relaxation_strategy.set_dual_residuals_statistics(statistics, trial_iterate);

--- a/uno/optimization/WarmstartInformation.cpp
+++ b/uno/optimization/WarmstartInformation.cpp
@@ -26,7 +26,6 @@ namespace uno {
       this->constraints_changed = true;
       this->constraint_bounds_changed = true;
       this->variable_bounds_changed = true;
-      this->problem_changed = false;
    }
 
    void WarmstartInformation::whole_problem_changed() {

--- a/uno/optimization/WarmstartInformation.hpp
+++ b/uno/optimization/WarmstartInformation.hpp
@@ -6,11 +6,11 @@
 
 namespace uno {
    struct WarmstartInformation {
-      bool objective_changed{false};
-      bool constraints_changed{false};
-      bool constraint_bounds_changed{false};
-      bool variable_bounds_changed{false};
-      bool problem_changed{false};
+      bool objective_changed{true};
+      bool constraints_changed{true};
+      bool constraint_bounds_changed{true};
+      bool variable_bounds_changed{true};
+      bool problem_changed{true};
 
       void display() const;
       void no_changes();


### PR DESCRIPTION
Fixes:
- iterate_changed() in WarmstartInformation does not modify the problem field (this is determined by the constraint relaxation strategy)
- prevent premature convergence to infeasible points by imposing that the feasibility duals be not all zero.