### PR TITLE
Revert Hessian-free feature in BQPD

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -68,12 +68,12 @@ namespace uno {
       return current_constraint_violation - trial_linearized_constraint_violation;
    }
 
-   std::function<double(double)> ConstraintRelaxationStrategy::compute_predicted_objective_reduction_model(const OptimizationProblem& problem,
-         HessianModel& hessian_model, const Iterate& current_iterate, const Multipliers& multipliers, const Vector<double>& primal_direction, double step_length) const {
+   std::function<double(double)> ConstraintRelaxationStrategy::compute_predicted_objective_reduction_model(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length) const {
       // predicted objective reduction: "-∇f(x)^T (αd) - α^2/2 d^T H d"
       const double directional_derivative = dot(primal_direction, current_iterate.evaluations.objective_gradient);
       const double quadratic_term = this->first_order_predicted_reduction ? 0. :
-         this->inequality_handling_method->hessian_quadratic_product(problem, hessian_model, primal_direction, multipliers);
+         this->inequality_handling_method->hessian_quadratic_product(primal_direction);
       return [=](double objective_multiplier) {
          return step_length * (-objective_multiplier*directional_derivative) - step_length*step_length/2. * quadratic_term;
       };

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -78,9 +78,8 @@ namespace uno {
       void set_infeasibility_measure(const Model& model, Iterate& iterate) const;
       [[nodiscard]] double compute_predicted_infeasibility_reduction_model(const Model& model, const Iterate& current_iterate,
          const Vector<double>& primal_direction, double step_length) const;
-      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction_model(const OptimizationProblem& problem,
-         HessianModel& hessian_model, const Iterate& current_iterate, const Multipliers& multipliers, const Vector<double>& primal_direction,
-         double step_length) const;
+      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction_model(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length) const;
       void compute_progress_measures(const Model& model, Iterate& current_iterate, Iterate& trial_iterate);
       virtual void evaluate_progress_measures(const Model& model, Iterate& iterate) const = 0;
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -58,7 +58,7 @@ namespace uno {
 
       void evaluate_progress_measures(const Model& model, Iterate& iterate) const override;
       [[nodiscard]] ProgressMeasures compute_predicted_reduction_models(const Model& model, const Iterate& current_iterate,
-         const Direction& direction, double step_length);
+         const Direction& direction, double step_length) const;
       [[nodiscard]] bool can_switch_to_optimality_phase(const Iterate& current_iterate, const Model& model, const Iterate& trial_iterate,
          const Direction& direction, double step_length);
    };

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
@@ -251,8 +251,8 @@ namespace uno {
       const l1RelaxedProblem l1_relaxed_problem{model, this->penalty_parameter, this->constraint_violation_coefficient};
       this->inequality_handling_method->postprocess_iterate(l1_relaxed_problem, trial_iterate.primals, trial_iterate.multipliers);
       // compute the predicted reduction before the progress measures to make sure second-order information is valid
-      const ProgressMeasures predicted_reduction = this->compute_predicted_reduction_models(model, l1_relaxed_problem,
-         current_iterate, direction, step_length);
+      const ProgressMeasures predicted_reduction = this->compute_predicted_reduction_models(model, current_iterate, direction,
+         step_length);
       this->compute_progress_measures(model, current_iterate, trial_iterate);
       trial_iterate.objective_multiplier = l1_relaxed_problem.get_objective_multiplier();
 
@@ -288,11 +288,11 @@ namespace uno {
       this->inequality_handling_method->set_auxiliary_measure(model, iterate);
    }
 
-   ProgressMeasures l1Relaxation::compute_predicted_reduction_models(const Model& model, const OptimizationProblem& problem,
-         Iterate& current_iterate, const Direction& direction, double step_length) {
+   ProgressMeasures l1Relaxation::compute_predicted_reduction_models(const Model& model, Iterate& current_iterate,
+         const Direction& direction, double step_length) {
       return {
          this->compute_predicted_infeasibility_reduction_model(model, current_iterate, direction.primals, step_length),
-         this->compute_predicted_objective_reduction_model(problem, *this->hessian_model, current_iterate, current_iterate.multipliers, direction.primals, step_length),
+         this->compute_predicted_objective_reduction_model(current_iterate, direction.primals, step_length),
          this->inequality_handling_method->compute_predicted_auxiliary_reduction_model(model, current_iterate, direction.primals, step_length)
       };
    }

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
@@ -74,8 +74,8 @@ namespace uno {
          const Direction& feasibility_direction) const;
 
       void evaluate_progress_measures(const Model& model, Iterate& iterate) const override;
-      [[nodiscard]] ProgressMeasures compute_predicted_reduction_models(const Model& model, const OptimizationProblem& problem,
-         Iterate& current_iterate, const Direction& direction, double step_length);
+      [[nodiscard]] ProgressMeasures compute_predicted_reduction_models(const Model& model, Iterate& current_iterate,
+         const Direction& direction, double step_length);
 
       void check_exact_relaxation(Iterate& iterate) const;
    };

--- a/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.cpp
@@ -32,17 +32,17 @@ namespace uno {
 
    bool FunnelMethod::is_regular_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
          const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction) {
-      bool accept = false;
-      std::string scenario;
-      if (this->funnel.acceptable(trial_progress.infeasibility)) {
-         // in filter and funnel methods, we construct an unconstrained measure by ignoring infeasibility and scaling the objective measure by 1
-         const double current_merit = SwitchingMethod::unconstrained_merit_function(current_progress);
-         const double trial_merit = SwitchingMethod::unconstrained_merit_function(trial_progress);
-         const double merit_predicted_reduction = SwitchingMethod::unconstrained_merit_function(predicted_reduction);
-         DEBUG << "Current: (infeasibility, objective + auxiliary) = (" << current_progress.infeasibility << ", " << current_merit << ")\n";
-         DEBUG << "Trial:   (infeasibility, objective + auxiliary) = (" << trial_progress.infeasibility << ", " << trial_merit << ")\n";
-         DEBUG << "Unconstrained predicted reduction = " << merit_predicted_reduction << '\n';
+      // in filter and funnel methods, we construct an unconstrained measure by ignoring infeasibility and scaling the objective measure by 1
+      const double current_merit = SwitchingMethod::unconstrained_merit_function(current_progress);
+      const double trial_merit = SwitchingMethod::unconstrained_merit_function(trial_progress);
+      const double merit_predicted_reduction = SwitchingMethod::unconstrained_merit_function(predicted_reduction);
+      DEBUG << "Current: (infeasibility, objective + auxiliary) = (" << current_progress.infeasibility << ", " << current_merit << ")\n";
+      DEBUG << "Trial:   (infeasibility, objective + auxiliary) = (" << trial_progress.infeasibility << ", " << trial_merit << ")\n";
+      DEBUG << "Unconstrained predicted reduction = " << merit_predicted_reduction << '\n';
 
+      std::string scenario;
+      bool accept = false;
+      if (this->funnel.acceptable(trial_progress.infeasibility)) {
          // IF require_acceptance_wrt_current_iterate == false, then condition always fulfilled, we never check
          // If true, then first part is false, and we always check wrt current iterate
          if (!this->require_acceptance_wrt_current_iterate ||

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -42,8 +42,7 @@ namespace uno {
       virtual void exit_feasibility_problem(const OptimizationProblem& problem, Iterate& trial_iterate) = 0;
 
       // progress measures
-      [[nodiscard]] virtual double hessian_quadratic_product(const OptimizationProblem& problem, HessianModel& hessian_model,
-         const Vector<double>& primal_direction, const Multipliers& multipliers) const = 0;
+      [[nodiscard]] virtual double hessian_quadratic_product(const Vector<double>& vector) const = 0;
       virtual void set_auxiliary_measure(const Model& model, Iterate& iterate) = 0;
       [[nodiscard]] virtual double compute_predicted_auxiliary_reduction_model(const Model& model, const Iterate& current_iterate,
          const Vector<double>& primal_direction, double step_length) const = 0;

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/LPSubproblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/LPSubproblem.cpp
@@ -31,8 +31,7 @@ namespace uno {
       this->initial_point.fill(0.);
    }
 
-   double LPSubproblem::hessian_quadratic_product(const OptimizationProblem& /*problem*/, HessianModel& /*hessian_model*/,
-         const Vector<double>& /*primal_direction*/, const Multipliers& /*multipliers*/) const {
+   double LPSubproblem::hessian_quadratic_product(const Vector<double>& /*vector*/) const {
       return 0.;
    }
 } // namespace

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/LPSubproblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/LPSubproblem.hpp
@@ -20,8 +20,7 @@ namespace uno {
       void generate_initial_iterate(const OptimizationProblem& problem, Iterate& initial_iterate) override;
       void solve(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,  const Multipliers& current_multipliers,
             Direction& direction, HessianModel& hessian_model, WarmstartInformation& warmstart_information) override;
-      [[nodiscard]] double hessian_quadratic_product(const OptimizationProblem& problem, HessianModel& hessian_model,
-         const Vector<double>& primal_direction, const Multipliers& multipliers) const override;
+      [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override;
 
    private:
       // pointer to allow polymorphism

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/QPSubproblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/QPSubproblem.cpp
@@ -40,11 +40,7 @@ namespace uno {
       this->initial_point.fill(0.);
    }
 
-   double QPSubproblem::hessian_quadratic_product(const OptimizationProblem& problem, HessianModel& hessian_model,
-         const Vector<double>& primal_direction, const Multipliers& multipliers) const {
-      // TODO preallocate
-      Vector<double> result(primal_direction.size());
-      problem.compute_hessian_vector_product(hessian_model, primal_direction, multipliers, result);
-      return dot(primal_direction, result);
+   double QPSubproblem::hessian_quadratic_product(const Vector<double>& vector) const {
+      return this->solver->hessian_quadratic_product(vector);
    }
 } // namespace

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/QPSubproblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/QPSubproblem.hpp
@@ -20,8 +20,7 @@ namespace uno {
       void generate_initial_iterate(const OptimizationProblem& problem, Iterate& initial_iterate) override;
       void solve(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,  const Multipliers& current_multipliers,
          Direction& direction, HessianModel& hessian_model, WarmstartInformation& warmstart_information) override;
-      [[nodiscard]] double hessian_quadratic_product(const OptimizationProblem& problem, HessianModel& hessian_model,
-         const Vector<double>& primal_direction, const Multipliers& multipliers) const override;
+      [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override;
 
    protected:
       const bool enforce_linear_constraints_at_initial_iterate;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
@@ -179,13 +179,8 @@ namespace uno {
       direction.subproblem_objective = this->evaluate_subproblem_objective(direction);
    }
 
-   double PrimalDualInteriorPointMethod::hessian_quadratic_product(const OptimizationProblem& problem, HessianModel& hessian_model,
-         const Vector<double>& primal_direction, const Multipliers& multipliers) const {
-      const PrimalDualInteriorPointProblem barrier_problem(problem, this->barrier_parameter());
-      // TODO preallocate
-      Vector<double> result(primal_direction.size());
-      barrier_problem.compute_hessian_vector_product(hessian_model, primal_direction, multipliers, result);
-      return dot(primal_direction, result);
+   double PrimalDualInteriorPointMethod::hessian_quadratic_product(const Vector<double>& /*vector*/) const {
+      return 0.; // TODO
    }
 
    void PrimalDualInteriorPointMethod::assemble_augmented_system(Statistics& statistics, const OptimizationProblem& problem,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.hpp
@@ -40,8 +40,7 @@ namespace uno {
 
       void solve(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,  const Multipliers& current_multipliers,
             Direction& direction, HessianModel& hessian_model, WarmstartInformation& warmstart_information) override;
-      [[nodiscard]] double hessian_quadratic_product(const OptimizationProblem& problem, HessianModel& hessian_model,
-         const Vector<double>& primal_direction, const Multipliers& multipliers) const override;
+      [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override;
 
       void set_auxiliary_measure(const Model& model, Iterate& iterate) override;
       [[nodiscard]] double compute_predicted_auxiliary_reduction_model(const Model& model, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -104,6 +104,12 @@ namespace uno {
       this->solve_subproblem(problem, initial_point, direction, warmstart_information);
    }
 
+   double BQPDSolver::hessian_quadratic_product(const Vector<double>& vector) const {
+      return this->hessian.quadratic_product(vector, vector);
+   }
+
+   // protected member functions
+
    void BQPDSolver::set_up_subproblem(const OptimizationProblem& problem, Iterate& current_iterate, double trust_region_radius,
          const WarmstartInformation& warmstart_information) {
       // initialize wsc_ common block (Hessian & workspace for BQPD)

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
@@ -94,8 +94,7 @@ namespace uno {
       void solve_subproblem(const OptimizationProblem& problem, const Vector<double>& initial_point, Direction& direction,
          const WarmstartInformation& warmstart_information);
       [[nodiscard]] static BQPDMode determine_mode(const WarmstartInformation& warmstart_information);
-      void save_hessian_operator(const OptimizationProblem& problem, HessianModel& hessian_model,
-         const Multipliers& current_multipliers);
+      void save_hessian_in_local_format();
       void save_gradients_to_local_format(size_t number_constraints);
       void set_multipliers(size_t number_variables, Multipliers& direction_multipliers);
       static BQPDStatus bqpd_status_from_int(int ifail);

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
@@ -57,6 +57,8 @@ namespace uno {
          const Vector<double>& initial_point, Direction& direction, HessianModel& hessian_model, double trust_region_radius,
          const WarmstartInformation& warmstart_information) override;
 
+      [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override;
+
    private:
       const bool subproblem_is_regularized;
       std::vector<double> lower_bounds{}, upper_bounds{}; // lower and upper bounds of variables and constraints

--- a/uno/ingredients/subproblem_solvers/QPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/QPSolver.hpp
@@ -30,6 +30,8 @@ namespace uno {
       virtual void solve_QP(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate, const Multipliers& current_multipliers,
             const Vector<double>& initial_point, Direction& direction, HessianModel& hessian_model, double trust_region_radius,
             const WarmstartInformation& warmstart_information) = 0;
+
+      [[nodiscard]] virtual double hessian_quadratic_product(const Vector<double>& vector) const = 0;
    };
 } // namespace
 


### PR DESCRIPTION
When the trial iterate is evaluated, ASL modifies the definition of the Hessian-vector product. In a trust-region framework, this means that when the trial iterate is rejected, the next QP (with a smaller radius) has a wrong Hessian.
We stick to explicit Hessians in BQPD for now.