### PR TITLE
[CI] Fix the compilation on Windows

### DIFF
--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -83,6 +83,12 @@ cd $WORKSPACE/srcdir/Uno
 mkdir -p build
 cd build
 
+if [[ "${target}" == *mingw* ]]; then
+    LIBHIGHS=${prefix}/lib/libhighs.dll.a
+else
+    LIBHIGHS=${libdir}/libhighs.${dlext}
+fi
+
 if [[ "${target}" == *apple* ]] || [[ "${target}" == *freebsd* ]]; then
     OMP=omp
 else
@@ -98,7 +104,7 @@ cmake \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DAMPLSOLVER=${libdir}/libasl.${dlext} \
-    -DHIGHS=${libdir}/libhighs.${dlext} \
+    -DHIGHS=${LIBHIGHS} \
     -DHSL=${libdir}/libhsl.${dlext} \
     -DMUMPS_INCLUDE_DIR=${includedir} \
     -DMETIS_INCLUDE_DIR=${includedir} \
@@ -117,7 +123,7 @@ install -v -m 755 "uno_ampl${exeext}" -t "${bindir}"
 
 # Currently, Uno does not provide a shared library. This may be useful in the future once it has a C API.
 # We just check that we can generate it, but we don't include it in the tarballs.
-${CXX} -shared $(flagon -Wl,--whole-archive) libuno.a $(flagon -Wl,--no-whole-archive) -o libuno.${dlext} -L${libdir} -l${OMP} -lopenblas -ldmumps -lmetis -lhsl
+${CXX} -shared $(flagon -Wl,--whole-archive) libuno.a $(flagon -Wl,--no-whole-archive) -o libuno.${dlext} -L${libdir} -l${OMP} -lopenblas -ldmumps -lmetis -lhsl -lhighs
 cp libuno.a ${prefix}/lib/libuno.a
 cp libuno.${dlext} ${libdir}/libuno.${dlext}
 """

--- a/.github/julia/build_tarballs_yggdrasil.jl
+++ b/.github/julia/build_tarballs_yggdrasil.jl
@@ -23,8 +23,10 @@ cd build
 
 if [[ "${target}" == *mingw* ]]; then
     LBT=blastrampoline-5
+    LIBHIGHS=${prefix}/lib/libhighs.dll.a
 else
     LBT=blastrampoline
+    LIBHIGHS=${libdir}/libhighs.${dlext}
 fi
 
 if [[ "${target}" == *apple* ]] || [[ "${target}" == *freebsd* ]]; then
@@ -42,7 +44,7 @@ cmake \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DAMPLSOLVER=${libdir}/libasl.${dlext} \
-    -DHIGHS=${libdir}/libhighs.${dlext} \
+    -DHIGHS=${LIBHIGHS} \
     -DHSL=${libdir}/libhsl.${dlext} \
     -DBLA_VENDOR="libblastrampoline" \
     -DMUMPS_INCLUDE_DIR=${includedir} \
@@ -62,7 +64,7 @@ install -v -m 755 "uno_ampl${exeext}" -t "${bindir}"
 
 # Currently, Uno does not provide a shared library. This may be useful in the future once it has a C API.
 # We just check that we can generate it, but we don't include it in the tarballs.
-${CXX} -shared $(flagon -Wl,--whole-archive) libuno.a $(flagon -Wl,--no-whole-archive) -o libuno.${dlext} -L${libdir} -l${OMP} -l${LBT} -ldmumps -lmetis -lhsl
+${CXX} -shared $(flagon -Wl,--whole-archive) libuno.a $(flagon -Wl,--no-whole-archive) -o libuno.${dlext} -L${libdir} -l${OMP} -l${LBT} -ldmumps -lmetis -lhsl -lhighs
 # cp libuno.${dlext} ${libdir}/libuno.${dlext}
 """
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,25 +22,25 @@ jobs:
           echo "BINARYBUILDER_AUTOMATIC_APPLE=true" >> $GITHUB_ENV
           echo "UNO_RELEASE=${{ github.ref_name }}" >> $GITHUB_ENV
           echo "UNO_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
-      - name: Cross-compilation of Uno -- x86_64-linux-gnu-libgfortran5
+      - name: Cross-compilation of Uno -- x86_64-linux-gnu-cxx11
         run: |
           julia --color=yes -e 'using Pkg; Pkg.add("BinaryBuilder")'
