### PR TITLE
[CMake] Link the Fortran compiler when static libraries are linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,10 @@ endif()
 add_library(uno STATIC ${UNO_SOURCE_FILES})
 set_property(TARGET uno PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(uno PUBLIC ${DIRECTORIES})
-target_link_libraries(uno PUBLIC ${LIBRARIES})
+target_link_libraries(uno PUBLIC ${LIBRARIES}
+   # link Fortran compiler even when static libraries are linked
+   ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES} 
+)
 
 ######################
 # optional AMPL main #


### PR DESCRIPTION
This is necessary for WIP developments (making BQPD matrix-free, see https://github.com/cvanaret/Uno/pull/114).