### PR TITLE
BQPD: use the existing sparse Hessian instead of copying it in the workspace

### DIFF
--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
@@ -93,7 +93,7 @@ namespace uno {
       void solve_subproblem(const Subproblem& subproblem, const Vector<double>& initial_point, Direction& direction,
          const WarmstartInformation& warmstart_information);
       [[nodiscard]] static BQPDMode determine_mode(const WarmstartInformation& warmstart_information);
-      void save_hessian_in_local_format();
+      void hide_pointers_in_workspace();
       void save_gradients_to_local_format(size_t number_constraints);
       void set_multipliers(size_t number_variables, Multipliers& direction_multipliers) const;
       static BQPDStatus bqpd_status_from_int(int ifail);

--- a/uno/linear_algebra/SymmetricMatrix.hpp
+++ b/uno/linear_algebra/SymmetricMatrix.hpp
@@ -32,6 +32,8 @@ namespace uno {
       [[nodiscard]] size_t number_nonzeros() const { return this->sparse_storage->number_nonzeros; }
       [[nodiscard]] size_t capacity() const { return this->sparse_storage->capacity; }
       template <typename Vector1, typename Vector2>
+      void product(const Vector1& vector, Vector2& result) const;
+      template <typename Vector1, typename Vector2>
       ElementType quadratic_product(const Vector1& x, const Vector2& y) const;
 
       // build the matrix incrementally
@@ -85,7 +87,19 @@ namespace uno {
       // look at the first max_dimension diagonal entries
       return *std::min_element(diagonal_entries.begin(), diagonal_entries.end());
    }
-   
+
+   template <typename IndexType, typename ElementType>
+   template <typename Vector1, typename Vector2>
+   inline void SymmetricMatrix<IndexType, ElementType>::product(const Vector1& vector, Vector2& result) const {
+      for (const auto [row_index, column_index, element]: *this) { // get the (row_index, column_index) element
+         result[row_index] += element * vector[column_index];
+         if (row_index != column_index) {
+            // consider the (column_index, row_index) as well (by symmetry)
+            result[column_index] += element * vector[row_index];
+         }
+      }
+   }
+
    template <typename IndexType, typename ElementType>
    template <typename Vector1, typename Vector2>
    inline ElementType SymmetricMatrix<IndexType, ElementType>::quadratic_product(const Vector1& x, const Vector2& y) const {


### PR DESCRIPTION
Hid a pointer to existing sparse Hessian into workspace of BQPD, instead of copying it.
The pointer is retrieved in `hessian_vector_product`.
Also switched from CSC to COO because it's easier to regularize.
TODO: if regularization is active, get the Hessian directly from the linear solver instead of allocating a new one!