### PR TITLE
Return the Result from Uno::solve()

### DIFF
--- a/bindings/AMPL/uno_ampl.cpp
+++ b/bindings/AMPL/uno_ampl.cpp
@@ -55,7 +55,13 @@ namespace uno {
          AMPLUserCallbacks user_callbacks{};
 
          // solve the instance
-         uno.solve(*model, initial_iterate, options, user_callbacks);
+         Result result = uno.solve(*model, initial_iterate, options, user_callbacks);
+         if (result.optimization_status == OptimizationStatus::SUCCESS) {
+            // check result.solution.status
+         }
+         else {
+            // ...
+         }
          // std::cout << "memory_allocation_amount = " << memory_allocation_amount << '\n';
       }
       catch (std::exception& exception) {

--- a/uno/Uno.hpp
+++ b/uno/Uno.hpp
@@ -21,8 +21,8 @@ namespace uno {
       Uno(GlobalizationMechanism& globalization_mechanism, const Options& options);
 
       // solve with or without user callbacks
-      void solve(const Model& model, Iterate& initial_iterate, const Options& options);
-      void solve(const Model& model, Iterate& initial_iterate, const Options& options, UserCallbacks& user_callbacks);
+      Result solve(const Model& model, Iterate& initial_iterate, const Options& options);
+      Result solve(const Model& model, Iterate& initial_iterate, const Options& options, UserCallbacks& user_callbacks);
 
       static std::string current_version();
       static void print_available_strategies();


### PR DESCRIPTION
Return an object of type `Result` from Uno::solve().
Following https://github.com/cvanaret/Uno/pull/110, the user can access `Result.optimization_status` (success, iteration limit, time limit, evaluation error, algorithmic error) and `Result.solution.status` (KKT point, infeasible, etc).

Fixes https://github.com/cvanaret/Uno/issues/105.