### PR TITLE
[WIP] Reoptimization capabilities

### DIFF
--- a/bindings/AMPL/uno_ampl.cpp
+++ b/bindings/AMPL/uno_ampl.cpp
@@ -11,6 +11,7 @@
 #include "AMPLUserCallbacks.hpp"
 #include "Uno.hpp"
 #include "model/ModelFactory.hpp"
+#include "optimization/WarmstartInformation.hpp"
 #include "options/DefaultOptions.hpp"
 #include "options/Options.hpp"
 #include "options/Presets.hpp"
@@ -55,7 +56,8 @@ namespace uno {
          AMPLUserCallbacks user_callbacks{};
 
          // solve the instance
-         Result result = uno.solve(*model, initial_iterate, options, user_callbacks);
+         WarmstartInformation warmstart_information{};
+         Result result = uno.solve(*model, initial_iterate, options, user_callbacks, warmstart_information);
          if (result.optimization_status == OptimizationStatus::SUCCESS) {
             // check result.solution.status
          }

--- a/bindings/AMPL/uno_ampl.cpp
+++ b/bindings/AMPL/uno_ampl.cpp
@@ -58,6 +58,15 @@ namespace uno {
          // solve the instance
          WarmstartInformation warmstart_information{};
          Result result = uno.solve(*model, initial_iterate, options, user_callbacks, warmstart_information);
+
+
+         auto modified_model = AMPLModel("/media/data/AMPL/CUTEst/hs015_different_bounds", options);
+         WarmstartInformation warmstart_information2{};
+         warmstart_information2.no_changes();
+         warmstart_information2.variable_bounds_changed = true;
+         result = uno.solve(modified_model, result.solution, options, user_callbacks, warmstart_information2);
+
+
          if (result.optimization_status == OptimizationStatus::SUCCESS) {
             // check result.solution.status
          }

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -97,6 +97,7 @@ namespace uno {
       statistics.start_new_line();
       statistics.set("iter", 0);
       statistics.set("status", "initial point");
+
       this->globalization_mechanism.initialize(statistics, current_iterate, options);
       options.print_used();
       if (Logger::level == INFO) statistics.print_current_line();

--- a/uno/Uno.hpp
+++ b/uno/Uno.hpp
@@ -15,14 +15,16 @@ namespace uno {
    class Statistics;
    class Timer;
    class UserCallbacks;
+   class WarmstartInformation;
 
    class Uno {
    public:
       Uno(GlobalizationMechanism& globalization_mechanism, const Options& options);
 
       // solve with or without user callbacks
-      Result solve(const Model& model, Iterate& initial_iterate, const Options& options);
-      Result solve(const Model& model, Iterate& initial_iterate, const Options& options, UserCallbacks& user_callbacks);
+      Result solve(const Model& model, Iterate& initial_iterate, const Options& options, WarmstartInformation& warmstart_information);
+      Result solve(const Model& model, Iterate& initial_iterate, const Options& options, UserCallbacks& user_callbacks,
+         WarmstartInformation& warmstart_information);
 
       static std::string current_version();
       static void print_available_strategies();

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -33,7 +33,7 @@ namespace uno {
       statistics.add_column("TR iter", Statistics::int_width + 2, options.get_int("statistics_minor_column_order"));
       statistics.add_column("TR radius", Statistics::double_width - 4, options.get_int("statistics_TR_radius_column_order"));
       statistics.set("TR radius", this->radius);
-      
+
       this->constraint_relaxation_strategy.set_trust_region_radius(this->radius);
       this->constraint_relaxation_strategy.initialize(statistics, initial_iterate, options);
    }

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -5,7 +5,6 @@
 #include "BQPDSolver.hpp"
 #include "ingredients/constraint_relaxation_strategies/OptimizationProblem.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
-#include "linear_algebra/SymmetricMatrix.hpp"
 #include "linear_algebra/Vector.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Iterate.hpp"

--- a/uno/optimization/WarmstartInformation.cpp
+++ b/uno/optimization/WarmstartInformation.cpp
@@ -23,7 +23,7 @@ namespace uno {
       this->jacobian_sparsity_changed = false;
    }
 
-   void WarmstartInformation::iterate_changed() {
+   void WarmstartInformation::new_iterate() {
       this->objective_changed = true;
       this->constraints_changed = true;
       this->constraint_bounds_changed = true;

--- a/uno/optimization/WarmstartInformation.hpp
+++ b/uno/optimization/WarmstartInformation.hpp
@@ -16,7 +16,7 @@ namespace uno {
 
       void display() const;
       void no_changes();
-      void iterate_changed();
+      void new_iterate();
       void whole_problem_changed();
       void only_objective_changed();
    };


### PR DESCRIPTION
Added reoptimization capabilities to Uno, using the existing `WarmstartInformation` object:
- [x] pass the `WarmstartInformation` object as a parameter to `Uno::solve()`, instead of creating it within the function;
- [x] modify the `WarmstartInformation` object at the end of each major iteration, not at the beginning;
- [x] generate reformulation on the fly in `ConstraintRelaxationStrategy`, instead of storing it once and for all;
- [ ] determine whether the initial point of the reoptimization (= the solution to the previous problem, at which the functions were not evaluated!) is close enough to the previous iterate. If so, use the evaluations as is. If not, reevaluate them.

Guidelines for a good reoptimization:
- the `WarmstartInformation` object must be updated properly between consecutive calls to ``Uno::solve() (e.g. the field `variable_bounds_changed` must be set to true if the variable bounds change);
- the initial iterate should be the previous solution `Result.solution`.

Addresses https://github.com/cvanaret/Uno/issues/107
[@ashu](https://github.com/ashutoshmahajan)