### PR TITLE
Reduce the number of symbolic analyses

### DIFF
--- a/.github/julia/runtests.jl
+++ b/.github/julia/runtests.jl
@@ -18,11 +18,11 @@ import Uno_jll
 Create a new `AmplNLWriter.Optimizer` object that uses Uno as the backing
 solver.
 """
-function Optimizer(options = String["logger=SILENT"])
+function Optimizer(options = String["logger=SILENT", "unbounded_objective_threshold=-1e15"])
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_LP() = Optimizer(["logger=SILENT", "preset=filterslp", "max_iterations=10000"])
+Optimizer_LP() = Optimizer(["logger=SILENT", "preset=filterslp", "max_iterations=10000", "unbounded_objective_threshold=-1e15"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 @testset "MINLPTests" begin

--- a/uno/ingredients/subproblems/interior_point_methods/PrimalDualInteriorPointSubproblem.cpp
+++ b/uno/ingredients/subproblems/interior_point_methods/PrimalDualInteriorPointSubproblem.cpp
@@ -213,6 +213,7 @@ namespace uno {
          const Multipliers& current_multipliers, const WarmstartInformation& warmstart_information) {
       // assemble, factorize and regularize the augmented matrix
       this->augmented_system.assemble_matrix(this->hessian_model->hessian, this->constraint_jacobian, problem.number_variables, problem.number_constraints);
+      DEBUG << "Testing factorization with regularization factors (0, 0)\n";
       this->augmented_system.factorize_matrix(*this->linear_solver, warmstart_information);
       const double dual_regularization_parameter = std::pow(this->barrier_parameter(), this->parameters.regularization_exponent);
       this->augmented_system.regularize_matrix(statistics, *this->linear_solver, problem.number_variables, problem.number_constraints,

--- a/uno/ingredients/subproblems/interior_point_methods/PrimalDualInteriorPointSubproblem.hpp
+++ b/uno/ingredients/subproblems/interior_point_methods/PrimalDualInteriorPointSubproblem.hpp
@@ -79,7 +79,8 @@ namespace uno {
             const Vector<double>& primal_direction, double tau);
       [[nodiscard]] static double dual_fraction_to_boundary(const OptimizationProblem& problem, const Multipliers& current_multipliers,
             Multipliers& direction_multipliers, double tau);
-      void assemble_augmented_system(Statistics& statistics, const OptimizationProblem& problem, const Multipliers& current_multipliers);
+      void assemble_augmented_system(Statistics& statistics, const OptimizationProblem& problem, const Multipliers& current_multipliers,
+            const WarmstartInformation& warmstart_information);
       void assemble_augmented_rhs(const OptimizationProblem& problem, const Multipliers& current_multipliers);
       void assemble_primal_dual_direction(const OptimizationProblem& problem, const Vector<double>& current_primals, const Multipliers& current_multipliers,
             Vector<double>& direction_primals, Multipliers& direction_multipliers);

--- a/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
+++ b/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
@@ -99,6 +99,7 @@ namespace uno {
       this->number_factorizations++;
    }
 
+   // the matrix has been factorized prior to calling this function
    template <typename ElementType>
    void SymmetricIndefiniteLinearSystem<ElementType>::regularize_matrix(Statistics& statistics,
          DirectSymmetricIndefiniteLinearSolver<size_t, ElementType>& linear_solver, size_t size_primal_block, size_t size_dual_block,
@@ -107,17 +108,17 @@ namespace uno {
       this->primal_regularization = ElementType(0.);
       this->dual_regularization = ElementType(0.);
       size_t number_attempts = 1;
-      DEBUG << "Testing factorization with regularization factors (" << this->primal_regularization << ", " << this->dual_regularization << ")\n";
+      DEBUG << "Number of attempts: " << number_attempts << "\n\n";
 
-      if (not linear_solver.matrix_is_singular() && linear_solver.number_negative_eigenvalues() == size_dual_block) {
-         DEBUG << "Inertia is good\n";
+      auto [number_pos_eigenvalues, number_neg_eigenvalues, number_zero_eigenvalues] = linear_solver.get_inertia();
+      DEBUG << "Expected inertia (" << size_primal_block << ", " << size_dual_block << ", 0), ";
+      DEBUG << "Estimated inertia (" << number_pos_eigenvalues << ", " << number_neg_eigenvalues << ", " << number_zero_eigenvalues << ")\n";
+
+      if (number_pos_eigenvalues == size_primal_block && number_neg_eigenvalues == size_dual_block && number_zero_eigenvalues == 0) {
+         DEBUG << "The inertia is correct\n";
          statistics.set("regulariz", this->primal_regularization);
          return;
       }
-      auto [number_pos_eigenvalues, number_neg_eigenvalues, number_zero_eigenvalues] = linear_solver.get_inertia();
-      DEBUG << "Expected inertia (" << size_primal_block << ", " << size_dual_block << ", 0), ";
-      DEBUG << "got (" << number_pos_eigenvalues << ", " << number_neg_eigenvalues << ", " << number_zero_eigenvalues << ")\n";
-      DEBUG << "Number of attempts: " << number_attempts << "\n\n";
 
       // set the constraint regularization coefficient
       if (linear_solver.matrix_is_singular()) {
@@ -144,17 +145,18 @@ namespace uno {
          DEBUG2 << this->matrix << '\n';
          this->factorize_matrix(linear_solver, warmstart_information);
          number_attempts++;
+         DEBUG << "Number of attempts: " << number_attempts << "\n";
 
-         if (not linear_solver.matrix_is_singular() && linear_solver.number_negative_eigenvalues() == size_dual_block) {
+         std::tie(number_pos_eigenvalues, number_neg_eigenvalues, number_zero_eigenvalues) = linear_solver.get_inertia();
+         DEBUG << "Expected inertia (" << size_primal_block << ", " << size_dual_block << ", 0), ";
+         DEBUG << "Estimated inertia (" << number_pos_eigenvalues << ", " << number_neg_eigenvalues << ", " << number_zero_eigenvalues << ")\n";
+
+         if (number_pos_eigenvalues == size_primal_block && number_neg_eigenvalues == size_dual_block && number_zero_eigenvalues == 0) {
             good_inertia = true;
-            DEBUG << "Factorization was a success\n";
+            DEBUG << "The inertia is correct\n";
             this->previous_primal_regularization = this->primal_regularization;
          }
          else {
-            std::tie(number_pos_eigenvalues, number_neg_eigenvalues, number_zero_eigenvalues) = linear_solver.get_inertia();
-            DEBUG << "Expected inertia (" << size_primal_block << ", " << size_dual_block << ", 0), ";
-            DEBUG << "got (" << number_pos_eigenvalues << ", " << number_neg_eigenvalues << ", " << number_zero_eigenvalues << ")\n";
-            DEBUG << "Number of attempts: " << number_attempts << "\n";
             if (this->previous_primal_regularization == 0. || this->threshold_unsuccessful_attempts < number_attempts) {
                this->primal_regularization *= this->primal_regularization_fast_increase_factor;
             }

--- a/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
+++ b/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
@@ -111,7 +111,7 @@ namespace uno {
       DEBUG << "Number of attempts: " << number_attempts << "\n\n";
 
       auto [number_pos_eigenvalues, number_neg_eigenvalues, number_zero_eigenvalues] = linear_solver.get_inertia();
-      DEBUG << "Expected inertia (" << size_primal_block << ", " << size_dual_block << ", 0), ";
+      DEBUG << "Expected inertia  (" << size_primal_block << ", " << size_dual_block << ", 0)\n";
       DEBUG << "Estimated inertia (" << number_pos_eigenvalues << ", " << number_neg_eigenvalues << ", " << number_zero_eigenvalues << ")\n";
 
       if (number_pos_eigenvalues == size_primal_block && number_neg_eigenvalues == size_dual_block && number_zero_eigenvalues == 0) {
@@ -148,7 +148,7 @@ namespace uno {
          DEBUG << "Number of attempts: " << number_attempts << "\n";
 
          std::tie(number_pos_eigenvalues, number_neg_eigenvalues, number_zero_eigenvalues) = linear_solver.get_inertia();
-         DEBUG << "Expected inertia (" << size_primal_block << ", " << size_dual_block << ", 0), ";
+         DEBUG << "Expected inertia  (" << size_primal_block << ", " << size_dual_block << ", 0)\n";
          DEBUG << "Estimated inertia (" << number_pos_eigenvalues << ", " << number_neg_eigenvalues << ", " << number_zero_eigenvalues << ")\n";
 
          if (number_pos_eigenvalues == size_primal_block && number_neg_eigenvalues == size_dual_block && number_zero_eigenvalues == 0) {

--- a/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
+++ b/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
@@ -91,7 +91,7 @@ namespace uno {
    template <typename ElementType>
    void SymmetricIndefiniteLinearSystem<ElementType>::factorize_matrix(DirectSymmetricIndefiniteLinearSolver<size_t, ElementType>& linear_solver,
          const WarmstartInformation& warmstart_information) {
-      if (warmstart_information.problem_structure_changed) {
+      if (true) {
          DEBUG << "Performing symbolic analysis of the indefinite system\n";
          linear_solver.do_symbolic_analysis(this->matrix);
       }

--- a/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
+++ b/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
@@ -91,7 +91,7 @@ namespace uno {
    template <typename ElementType>
    void SymmetricIndefiniteLinearSystem<ElementType>::factorize_matrix(DirectSymmetricIndefiniteLinearSolver<size_t, ElementType>& linear_solver,
          const WarmstartInformation& warmstart_information) {
-      if (true) {
+      if (warmstart_information.problem_structure_changed) {
          DEBUG << "Performing symbolic analysis of the indefinite system\n";
          linear_solver.do_symbolic_analysis(this->matrix);
       }

--- a/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
+++ b/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
@@ -34,7 +34,6 @@ namespace uno {
       // [[nodiscard]] T get_primal_regularization() const;
 
    protected:
-      size_t number_factorizations{0};
       ElementType primal_regularization{0.};
       ElementType dual_regularization{0.};
       ElementType previous_primal_regularization{0.};
@@ -92,11 +91,12 @@ namespace uno {
    template <typename ElementType>
    void SymmetricIndefiniteLinearSystem<ElementType>::factorize_matrix(DirectSymmetricIndefiniteLinearSolver<size_t, ElementType>& linear_solver,
          const WarmstartInformation& warmstart_information) {
-      if (warmstart_information.problem_changed) {
+      if (warmstart_information.problem_structure_changed) {
+         DEBUG << "Performing symbolic analysis of the indefinite system\n";
          linear_solver.do_symbolic_analysis(this->matrix);
       }
+      DEBUG << "Performing numerical factorization of the indefinite system\n";
       linear_solver.do_numerical_factorization(this->matrix);
-      this->number_factorizations++;
    }
 
    // the matrix has been factorized prior to calling this function

--- a/uno/optimization/WarmstartInformation.cpp
+++ b/uno/optimization/WarmstartInformation.cpp
@@ -10,7 +10,7 @@ namespace uno {
       std::cout << "Constraints: " << std::boolalpha << this->constraints_changed << '\n';
       std::cout << "Constraint bounds: " << std::boolalpha << this->constraint_bounds_changed << '\n';
       std::cout << "Variable bounds: " << std::boolalpha << this->variable_bounds_changed << '\n';
-      std::cout << "Problem: " << std::boolalpha << this->problem_changed << '\n';
+      std::cout << "Problem structure: " << std::boolalpha << this->problem_structure_changed << '\n';
    }
 
    void WarmstartInformation::no_changes() {
@@ -18,7 +18,7 @@ namespace uno {
       this->constraints_changed = false;
       this->constraint_bounds_changed = false;
       this->variable_bounds_changed = false;
-      this->problem_changed = false;
+      this->problem_structure_changed = false;
    }
 
    void WarmstartInformation::iterate_changed() {
@@ -33,7 +33,7 @@ namespace uno {
       this->constraints_changed = true;
       this->constraint_bounds_changed = true;
       this->variable_bounds_changed = true;
-      this->problem_changed = true;
+      this->problem_structure_changed = true;
    }
 
    void WarmstartInformation::only_objective_changed() {
@@ -41,6 +41,6 @@ namespace uno {
       this->constraints_changed = false;
       this->constraint_bounds_changed = false;
       this->variable_bounds_changed = false;
-      this->problem_changed = false;
+      this->problem_structure_changed = false;
    }
 } // namespace

--- a/uno/optimization/WarmstartInformation.hpp
+++ b/uno/optimization/WarmstartInformation.hpp
@@ -10,7 +10,7 @@ namespace uno {
       bool constraints_changed{true};
       bool constraint_bounds_changed{true};
       bool variable_bounds_changed{true};
-      bool problem_changed{true};
+      bool problem_structure_changed{true};
 
       void display() const;
       void no_changes();

--- a/uno/solvers/BQPD/BQPDSolver.cpp
+++ b/uno/solvers/BQPD/BQPDSolver.cpp
@@ -165,8 +165,8 @@ namespace uno {
 
    BQPDMode BQPDSolver::determine_mode(const WarmstartInformation& warmstart_information) const {
       BQPDMode mode = (this->number_calls == 0) ? BQPDMode::ACTIVE_SET_EQUALITIES : BQPDMode::USER_DEFINED;
-      // if problem changed, use cold start
-      if (warmstart_information.problem_changed) {
+      // if problem structure changed, use cold start
+      if (warmstart_information.problem_structure_changed) {
          mode = BQPDMode::ACTIVE_SET_EQUALITIES;
       }
       // if only the variable bounds changed, reuse the active set estimate and the Jacobian information

--- a/uno/solvers/MA57/MA57Solver.cpp
+++ b/uno/solvers/MA57/MA57Solver.cpp
@@ -165,7 +165,7 @@ namespace uno {
       // build the internal matrix representation
       this->row_indices.clear();
       this->column_indices.clear();
-      for (const auto [row_index, column_index, element]: matrix) {
+      for (const auto [row_index, column_index, _]: matrix) {
          this->row_indices.emplace_back(static_cast<int>(row_index + this->fortran_shift));
          this->column_indices.emplace_back(static_cast<int>(column_index + this->fortran_shift));
       }

--- a/uno/solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/solvers/MUMPS/MUMPSSolver.cpp
@@ -62,6 +62,7 @@ namespace uno {
       this->mumps_structure.jcn = this->column_indices.data();
       this->mumps_structure.a = nullptr;
       dmumps_c(&this->mumps_structure);
+      this->mumps_structure.icntl[7] = 8; // ICNTL(8) = 8: recompute scaling before factorization
    }
 
    void MUMPSSolver::do_numerical_factorization(const SymmetricMatrix<size_t, double>& matrix) {

--- a/uno/solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/solvers/MUMPS/MUMPSSolver.cpp
@@ -35,6 +35,13 @@ namespace uno {
       this->mumps_structure.icntl[12] = 1;
       this->mumps_structure.icntl[23] = 1; // ICNTL(24) controls the detection of “null pivot rows”
 
+      /*
+      // debug for MUMPS team
+      this->mumps_structure.icntl[1] = 6; // ICNTL(2)=6
+      this->mumps_structure.icntl[2] = 6; // ICNTL(3)=6
+      this->mumps_structure.icntl[3] = 6; // ICNTL(4)=2
+       */
+
       this->row_indices.reserve(number_nonzeros);
       this->column_indices.reserve(number_nonzeros);
    }

--- a/uno/solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/solvers/MUMPS/MUMPSSolver.cpp
@@ -29,8 +29,8 @@ namespace uno {
       this->mumps_structure.icntl[1] = -1;
       this->mumps_structure.icntl[2] = -1;
       this->mumps_structure.icntl[3] = 0;
-      this->mumps_structure.icntl[5] = 0; // no scaling
-      this->mumps_structure.icntl[7] = 0; // no scaling
+      //this->mumps_structure.icntl[5] = 0; // no scaling
+      //this->mumps_structure.icntl[7] = 0; // no scaling
 
       this->mumps_structure.icntl[12] = 1;
       this->mumps_structure.icntl[23] = 1; // ICNTL(24) controls the detection of “null pivot rows”

--- a/uno/solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/solvers/MUMPS/MUMPSSolver.cpp
@@ -29,6 +29,8 @@ namespace uno {
       this->mumps_structure.icntl[1] = -1;
       this->mumps_structure.icntl[2] = -1;
       this->mumps_structure.icntl[3] = 0;
+      this->mumps_structure.icntl[5] = 0; // no scaling
+      this->mumps_structure.icntl[7] = 0; // no scaling
 
       this->mumps_structure.icntl[12] = 1;
       this->mumps_structure.icntl[23] = 1; // ICNTL(24) controls the detection of “null pivot rows”
@@ -51,6 +53,7 @@ namespace uno {
       // connect the local sparsity with the pointers in the structure
       this->mumps_structure.irn = this->row_indices.data();
       this->mumps_structure.jcn = this->column_indices.data();
+      this->mumps_structure.a = nullptr;
       dmumps_c(&this->mumps_structure);
    }
 

--- a/uno/solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/solvers/MUMPS/MUMPSSolver.cpp
@@ -26,12 +26,9 @@ namespace uno {
       dmumps_c(&this->mumps_structure);
       // control parameters
       this->mumps_structure.icntl[0] = -1;
-      this->mumps_structure.icntl[1] = 0;
-      this->mumps_structure.icntl[2] = 0;
+      this->mumps_structure.icntl[1] = -1;
+      this->mumps_structure.icntl[2] = -1;
       this->mumps_structure.icntl[3] = 0;
-      this->mumps_structure.icntl[6] = 7; // pivot order
-      this->mumps_structure.icntl[7] = 6; // scaling
-      this->mumps_structure.icntl[9] = 0; // no iterative refinement
       this->mumps_structure.icntl[12] = 1;
       this->mumps_structure.icntl[23] = 1; // ICNTL(24) controls the detection of “null pivot rows”
    }

--- a/uno/solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/solvers/MUMPS/MUMPSSolver.cpp
@@ -26,9 +26,12 @@ namespace uno {
       dmumps_c(&this->mumps_structure);
       // control parameters
       this->mumps_structure.icntl[0] = -1;
-      this->mumps_structure.icntl[1] = -1;
-      this->mumps_structure.icntl[2] = -1;
+      this->mumps_structure.icntl[1] = 0;
+      this->mumps_structure.icntl[2] = 0;
       this->mumps_structure.icntl[3] = 0;
+      this->mumps_structure.icntl[6] = 7; // pivot order
+      this->mumps_structure.icntl[7] = 6; // scaling
+      this->mumps_structure.icntl[9] = 0; // no iterative refinement
       this->mumps_structure.icntl[12] = 1;
       this->mumps_structure.icntl[23] = 1; // ICNTL(24) controls the detection of “null pivot rows”
    }
@@ -37,12 +40,12 @@ namespace uno {
       this->mumps_structure.job = MUMPSSolver::JOB_END;
       dmumps_c(&this->mumps_structure);
    }
-
+   
    void MUMPSSolver::do_symbolic_analysis(const SymmetricMatrix<size_t, double>& matrix) {
+      this->mumps_structure.job = MUMPSSolver::JOB_ANALYSIS;
       this->save_sparsity_to_local_format(matrix);
       this->mumps_structure.n = static_cast<int>(matrix.dimension());
       this->mumps_structure.nnz = static_cast<int>(matrix.number_nonzeros());
-      this->mumps_structure.job = MUMPSSolver::JOB_ANALYSIS;
       this->mumps_structure.a = nullptr;
       // connect the local COO matrix with the pointers in the structure
       this->mumps_structure.irn = this->row_indices.data();

--- a/uno/solvers/MUMPS/MUMPSSolver.hpp
+++ b/uno/solvers/MUMPS/MUMPSSolver.hpp
@@ -27,6 +27,7 @@ namespace uno {
 
    protected:
       DMUMPS_STRUC_C mumps_structure{};
+
       // matrix sparsity
       std::vector<int> row_indices{};
       std::vector<int> column_indices{};


### PR DESCRIPTION
Tasks:
- [x] pass WarmstartInformation object to `factorize_matrix()`;
- [x] compute symbolic analysis only when the Hessian sparsity changes;
- [x] figure out why MUMPS behaves differently when there is a single analysis at the beginning (apparently a different scaling).