### PR TITLE
Compute the (primal and dual) regularization indices automatically

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
@@ -290,6 +290,10 @@ namespace uno {
       return this->model.get_inequality_constraints();
    }
 
+   const Collection<size_t>& l1RelaxedProblem::get_dual_regularization_constraints() const {
+      return this->dual_regularization_constraints;
+   }
+
    size_t l1RelaxedProblem::number_objective_gradient_nonzeros() const {
       // elastic contribution
       size_t number_nonzeros = this->number_elastic_variables;

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
@@ -33,11 +33,13 @@ namespace uno {
       [[nodiscard]] const Collection<size_t>& get_single_lower_bounded_variables() const override;
       [[nodiscard]] const Collection<size_t>& get_single_upper_bounded_variables() const override;
       [[nodiscard]] const Vector<size_t>& get_fixed_variables() const override;
+      // [[nodiscard]] virtual const Collection<size_t>& get_primal_regularization_variables() const;
 
       [[nodiscard]] double constraint_lower_bound(size_t constraint_index) const override;
       [[nodiscard]] double constraint_upper_bound(size_t constraint_index) const override;
       [[nodiscard]] const Collection<size_t>& get_equality_constraints() const override;
       [[nodiscard]] const Collection<size_t>& get_inequality_constraints() const override;
+      [[nodiscard]] const Collection<size_t>& get_dual_regularization_constraints() const override;
 
       [[nodiscard]] size_t number_objective_gradient_nonzeros() const override;
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;
@@ -60,6 +62,7 @@ namespace uno {
       double const* proximal_center;
       const Concatenation<const Collection<size_t>&, ForwardRange> lower_bounded_variables; // model variables + elastic variables
       const Concatenation<const Collection<size_t>&, ForwardRange> single_lower_bounded_variables; // model variables + elastic variables
+      const ForwardRange dual_regularization_constraints{0};
    };
 } // namespace
 

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
@@ -55,10 +55,8 @@ namespace uno {
          const Multipliers& current_multipliers, Direction& direction, HessianModel& hessian_model,
          RegularizationStrategy<double>& regularization_strategy, double trust_region_radius, WarmstartInformation& warmstart_information) {
       // create the subproblem and solve it
-      const ForwardRange primal_regularization_variables(problem.get_number_original_variables());
-      const ForwardRange dual_regularization_variables(0);
       Subproblem subproblem{problem, current_iterate, current_multipliers, hessian_model, regularization_strategy,
-         trust_region_radius, primal_regularization_variables, dual_regularization_variables};
+         trust_region_radius};
       this->solver->solve(statistics, subproblem, this->initial_point, direction, warmstart_information);
       InequalityConstrainedMethod::compute_dual_displacements(current_multipliers, direction.multipliers);
       this->number_subproblems_solved++;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
@@ -146,10 +146,8 @@ namespace uno {
       // create the interior-point reformulation
       const PrimalDualInteriorPointProblem barrier_problem(problem, this->barrier_parameter(), this->parameters.regularization_exponent);
       // crate the subproblem
-      const ForwardRange primal_regularization_indices = Range(problem.get_number_original_variables());
-      const Collection<size_t>& dual_regularization_indices = problem.get_equality_constraints();
       const Subproblem subproblem{barrier_problem, current_iterate, current_multipliers, hessian_model, regularization_strategy,
-         trust_region_radius, primal_regularization_indices, dual_regularization_indices};
+         trust_region_radius};
 
       // compute the primal-dual solution
       this->linear_solver->solve_indefinite_system(statistics, subproblem, this->solution, warmstart_information);

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
@@ -142,6 +142,10 @@ namespace uno {
       return this->inequality_constraints;
    }
 
+   const Collection<size_t>& PrimalDualInteriorPointProblem::get_dual_regularization_constraints() const {
+      return this->first_reformulation.get_equality_constraints();
+   }
+
    size_t PrimalDualInteriorPointProblem::number_objective_gradient_nonzeros() const {
       size_t number_nonzeros = this->first_reformulation.number_objective_gradient_nonzeros();
       // barrier contribution

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
@@ -143,6 +143,12 @@ namespace uno {
    }
 
    const Collection<size_t>& PrimalDualInteriorPointProblem::get_dual_regularization_constraints() const {
+      if (this->first_reformulation.get_dual_regularization_constraints().empty()) {
+         // this is an indication that the constraints (if there is any) were already regularized in a previous
+         // reformulation (e.g. l1 relaxation). In that case, we stick to an empty set
+         return this->first_reformulation.get_dual_regularization_constraints();
+      }
+      // otherwise, we pick the set of equality constraints, since the inequality constraints have slacks
       return this->first_reformulation.get_equality_constraints();
    }
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
@@ -30,11 +30,13 @@ namespace uno {
       [[nodiscard]] const Collection<size_t>& get_single_lower_bounded_variables() const override;
       [[nodiscard]] const Collection<size_t>& get_single_upper_bounded_variables() const override;
       [[nodiscard]] const Vector<size_t>& get_fixed_variables() const override;
+      // [[nodiscard]] virtual const Collection<size_t>& get_primal_regularization_variables() const;
 
       [[nodiscard]] double constraint_lower_bound(size_t constraint_index) const override;
       [[nodiscard]] double constraint_upper_bound(size_t constraint_index) const override;
       [[nodiscard]] const Collection<size_t>& get_equality_constraints() const override;
       [[nodiscard]] const Collection<size_t>& get_inequality_constraints() const override;
+      [[nodiscard]] const Collection<size_t>& get_dual_regularization_constraints() const override;
 
       [[nodiscard]] size_t number_objective_gradient_nonzeros() const override;
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;

--- a/uno/ingredients/regularization_strategies/PrimalRegularization.hpp
+++ b/uno/ingredients/regularization_strategies/PrimalRegularization.hpp
@@ -134,7 +134,7 @@ namespace uno {
       if (this->optional_linear_solver == nullptr) {
          this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name);
          this->optional_linear_solver->initialize_memory(this->dimension, 0, this->number_nonzeros,
-            primal_indices.size() + dual_indices.size());
+            primal_indices.size());
       }
       this->regularize_augmented_matrix(statistics, augmented_matrix, primal_indices, dual_indices,
          dual_regularization_parameter, expected_inertia, *this->optional_linear_solver);

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -31,8 +31,7 @@ namespace uno {
       const size_t number_variables, number_constraints;
 
       Subproblem(const OptimizationProblem& problem, Iterate& current_iterate, const Multipliers& current_multipliers,
-         HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius,
-         const Collection<size_t>& primal_regularization_indices, const Collection<size_t>& dual_regularization_indices);
+         HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius);
 
       // constraints, objective gradient and Jacobian
       void evaluate_objective_gradient(SparseVector<double>& linear_objective) const;
@@ -67,8 +66,6 @@ namespace uno {
       HessianModel& hessian_model;
       RegularizationStrategy<double>& regularization_strategy;
       const double trust_region_radius;
-      const Collection<size_t>& primal_regularization_indices;
-      const Collection<size_t>& dual_regularization_indices;
    };
 
    template <typename Array>

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -8,11 +8,13 @@
 
 namespace uno {
    OptimizationProblem::OptimizationProblem(const Model& model):
-         model(model), number_variables(model.number_variables), number_constraints(model.number_constraints) {
+         model(model), number_variables(model.number_variables), number_constraints(model.number_constraints),
+         primal_regularization_variables(model.number_variables), dual_regularization_constraints(model.number_constraints) {
    }
 
    OptimizationProblem::OptimizationProblem(const Model& model, size_t number_variables, size_t number_constraints):
-         model(model), number_variables(number_variables), number_constraints(number_constraints) {
+         model(model), number_variables(number_variables), number_constraints(number_constraints),
+         primal_regularization_variables(model.number_variables), dual_regularization_constraints(model.number_constraints) {
    }
 
    double OptimizationProblem::get_objective_multiplier() const {
@@ -78,6 +80,10 @@ namespace uno {
       return this->model.get_fixed_variables();
    }
 
+   const Collection<size_t>& OptimizationProblem::get_primal_regularization_variables() const {
+      return this->primal_regularization_variables;
+   }
+
    double OptimizationProblem::constraint_lower_bound(size_t constraint_index) const {
       return this->model.constraint_lower_bound(constraint_index);
    }
@@ -92,6 +98,10 @@ namespace uno {
 
    const Collection<size_t>& OptimizationProblem::get_inequality_constraints() const {
       return this->model.get_inequality_constraints();
+   }
+
+   const Collection<size_t>& OptimizationProblem::get_dual_regularization_constraints() const {
+      return this->dual_regularization_constraints;
    }
 
    size_t OptimizationProblem::number_objective_gradient_nonzeros() const {

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -52,11 +52,13 @@ namespace uno {
       [[nodiscard]] virtual const Collection<size_t>& get_single_lower_bounded_variables() const;
       [[nodiscard]] virtual const Collection<size_t>& get_single_upper_bounded_variables() const;
       [[nodiscard]] virtual const Vector<size_t>& get_fixed_variables() const;
+      [[nodiscard]] virtual const Collection<size_t>& get_primal_regularization_variables() const;
 
       [[nodiscard]] virtual double constraint_lower_bound(size_t constraint_index) const;
       [[nodiscard]] virtual double constraint_upper_bound(size_t constraint_index) const;
       [[nodiscard]] virtual const Collection<size_t>& get_equality_constraints() const;
       [[nodiscard]] virtual const Collection<size_t>& get_inequality_constraints() const;
+      [[nodiscard]] virtual const Collection<size_t>& get_dual_regularization_constraints() const;
 
       [[nodiscard]] virtual size_t number_objective_gradient_nonzeros() const;
       [[nodiscard]] virtual size_t number_jacobian_nonzeros() const;
@@ -68,6 +70,10 @@ namespace uno {
       [[nodiscard]] virtual double complementarity_error(const Vector<double>& primals, const std::vector<double>& constraints,
          const Multipliers& multipliers, double shift_value, Norm residual_norm) const;
       [[nodiscard]] virtual double dual_regularization_factor() const;
+
+   protected:
+      const ForwardRange primal_regularization_variables;
+      const ForwardRange dual_regularization_constraints;
    };
 } // namespace
 


### PR DESCRIPTION
Compute the (primal and dual) regularization indices automatically in the `OptimizationProblem` subclasses, instead of passing them upon creation of `Subproblem` object.