### PR TITLE
(WIP) Review of the MA27 interface

### DIFF
--- a/uno/solvers/MA27/MA27Solver.hpp
+++ b/uno/solvers/MA27/MA27Solver.hpp
@@ -37,8 +37,8 @@ private:
    int nz_max{};                    // maximal number of nonzeros entries
    int n{};			                // dimension of current factorisation (maximal value here is <= max_dimension)
    int nnz{};			            // number of nonzeros of current factorisation
-   std::array<int,30> icntl{};      // integer array of length 30; integer control values
-   std::array<double,5> cntl{};     // double array of length 5; double control values
+   std::array<int, 30> icntl{};      // integer array of length 30; integer control values
+   std::array<double, 5> cntl{};     // double array of length 5; double control values
 
    std::vector<int> irn{};          // row index of input
    std::vector<int> icn{};          // col index of input
@@ -48,7 +48,7 @@ private:
    std::vector<int> iw1{};          // integer workspace array of length n
    int nsteps{};                    // integer, to be set by ma27
    int iflag{};                     // integer; 0 if pivot order chosen automatically; 1 if the pivot order set by ikeep
-   std::array<int,20> info{};       // integer array of length 20
+   std::array<int, 20> info{};       // integer array of length 20
    double ops{};                    // double, operations count
 
    std::vector<double> factor{};    // data array of length la;


### PR DESCRIPTION
Fixed following bugs:
- `ikeep` has size `3n`, not `3nnz`;
- the member `factor` that initially contains the matrix entries, then the factors after a call to `MA27BD`, must be initialized in `do_numerical_factorization()`. This solves the issue with the `byrd`preset on `hs015` mentioned in https://github.com/cvanaret/Uno/pull/115.

cc @worc4021 