-          julia --color=yes .github/julia/build_tarballs_release.jl x86_64-linux-gnu-libgfortran5 --verbose
+          julia --color=yes .github/julia/build_tarballs_release.jl x86_64-linux-gnu-cxx11 --verbose
           rm -r ~/.julia
-      - name: Cross-compilation of Uno -- x86_64-w64-mingw32-libgfortran5
+      - name: Cross-compilation of Uno -- x86_64-w64-mingw32-cxx11
         run: |
           julia --color=yes -e 'using Pkg; Pkg.add("BinaryBuilder")'
-          julia --color=yes .github/julia/build_tarballs_release.jl x86_64-w64-mingw32-libgfortran5 --verbose
+          julia --color=yes .github/julia/build_tarballs_release.jl x86_64-w64-mingw32-cxx11 --verbose
           rm -r ~/.julia
-      - name: Cross-compilation of Uno -- x86_64-apple-darwin-libgfortran5
+      - name: Cross-compilation of Uno -- x86_64-apple-darwin-cxx11
         run: |
           julia --color=yes -e 'using Pkg; Pkg.add("BinaryBuilder")'
-          julia --color=yes .github/julia/build_tarballs_release.jl x86_64-apple-darwin-libgfortran5 --verbose
+          julia --color=yes .github/julia/build_tarballs_release.jl x86_64-apple-darwin-cxx11 --verbose
           rm -r ~/.julia
-      - name: Cross-compilation of Uno -- aarch64-apple-darwin-libgfortran5
+      - name: Cross-compilation of Uno -- aarch64-apple-darwin-cxx11
         run: |
           julia --color=yes -e 'using Pkg; Pkg.add("BinaryBuilder")'
-          julia --color=yes .github/julia/build_tarballs_release.jl aarch64-apple-darwin-libgfortran5 --verbose
+          julia --color=yes .github/julia/build_tarballs_release.jl aarch64-apple-darwin-cxx11 --verbose
           rm -r ~/.julia
       - name: Generate the binaries
         run: julia --color=yes .github/julia/generate_binaries.jl
@@ -61,7 +61,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Uno_binaries.${{ github.ref_name }}.x86_64-linux-gnu-libgfortran5.tar.gz
+          asset_path: ./Uno_binaries.${{ github.ref_name }}.x86_64-linux-gnu-cxx11.tar.gz
           asset_name: Uno.${{ github.ref_name }}.linux.tar.gz
           asset_content_type: application/gzip
       - name: upload Mac (Intel) artifact
@@ -70,7 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Uno_binaries.${{ github.ref_name }}.x86_64-apple-darwin-libgfortran5.tar.gz
+          asset_path: ./Uno_binaries.${{ github.ref_name }}.x86_64-apple-darwin-cxx11.tar.gz
           asset_name: Uno.${{ github.ref_name }}.mac-intel.tar.gz
           asset_content_type: application/gzip
       - name: upload Mac (ARM) artifact
@@ -79,7 +79,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Uno_binaries.${{ github.ref_name }}.aarch64-apple-darwin-libgfortran5.tar.gz
+          asset_path: ./Uno_binaries.${{ github.ref_name }}.aarch64-apple-darwin-cxx11.tar.gz
           asset_name: Uno.${{ github.ref_name }}.mac-arm.tar.gz
           asset_content_type: application/gzip
       - name: upload Windows artifact
@@ -88,6 +88,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Uno_binaries.${{ github.ref_name }}.x86_64-w64-mingw32-libgfortran5.zip
+          asset_path: ./Uno_binaries.${{ github.ref_name }}.x86_64-w64-mingw32-cxx11.zip
           asset_name: Uno.${{ github.ref_name }}.windows.zip
           asset_content_type: application/zip


### PR DESCRIPTION
@odow @cvanaret 
`HiGHS` provides some configuration files for CMake, making it easier to detect when compiling it with other libraries like `Uno`.

The issue is that these configuration files use `libuno.dll.a` on Windows as an entry point for linking.
A file `*.dll.a` is an import library (neither static nor shared) — see my explanation [here](https://github.com/cvanaret/Uno/pull/78#issuecomment-2479013907).
If we use `-DHIGHS=${libdir}/libhighs.dll`, we create another entry point that leads to duplicate symbols during the linking phase.

I modified the files `build_tarballs_*.jl` so that we use the import library of HiGHS on Windows to ensure a single entry point.

After merging this PR, Charlie, you can retrigger the CI build by forcing the tag with:
```
git tag v1.3.0 -f
git push --tags -f
```
