### PR TITLE
FeasibilityRestoration: move the switch from phase 1 to phase 2 to the end

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -191,15 +191,6 @@ namespace uno {
          (this->current_phase == Phase::OPTIMALITY) ? *this->optimality_inequality_handling_method : *this->feasibility_inequality_handling_method,
          model, current_iterate, direction, step_length);
 
-      // possibly go from restoration phase to optimality phase
-      if (this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(current_iterate, globalization_strategy,
-            model, trial_iterate, direction, step_length)) {
-         this->switch_to_optimality_phase(current_iterate, globalization_strategy, model, trial_iterate, warmstart_information);
-      }
-      else {
-         warmstart_information.no_changes();
-      }
-
       bool accept_iterate = false;
       const double objective_multiplier = (this->current_phase == Phase::OPTIMALITY) ? 1. : 0.;
       if (direction.norm == 0.) {
@@ -217,6 +208,15 @@ namespace uno {
          user_callbacks.notify_acceptable_iterate(trial_iterate.primals,
                this->current_phase == Phase::OPTIMALITY ? trial_iterate.multipliers : trial_iterate.feasibility_multipliers,
                objective_multiplier);
+      }
+
+      // possibly go from restoration phase to optimality phase
+      if (this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(current_iterate, globalization_strategy,
+            model, trial_iterate, direction, step_length)) {
+         this->switch_to_optimality_phase(current_iterate, globalization_strategy, model, trial_iterate, warmstart_information);
+            }
+      else {
+         warmstart_information.no_changes();
       }
       return accept_iterate;
    }

--- a/uno/tools/Statistics.cpp
+++ b/uno/tools/Statistics.cpp
@@ -102,6 +102,7 @@ namespace uno {
    }
 
    void Statistics::print_footer() {
+      /*
       for (const auto& element: this->columns) {
          const auto& header = element.second;
          for (int j = 0; j < this->widths[header]; j++) {
@@ -109,6 +110,8 @@ namespace uno {
          }
       }
       std::cout << '\n';
+      */
+      Statistics::print_header();
    }
    
    std::string_view Statistics::symbol(std::string_view value) {


### PR DESCRIPTION
In `FeasibilityRestoration`, move the switch from phase 1 to phase 2 to the end of `is_iterate_acceptable` to avoid meddling with the predicted reductions.