### PR TITLE
Replaced std::optional.value() with * dereferencing

### DIFF
--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -87,25 +87,6 @@ cd $WORKSPACE/srcdir/Uno
 mkdir -p build
 cd build
 
-if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    # Work around the issue
-    #     /workspace/srcdir/Uno/uno/options/Presets.cpp:17:48: error: 'value' is unavailable: introduced in macOS 10.14
-    #           Presets::set(options, optional_preset.value());
-    #                               ^
-    #     /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/optional:938:33: note: 'value' has been explicitly marked unavailable here
-    #           constexpr value_type const& value() const&
-    #                               ^
-    export MACOSX_DEPLOYMENT_TARGET=10.15
-    # ...and install a newer SDK which supports `std::filesystem`
-    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
-    # CV: replacing rm -rf with mv to fix https://github.com/cvanaret/Uno/issues/94
-    # rm -rf /opt/${target}/${target}/sys-root/System
-    mv /opt/${target}/${target}/sys-root/System /opt/${target}/${target}/sys-root/System_old
-    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
-    cp -ra System "/opt/${target}/${target}/sys-root/."
-    popd
-fi
-
 if [[ "${target}" == *mingw* ]]; then
     LIBHIGHS=${prefix}/lib/libhighs.dll.a
 else

--- a/.github/julia/build_tarballs_yggdrasil.jl
+++ b/.github/julia/build_tarballs_yggdrasil.jl
@@ -23,23 +23,6 @@ cd $WORKSPACE/srcdir/Uno
 mkdir -p build
 cd build
 
-if [[ "${target}" == x86_64-apple-darwin* ]]; then
-    # Work around the issue
-    #     /workspace/srcdir/Uno/uno/options/Presets.cpp:17:48: error: 'value' is unavailable: introduced in macOS 10.14
-    #           Presets::set(options, optional_preset.value());
-    #                               ^
-    #     /opt/x86_64-apple-darwin14/x86_64-apple-darwin14/sys-root/usr/include/c++/v1/optional:938:33: note: 'value' has been explicitly marked unavailable here
-    #           constexpr value_type const& value() const&
-    #                               ^
-    export MACOSX_DEPLOYMENT_TARGET=10.15
-    # ...and install a newer SDK which supports `std::filesystem`
-    pushd $WORKSPACE/srcdir/MacOSX10.*.sdk
-    rm -rf /opt/${target}/${target}/sys-root/System
-    cp -ra usr/* "/opt/${target}/${target}/sys-root/usr/."
-    cp -ra System "/opt/${target}/${target}/sys-root/."
-    popd
-fi
-
 if [[ "${target}" == *mingw* ]]; then
     LBT=blastrampoline-5
     LIBHIGHS=${prefix}/lib/libhighs.dll.a

--- a/.github/julia/generate_binaries.jl
+++ b/.github/julia/generate_binaries.jl
@@ -31,11 +31,10 @@ for (platform, libdir, ext) in platforms
       run(`tar -xzf products/$platform/deps.tar.gz -C products/$platform`)
 
       # Copy the license of each dependency
-      # CV: comment out temporarily
-      #for folder in readdir("products/$platform/deps/licenses")
-      #  cp("products/$platform/deps/licenses/$folder", "products/$platform/share/licenses/$folder")
-      #end
-      #rm("products/$platform/deps/licenses", recursive=true)
+      for folder in readdir("products/$platform/deps/licenses")
+        cp("products/$platform/deps/licenses/$folder", "products/$platform/share/licenses/$folder")
+      end
+      rm("products/$platform/deps/licenses", recursive=true)
 
       # Copy the shared library of each dependency
       for file in readdir("products/$platform/deps")

--- a/bindings/AMPL/uno_ampl.cpp
+++ b/bindings/AMPL/uno_ampl.cpp
@@ -113,7 +113,7 @@ int main(int argc, char* argv[]) {
          // possibly set options from an option file
          const auto optional_option_file = command_line_options.get_string_optional("option_file");
          if (optional_option_file.has_value()) {
-            Options file_options = Options::load_option_file(optional_option_file.value());
+            Options file_options = Options::load_option_file(*optional_option_file);
             options.overwrite_with(file_options);
          }
 

--- a/uno/options/Presets.cpp
+++ b/uno/options/Presets.cpp
@@ -14,7 +14,7 @@ namespace uno {
 
       /** optional user preset **/
       if (optional_preset.has_value()) {
-         Presets::set(options, optional_preset.value());
+         Presets::set(options, *optional_preset);
       }
       else {
          /** default preset **/


### PR DESCRIPTION
Replaced:
```cpp
if (x.has_value()) {
   // use x.value()
}
```
with
```cpp
if (x.has_value()) {
   // use *x
}
```
as not supported by macOS < 10.13.
Removed specialized CI code for macOS (not needed any more).