### PR TITLE
Fixed unwanted copy of DualResiduals

### DIFF
--- a/uno/ingredients/subproblems/interior_point_methods/PrimalDualInteriorPointSubproblem.cpp
+++ b/uno/ingredients/subproblems/interior_point_methods/PrimalDualInteriorPointSubproblem.cpp
@@ -186,7 +186,7 @@ namespace uno {
       }
 
       // possibly update the barrier parameter
-      const auto residuals = this->solving_feasibility_problem ? current_iterate.feasibility_residuals : current_iterate.residuals;
+      const auto& residuals = this->solving_feasibility_problem ? current_iterate.feasibility_residuals : current_iterate.residuals;
       if (not this->first_feasibility_iteration) {
          this->update_barrier_parameter(problem, current_iterate, current_multipliers, residuals);
       }


### PR DESCRIPTION
Replaced
```cpp
const auto residuals = this->solving_feasibility_problem ? current_iterate.feasibility_residuals : current_iterate.residuals;
```
with
```cpp
const auto& residuals = this->solving_feasibility_problem ? current_iterate.feasibility_residuals : current_iterate.residuals;
```
in `PrimalDualInteriorPointSubproblem`, thus getting rid of an unwanted copy.