### PR TITLE
build_tarballs_release.jl: upgrade to HiGHS_jll 1.11.0

### DIFF
--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -149,7 +149,7 @@ products = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    Dependency(PackageSpec(name="HiGHS_jll", uuid="8fd58aa0-07eb-5a78-9b36-339c94fd15ea"), compat="=1.9.0"),
+    Dependency(PackageSpec(name="HiGHS_jll", uuid="8fd58aa0-07eb-5a78-9b36-339c94fd15ea"), compat="1.11.0"),
     Dependency(PackageSpec(name="HSL_jll", uuid="017b0a0e-03f4-516a-9b91-836bbd1904dd")),
     Dependency(PackageSpec(name="METIS_jll", uuid="d00139f3-1899-568f-a2f0-47f597d42d70")),
     Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), compat="0.1.3"),


### PR DESCRIPTION
For the next release, we will have BQPD, MUMPS 5.8.0 and HiGHS v1.11.