### PR TITLE
Compile-time lists of solvers/strategies

### DIFF
--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -163,12 +163,12 @@ namespace uno {
 
    void Uno::print_available_strategies() {
       std::cout << "Available strategies:\n";
-      std::cout << "- Constraint relaxation strategies: " << join(ConstraintRelaxationStrategyFactory::available_strategies(), ", ") << '\n';
-      std::cout << "- Globalization mechanisms: " << join(GlobalizationMechanismFactory::available_strategies(), ", ") << '\n';
-      std::cout << "- Globalization strategies: " << join(GlobalizationStrategyFactory::available_strategies(), ", ") << '\n';
+      std::cout << "- Constraint relaxation strategies: " << join(ConstraintRelaxationStrategyFactory::available_strategies, ", ") << '\n';
+      std::cout << "- Globalization mechanisms: " << join(GlobalizationMechanismFactory::available_strategies, ", ") << '\n';
+      std::cout << "- Globalization strategies: " << join(GlobalizationStrategyFactory::available_strategies, ", ") << '\n';
       std::cout << "- Inequality handling methods: " << join(InequalityHandlingMethodFactory::available_strategies(), ", ") << '\n';
-      std::cout << "- QP solvers: " << join(QPSolverFactory::available_solvers(), ", ") << '\n';
-      std::cout << "- LP solvers: " << join(LPSolverFactory::available_solvers(), ", ") << '\n';
+      std::cout << "- QP solvers: " << join(QPSolverFactory::available_solvers, ", ") << '\n';
+      std::cout << "- LP solvers: " << join(LPSolverFactory::available_solvers, ", ") << '\n';
       std::cout << "- Linear solvers: " << join(SymmetricIndefiniteLinearSolverFactory::available_solvers(), ", ") << '\n';
    }
 

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategyFactory.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategyFactory.cpp
@@ -24,8 +24,4 @@ namespace uno {
       }
       throw std::invalid_argument("ConstraintRelaxationStrategy " + constraint_relaxation_type + " is not supported");
    }
-
-   std::vector<std::string> ConstraintRelaxationStrategyFactory::available_strategies() {
-      return {"feasibility_restoration", "l1_relaxation"};
-   }
 } // namespace

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategyFactory.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategyFactory.hpp
@@ -4,8 +4,8 @@
 #ifndef UNO_CONSTRAINTRELAXATIONSTRATEGYFACTORY_H
 #define UNO_CONSTRAINTRELAXATIONSTRATEGYFACTORY_H
 
+#include <array>
 #include <memory>
-#include <vector>
 
 namespace uno {
    // forward declarations
@@ -15,7 +15,10 @@ namespace uno {
    class ConstraintRelaxationStrategyFactory {
    public:
       static std::unique_ptr<ConstraintRelaxationStrategy> create(size_t number_constraints, const Options& options);
-      static std::vector<std::string> available_strategies();
+
+      constexpr static std::array available_strategies{
+         "feasibility_restoration", "l1_relaxation"
+      };
    };
 } // namespace
 

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanismFactory.cpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanismFactory.cpp
@@ -20,8 +20,4 @@ namespace uno {
        }
        throw std::invalid_argument("GlobalizationMechanism " + mechanism_type + " is not supported");
    }
-
-   std::vector<std::string> GlobalizationMechanismFactory::available_strategies() {
-      return {"TR", "LS"};
-   }
 } // namespace

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanismFactory.hpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanismFactory.hpp
@@ -4,8 +4,8 @@
 #ifndef UNO_GLOBALIZATIONMECHANISMFACTORY_H
 #define UNO_GLOBALIZATIONMECHANISMFACTORY_H
 
+#include <array>
 #include <memory>
-#include <vector>
 #include "GlobalizationMechanism.hpp"
 
 namespace uno {
@@ -15,7 +15,10 @@ namespace uno {
    class GlobalizationMechanismFactory {
    public:
       static std::unique_ptr<GlobalizationMechanism> create(const Options& options);
-      static std::vector<std::string> available_strategies();
+
+      constexpr static std::array available_strategies{
+         "TR", "LS"
+      };
    };
 } // namespace
 

--- a/uno/ingredients/globalization_strategies/GlobalizationStrategyFactory.cpp
+++ b/uno/ingredients/globalization_strategies/GlobalizationStrategyFactory.cpp
@@ -32,8 +32,4 @@ namespace uno {
       }
       throw std::invalid_argument("GlobalizationStrategy " + strategy_type + " is not supported");
    }
