### PR TITLE
Bugfix in AMPLModel: size of multipliers vector may be larger than expected

### DIFF
--- a/bindings/AMPL/AMPLModel.cpp
+++ b/bindings/AMPL/AMPLModel.cpp
@@ -182,7 +182,8 @@ namespace uno {
       const int objective_number = -1;
       objective_multiplier *= this->objective_sign;
       // flip the signs of the multipliers: in AMPL, the Lagrangian is f + lambda.g, while Uno uses f - lambda.g
-      this->multipliers_with_flipped_sign = -multipliers;
+      // note: multipliers may be larger than multipliers_with_flipped_sign, therefore we create a view
+      this->multipliers_with_flipped_sign = -view(multipliers, 0, this->number_constraints);
       (*(this->asl)->p.Sphes)(this->asl, nullptr, const_cast<double*>(this->asl_hessian.data()), objective_number, &objective_multiplier,
             const_cast<double*>(this->multipliers_with_flipped_sign.data()));
 

--- a/uno/linear_algebra/Vector.hpp
+++ b/uno/linear_algebra/Vector.hpp
@@ -4,6 +4,7 @@
 #ifndef UNO_VECTOR_H
 #define UNO_VECTOR_H
 
+#include <cassert>
 #include <vector>
 #include <initializer_list>
 #include "symbolic/Range.hpp"
@@ -45,6 +46,7 @@ namespace uno {
       template <typename Expression>
       Vector<ElementType>& operator=(const Expression& expression) {
          static_assert(std::is_same_v<typename Expression::value_type, ElementType>);
+         assert(expression.size() <= this->size() && "The expression is larger than the current vector");
          for (size_t index = 0; index < this->size(); index++) {
             this->vector[index] = expression[index];
          }


### PR DESCRIPTION
Bugfix in AMPLModel: before flipping the signs of the multipliers, create a view in case the vector is longer than expected