### PR TITLE
Bugfix in Vector::operator=(const Expression& expression)

### DIFF
--- a/uno/linear_algebra/Vector.hpp
+++ b/uno/linear_algebra/Vector.hpp
@@ -47,7 +47,7 @@ namespace uno {
       Vector<ElementType>& operator=(const Expression& expression) {
          static_assert(std::is_same_v<typename Expression::value_type, ElementType>);
          assert(expression.size() <= this->size() && "The expression is larger than the current vector");
-         for (size_t index = 0; index < this->size(); index++) {
+         for (size_t index: Range(expression.size())) {
             this->vector[index] = expression[index];
          }
          return *this;


### PR DESCRIPTION
Loop over the size of the expression instead of that of the current vector (completes https://github.com/cvanaret/Uno/pull/184).