-
-   std::vector<std::string> GlobalizationStrategyFactory::available_strategies() {
-      return {"l1_merit", "fletcher_filter_method", "waechter_filter_method", "funnel_method"};
-   }
 }

--- a/uno/ingredients/globalization_strategies/GlobalizationStrategyFactory.hpp
+++ b/uno/ingredients/globalization_strategies/GlobalizationStrategyFactory.hpp
@@ -4,8 +4,8 @@
 #ifndef UNO_GLOBALIZATIONSTRATEGYFACTORY_H
 #define UNO_GLOBALIZATIONSTRATEGYFACTORY_H
 
+#include <array>
 #include <memory>
-#include <vector>
 
 namespace uno {
    // forward declarations
@@ -15,7 +15,10 @@ namespace uno {
    class GlobalizationStrategyFactory {
    public:
       static std::unique_ptr<GlobalizationStrategy> create(size_t number_constraints, const Options& options);
-      static std::vector<std::string> available_strategies();
+
+      constexpr static std::array available_strategies{
+         "l1_merit", "fletcher_filter_method", "waechter_filter_method", "funnel_method"
+      };
    };
 } // namespace
 

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.cpp
@@ -28,7 +28,7 @@ namespace uno {
 
    std::vector<std::string> InequalityHandlingMethodFactory::available_strategies() {
       std::vector<std::string> strategies{};
-      if (!LPSolverFactory::available_solvers().empty() || !QPSolverFactory::available_solvers().empty()) {
+      if constexpr (0 < LPSolverFactory::available_solvers.size() || 0 < QPSolverFactory::available_solvers.size()) {
          strategies.emplace_back("inequality_constrained");
       }
       if (!SymmetricIndefiniteLinearSolverFactory::available_solvers().empty()) {

--- a/uno/ingredients/subproblem_solvers/LPSolverFactory.cpp
+++ b/uno/ingredients/subproblem_solvers/LPSolverFactory.cpp
@@ -30,24 +30,13 @@ namespace uno {
 #endif
          std::string message = "The LP solver ";
          message.append(LP_solver_name).append(" is unknown").append("\n").append("The following values are available: ")
-               .append(join(LPSolverFactory::available_solvers(), ", "));
+               .append(join(LPSolverFactory::available_solvers, ", "));
          throw std::invalid_argument(message);
       }
       catch (const std::out_of_range& exception) {
          std::string message = exception.what();
-         message.append("\n").append("The following values are available: ").append(join(LPSolverFactory::available_solvers(), ", "));
+         message.append("\n").append("The following values are available: ").append(join(LPSolverFactory::available_solvers, ", "));
          throw std::out_of_range(message);
       }
-   }
-
-   std::vector<std::string> LPSolverFactory::available_solvers() {
-      std::vector<std::string> solvers{};
-#ifdef HAS_BQPD
-      solvers.emplace_back("BQPD");
-#endif
-#ifdef HAS_HIGHS
-      solvers.emplace_back("HiGHS");
-#endif
-      return solvers;
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/LPSolverFactory.hpp
+++ b/uno/ingredients/subproblem_solvers/LPSolverFactory.hpp
@@ -4,8 +4,8 @@
 #ifndef UNO_LPSOLVERFACTORY_H
 #define UNO_LPSOLVERFACTORY_H
 
+#include <initializer_list>
 #include <memory>
-#include <vector>
 
 namespace uno {
    // forward declarations
@@ -17,7 +17,14 @@ namespace uno {
       static std::unique_ptr<LPSolver> create([[maybe_unused]] const Options& options);
 
       // list of available LP solvers
-      static std::vector<std::string> available_solvers();
+      constexpr static std::initializer_list<std::string_view> available_solvers{
+#ifdef HAS_BQPD
+         "BQPD",
+#endif
+#ifdef HAS_HIGHS
+         "HiGHS",
+#endif
+      };
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/QPSolverFactory.cpp
+++ b/uno/ingredients/subproblem_solvers/QPSolverFactory.cpp
@@ -22,22 +22,13 @@ namespace uno {
 #endif
          std::string message = "The QP solver ";
          message.append(QP_solver_name).append(" is unknown").append("\n").append("The following values are available: ")
-            .append(join(QPSolverFactory::available_solvers(), ", "));
+            .append(join(QPSolverFactory::available_solvers, ", "));
          throw std::invalid_argument(message);
       }
       catch (const std::out_of_range& exception) {
          std::string message = exception.what();
-         message.append("\n").append("The following values are available: ").append(join(QPSolverFactory::available_solvers(), ", "));
+         message.append("\n").append("The following values are available: ").append(join(QPSolverFactory::available_solvers, ", "));
          throw std::out_of_range(message);
       }
-   }
-
-   // return the list of available QP solvers
-   std::vector<std::string> QPSolverFactory::available_solvers() {
-      std::vector<std::string> solvers{};
-#ifdef HAS_BQPD
-      solvers.emplace_back("BQPD");
-#endif
-      return solvers;
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/QPSolverFactory.hpp
+++ b/uno/ingredients/subproblem_solvers/QPSolverFactory.hpp
@@ -4,8 +4,8 @@
 #ifndef UNO_QPSOLVERFACTORY_H
 #define UNO_QPSOLVERFACTORY_H
 
+#include <initializer_list>
 #include <memory>
-#include <vector>
 #include "QPSolver.hpp"
 
 namespace uno {
@@ -18,7 +18,11 @@ namespace uno {
       static std::unique_ptr<QPSolver> create([[maybe_unused]] const Options& options);
 
       // list of available QP solvers
-      static std::vector<std::string> available_solvers();
+      constexpr static std::initializer_list<std::string_view> available_solvers{
+#ifdef HAS_BQPD
+         "BQPD",
+#endif
+      };
    };
 } // namespace
 

--- a/uno/linear_algebra/Vector.hpp
+++ b/uno/linear_algebra/Vector.hpp
@@ -139,11 +139,13 @@ namespace uno {
    template <typename Container>
    std::string join(const Container& vector, const std::string& separator) {
       std::string result{};
-      if (!vector.empty()) {
-         result = vector[0];
-         for (size_t variable_index: Range(1, vector.size())) {
-            result += separator + vector[variable_index];
+      size_t index = 0;
+      for (const auto& element: vector) {
+         if (0 < index) {
+            result += separator;
          }
+         result += element;
+         index++;
       }
       return result;
    }

--- a/uno/options/DefaultOptions.cpp
+++ b/uno/options/DefaultOptions.cpp
@@ -194,12 +194,12 @@ namespace uno {
 
       /** solvers: check the available solvers **/
       // QP solver
-      if (!QPSolverFactory::available_solvers().empty()) {
-         options["QP_solver"] = QPSolverFactory::available_solvers()[0];
+      if (0 < QPSolverFactory::available_solvers.size()) {
+         options["QP_solver"] = *QPSolverFactory::available_solvers.begin();
       }
       // LP solver
-      if (!LPSolverFactory::available_solvers().empty()) {
-         options["LP_solver"] = LPSolverFactory::available_solvers()[0];
+      if (0 < LPSolverFactory::available_solvers.size()) {
+         options["LP_solver"] = *LPSolverFactory::available_solvers.begin();
       }
       // linear solver
       const auto linear_solvers = SymmetricIndefiniteLinearSolverFactory::available_solvers();

--- a/uno/options/Presets.cpp
+++ b/uno/options/Presets.cpp
@@ -20,13 +20,13 @@ namespace uno {
          /** default preset **/
          const auto linear_solvers = SymmetricIndefiniteLinearSolverFactory::available_solvers();
 
-         if (!QPSolverFactory::available_solvers().empty()) {
+         if constexpr (0 < QPSolverFactory::available_solvers.size()) {
             Presets::set(options, "filtersqp");
          }
          else if (!linear_solvers.empty()) {
             Presets::set(options, "ipopt");
          }
-         else if (!LPSolverFactory::available_solvers().empty()) {
+         else if constexpr (0 < LPSolverFactory::available_solvers.size()) {
             Presets::set(options, "filterslp");
          }
          // note: byrd is not very robust and is not considered as a default preset


### PR DESCRIPTION
`constexpr` lists of solvers/strategies in factories: used `std::array` for fixed lists and `std::initializer_list<std::string_view>` for conditional lists (depending on preprocessor definitions, which implies trailing commas and potentially empty lists).