### PR TITLE
Update build_tarballs_release.jl

### DIFF
--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -10,8 +10,8 @@ version = VersionNumber(ENV["UNO_RELEASE"])
 # Collection of sources required to complete build
 sources = [
     GitSource(ENV["UNO_URL"], ENV["UNO_COMMIT"]),
-    ArchiveSource("https://mumps-solver.org/MUMPS_5.7.3.tar.gz",
-                  "84a47f7c4231b9efdf4d4f631a2cae2bdd9adeaabc088261d15af040143ed112"),
+    ArchiveSource("https://mumps-solver.org/MUMPS_5.8.0.tar.gz",
+                  "d762eb8b1d9843a0993b8cfc137d043d04c7c51877ad37c94560433a474340a0"),
 ]
 
 # Bash recipe for building across all platforms
@@ -31,7 +31,7 @@ done
 cd ${prefix}
 cp -rL share/licenses deps/licenses
 mkdir deps/licenses/MUMPS
-cp $WORKSPACE/srcdir/MUMPS_5.7.3/LICENSE deps/licenses/MUMPS/LICENSE
+cp $WORKSPACE/srcdir/MUMPS_5.8.0/LICENSE deps/licenses/MUMPS/LICENSE
 chmod -R u=rwx deps
 tar -czvf deps.tar.gz deps
 rm -r deps


### PR DESCRIPTION
Precompile Uno with MUMPS v5.8.0.