### PR TITLE
Improved WarmstartInformation object

### DIFF
--- a/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
+++ b/uno/linear_algebra/SymmetricIndefiniteLinearSystem.hpp
@@ -92,10 +92,10 @@ namespace uno {
    template <typename ElementType>
    void SymmetricIndefiniteLinearSystem<ElementType>::factorize_matrix(DirectSymmetricIndefiniteLinearSolver<size_t, ElementType>& linear_solver,
          WarmstartInformation& warmstart_information) {
-      if (warmstart_information.problem_structure_changed) {
+      if (warmstart_information.hessian_sparsity_changed || warmstart_information.jacobian_sparsity_changed) {
          DEBUG << "Performing symbolic analysis of the indefinite system\n";
          linear_solver.do_symbolic_analysis(this->matrix);
-         warmstart_information.problem_structure_changed = false;
+         warmstart_information.hessian_sparsity_changed = warmstart_information.jacobian_sparsity_changed = false;
       }
       DEBUG << "Performing numerical factorization of the indefinite system\n";
       linear_solver.do_numerical_factorization(this->matrix);

--- a/uno/optimization/WarmstartInformation.cpp
+++ b/uno/optimization/WarmstartInformation.cpp
@@ -6,11 +6,12 @@
 
 namespace uno {
    void WarmstartInformation::display() const {
-      std::cout << "Objective: " << std::boolalpha << this->objective_changed << '\n';
-      std::cout << "Constraints: " << std::boolalpha << this->constraints_changed << '\n';
-      std::cout << "Constraint bounds: " << std::boolalpha << this->constraint_bounds_changed << '\n';
-      std::cout << "Variable bounds: " << std::boolalpha << this->variable_bounds_changed << '\n';
-      std::cout << "Problem structure: " << std::boolalpha << this->problem_structure_changed << '\n';
+      std::cout << "Objective changed: " << std::boolalpha << this->objective_changed << '\n';
+      std::cout << "Constraints changed: " << std::boolalpha << this->constraints_changed << '\n';
+      std::cout << "Constraint bounds changed: " << std::boolalpha << this->constraint_bounds_changed << '\n';
+      std::cout << "Variable bounds changed: " << std::boolalpha << this->variable_bounds_changed << '\n';
+      std::cout << "Hessian sparsity changed: " << std::boolalpha << this->hessian_sparsity_changed << '\n';
+      std::cout << "Jacobian sparsity changed: " << std::boolalpha << this->jacobian_sparsity_changed << '\n';
    }
 
    void WarmstartInformation::no_changes() {
@@ -18,7 +19,8 @@ namespace uno {
       this->constraints_changed = false;
       this->constraint_bounds_changed = false;
       this->variable_bounds_changed = false;
-      this->problem_structure_changed = false;
+      this->hessian_sparsity_changed = false;
+      this->jacobian_sparsity_changed = false;
    }
 
    void WarmstartInformation::iterate_changed() {
@@ -33,7 +35,8 @@ namespace uno {
       this->constraints_changed = true;
       this->constraint_bounds_changed = true;
       this->variable_bounds_changed = true;
-      this->problem_structure_changed = true;
+      this->hessian_sparsity_changed = true;
+      this->jacobian_sparsity_changed = true;
    }
 
    void WarmstartInformation::only_objective_changed() {
@@ -41,6 +44,7 @@ namespace uno {
       this->constraints_changed = false;
       this->constraint_bounds_changed = false;
       this->variable_bounds_changed = false;
-      this->problem_structure_changed = false;
+      this->hessian_sparsity_changed = false;
+      this->jacobian_sparsity_changed = false;
    }
 } // namespace

--- a/uno/optimization/WarmstartInformation.hpp
+++ b/uno/optimization/WarmstartInformation.hpp
@@ -10,7 +10,9 @@ namespace uno {
       bool constraints_changed{true};
       bool constraint_bounds_changed{true};
       bool variable_bounds_changed{true};
-      bool problem_structure_changed{true};
+      // bool problem_structure_changed{true};
+      bool hessian_sparsity_changed{true};
+      bool jacobian_sparsity_changed{true};
 
       void display() const;
       void no_changes();

--- a/uno/solvers/BQPD/BQPDSolver.cpp
+++ b/uno/solvers/BQPD/BQPDSolver.cpp
@@ -166,7 +166,7 @@ namespace uno {
    BQPDMode BQPDSolver::determine_mode(const WarmstartInformation& warmstart_information) const {
       BQPDMode mode = (this->number_calls == 0) ? BQPDMode::ACTIVE_SET_EQUALITIES : BQPDMode::USER_DEFINED;
       // if problem structure changed, use cold start
-      if (warmstart_information.problem_structure_changed) {
+      if (warmstart_information.hessian_sparsity_changed || warmstart_information.jacobian_sparsity_changed) {
          mode = BQPDMode::ACTIVE_SET_EQUALITIES;
       }
       // if only the variable bounds changed, reuse the active set estimate and the Jacobian information


### PR DESCRIPTION
Replaced `WarmstartInformation.problem_structure_changed` with two flags: `hessian_sparsity_changed` and `jacobian_sparsity_changed`. This should allow a finer control in the subproblem solvers.