### PR TITLE
Correct computation of the number of Hessian nonzeros

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/OptimizationProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/OptimizationProblem.cpp
@@ -101,8 +101,8 @@ namespace uno {
       return this->model.number_jacobian_nonzeros();
    }
 
-   size_t OptimizationProblem::number_hessian_nonzeros() const {
-      return this->model.number_hessian_nonzeros();
+   size_t OptimizationProblem::number_hessian_nonzeros(const HessianModel& hessian_model) const {
+      return hessian_model.number_nonzeros(this->model);
    }
 
    double OptimizationProblem::stationarity_error(const LagrangianGradient<double>& lagrangian_gradient, double objective_multiplier,

--- a/uno/ingredients/constraint_relaxation_strategies/OptimizationProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/OptimizationProblem.hpp
@@ -61,7 +61,7 @@ namespace uno {
 
       [[nodiscard]] virtual size_t number_objective_gradient_nonzeros() const;
       [[nodiscard]] virtual size_t number_jacobian_nonzeros() const;
-      [[nodiscard]] virtual size_t number_hessian_nonzeros() const;
+      [[nodiscard]] virtual size_t number_hessian_nonzeros(const HessianModel& hessian_model) const;
 
       [[nodiscard]] static double stationarity_error(const LagrangianGradient<double>& lagrangian_gradient, double objective_multiplier,
             Norm residual_norm);

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
@@ -290,8 +290,13 @@ namespace uno {
       return this->model.number_jacobian_nonzeros() + this->number_elastic_variables;
    }
 
-   size_t l1RelaxedProblem::number_hessian_nonzeros() const {
-      return this->model.number_hessian_nonzeros();
+   size_t l1RelaxedProblem::number_hessian_nonzeros(const HessianModel& hessian_model) const {
+      size_t number_nonzeros = hessian_model.number_nonzeros(this->model);
+      // proximal contribution
+      if (this->proximal_center != nullptr && this->proximal_coefficient != 0.) {
+         number_nonzeros += this->model.number_variables;
+      }
+      return number_nonzeros;
    }
 
    void l1RelaxedProblem::set_proximal_multiplier(double new_proximal_coefficient) {

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
@@ -37,7 +37,7 @@ namespace uno {
 
       [[nodiscard]] size_t number_objective_gradient_nonzeros() const override;
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;
-      [[nodiscard]] size_t number_hessian_nonzeros() const override;
+      [[nodiscard]] size_t number_hessian_nonzeros(const HessianModel& hessian_model) const override;
 
       void evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate, const Multipliers& multipliers) const override;
       [[nodiscard]] double complementarity_error(const Vector<double>& primals, const std::vector<double>& constraints,

--- a/uno/ingredients/hessian_models/ConvexifiedHessian.cpp
+++ b/uno/ingredients/hessian_models/ConvexifiedHessian.cpp
@@ -26,8 +26,8 @@ namespace uno {
       linear_solver->initialize_memory(model.number_variables, model.number_hessian_nonzeros() + model.number_variables);
    }
 
-   size_t ConvexifiedHessian::number_nonzeros(const OptimizationProblem& problem) const {
-      return problem.number_hessian_nonzeros() + problem.number_variables;
+   size_t ConvexifiedHessian::number_nonzeros(const Model& model) const {
+      return model.number_hessian_nonzeros() + model.number_variables;
    }
 
    void ConvexifiedHessian::evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables,

--- a/uno/ingredients/hessian_models/ConvexifiedHessian.hpp
+++ b/uno/ingredients/hessian_models/ConvexifiedHessian.hpp
@@ -15,7 +15,7 @@ namespace uno {
       explicit ConvexifiedHessian(const Options& options);
 
       void initialize(const Model& model) override;
-      [[nodiscard]] size_t number_nonzeros(const OptimizationProblem& problem) const override;
+      [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
       void evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables, double objective_multiplier,
          const Vector<double>& constraint_multipliers, SymmetricMatrix<size_t, double>& hessian) override;
       void compute_hessian_vector_product(const Model& model, const Vector<double>& vector, double objective_multiplier,

--- a/uno/ingredients/hessian_models/ExactHessian.cpp
+++ b/uno/ingredients/hessian_models/ExactHessian.cpp
@@ -11,8 +11,8 @@ namespace uno {
    void ExactHessian::initialize(const Model& /*model*/) {
    }
 
-   size_t ExactHessian::number_nonzeros(const OptimizationProblem& problem) const {
-      return problem.number_hessian_nonzeros();
+   size_t ExactHessian::number_nonzeros(const Model& model) const {
+      return model.number_hessian_nonzeros();
    }
 
    void ExactHessian::evaluate_hessian(Statistics& /*statistics*/, const Model& model, const Vector<double>& primal_variables,

--- a/uno/ingredients/hessian_models/ExactHessian.hpp
+++ b/uno/ingredients/hessian_models/ExactHessian.hpp
@@ -10,7 +10,7 @@ namespace uno {
       ExactHessian() = default;
 
       void initialize(const Model& model) override;
-      [[nodiscard]] size_t number_nonzeros(const OptimizationProblem& problem) const override;
+      [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
       void evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables, double objective_multiplier,
          const Vector<double>& constraint_multipliers, SymmetricMatrix<size_t, double>& hessian) override;
       void compute_hessian_vector_product(const Model& model, const Vector<double>& vector, double objective_multiplier,

--- a/uno/ingredients/hessian_models/HessianModel.hpp
+++ b/uno/ingredients/hessian_models/HessianModel.hpp
@@ -9,7 +9,6 @@
 namespace uno {
    // forward declarations
    class Model;
-   class OptimizationProblem;
    class Options;
    class Statistics;
    template <typename IndexType, typename ElementType>
@@ -25,7 +24,7 @@ namespace uno {
       size_t evaluation_count{0};
 
       virtual void initialize(const Model& model) = 0;
-      [[nodiscard]] virtual size_t number_nonzeros(const OptimizationProblem& problem) const = 0;
+      [[nodiscard]] virtual size_t number_nonzeros(const Model& model) const = 0;
       virtual void evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables,
          double objective_multiplier, const Vector<double>& constraint_multipliers, SymmetricMatrix<size_t, double>& hessian) = 0;
       virtual void compute_hessian_vector_product(const Model& model, const Vector<double>& vector, double objective_multiplier,

--- a/uno/ingredients/hessian_models/ZeroHessian.cpp
+++ b/uno/ingredients/hessian_models/ZeroHessian.cpp
@@ -10,7 +10,7 @@ namespace uno {
 
    }
 
-   size_t ZeroHessian::number_nonzeros(const OptimizationProblem& /*problem*/) const {
+   size_t ZeroHessian::number_nonzeros(const Model& /*model*/) const {
       return 0;
    }
 

--- a/uno/ingredients/hessian_models/ZeroHessian.hpp
+++ b/uno/ingredients/hessian_models/ZeroHessian.hpp
@@ -10,7 +10,7 @@ namespace uno {
       ZeroHessian() = default;
 
       void initialize(const Model& model) override;
-      [[nodiscard]] size_t number_nonzeros(const OptimizationProblem& problem) const override;
+      [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
       void evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables, double objective_multiplier,
          const Vector<double>& constraint_multipliers, SymmetricMatrix<size_t, double>& hessian) override;
       void compute_hessian_vector_product(const Model& model, const Vector<double>& vector, double objective_multiplier,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
@@ -41,7 +41,7 @@ namespace uno {
       this->objective_gradient.reserve(barrier_problem.number_objective_gradient_nonzeros());
       this->constraints.resize(barrier_problem.number_constraints);
       this->constraint_jacobian.resize(barrier_problem.number_constraints, barrier_problem.number_variables);
-      const size_t number_hessian_nonzeros = hessian_model.number_nonzeros(barrier_problem);
+      const size_t number_hessian_nonzeros = barrier_problem.number_hessian_nonzeros(hessian_model);
       const size_t number_augmented_system_nonzeros = number_hessian_nonzeros + barrier_problem.number_jacobian_nonzeros() +
          barrier_problem.number_variables + barrier_problem.number_constraints; // primal-dual regularization,
       this->hessian = SymmetricMatrix<size_t, double>(barrier_problem.number_variables, number_hessian_nonzeros, false, "COO");

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
@@ -143,15 +143,15 @@ namespace uno {
       return this->first_reformulation.number_jacobian_nonzeros();
    }
 
-   size_t PrimalDualInteriorPointProblem::number_hessian_nonzeros() const {
-      size_t number_zeros = this->first_reformulation.number_hessian_nonzeros();
+   size_t PrimalDualInteriorPointProblem::number_hessian_nonzeros(const HessianModel& hessian_model) const {
+      size_t number_nonzeros = this->first_reformulation.number_hessian_nonzeros(hessian_model);
       // barrier contribution
       for (size_t variable_index: Range(this->first_reformulation.number_variables)) {
          if (is_finite(this->first_reformulation.variable_lower_bound(variable_index)) || is_finite(this->first_reformulation.variable_upper_bound(variable_index))) {
-            number_zeros++;
+            number_nonzeros++;
          }
       }
-      return number_zeros;
+      return number_nonzeros;
    }
 
    void PrimalDualInteriorPointProblem::evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
@@ -32,7 +32,7 @@ namespace uno {
 
       [[nodiscard]] size_t number_objective_gradient_nonzeros() const override;
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;
-      [[nodiscard]] size_t number_hessian_nonzeros() const override;
+      [[nodiscard]] size_t number_hessian_nonzeros(const HessianModel& hessian_model) const override;
 
       void evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate,
             const Multipliers& multipliers) const override;

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -59,7 +59,7 @@ namespace uno {
       this->constraint_jacobian.resize(problem.number_constraints, problem.number_variables);
       this->bqpd_jacobian.resize(problem.number_jacobian_nonzeros() + problem.number_objective_gradient_nonzeros()); // Jacobian + objective gradient
       this->bqpd_jacobian_sparsity.resize(problem.number_jacobian_nonzeros() + problem.number_objective_gradient_nonzeros() + problem.number_constraints + 3);
-      const size_t number_hessian_nonzeros = hessian_model.number_nonzeros(problem);
+      const size_t number_hessian_nonzeros = problem.number_hessian_nonzeros(hessian_model);
       this->hessian = SymmetricMatrix<size_t, double>(problem.number_variables, number_hessian_nonzeros, this->subproblem_is_regularized, "CSC");
       this->kmax = (0 < number_hessian_nonzeros) ? this->kmax_limit : 0;
       this->active_set.resize(problem.number_variables + problem.number_constraints);


### PR DESCRIPTION
Start with the `HessianModel` of the `Model`, then add contributions of the reformulations (possibly proximal term for `l1RelaxedProblem`, barrier terms for `PrimalDualInteriorPointProblem`).