### PR TITLE
Fix the cross-compilation with BQPD

### DIFF
--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -128,7 +128,7 @@ install -v -m 755 "uno_ampl${exeext}" -t "${bindir}"
 
 # Currently, Uno does not provide a shared library. This may be useful in the future once it has a C API.
 # We just check that we can generate it, but we don't include it in the tarballs.
-${CXX} -shared $(flagon -Wl,--whole-archive) libuno.a $(flagon -Wl,--no-whole-archive) -o libuno.${dlext} -L${libdir} -l${OMP} -lopenblas -ldmumps -lmetis -lhsl -lhighs
+${CXX} -shared $(flagon -Wl,--whole-archive) libuno.a $(flagon -Wl,--no-whole-archive) -o libuno.${dlext} -L${libdir} -l${OMP} -lopenblas -ldmumps -lmetis -lhsl -lhighs -lbqpd
 cp libuno.a ${prefix}/lib/libuno.a
 cp libuno.${dlext} ${libdir}/libuno.${dlext}
 

--- a/.github/julia/build_tarballs_yggdrasil.jl
+++ b/.github/julia/build_tarballs_yggdrasil.jl
@@ -65,7 +65,7 @@ install -v -m 755 "uno_ampl${exeext}" -t "${bindir}"
 
 # Currently, Uno does not provide a shared library. This may be useful in the future once it has a C API.
 # We just check that we can generate it, but we don't include it in the tarballs.
-${CXX} -shared $(flagon -Wl,--whole-archive) libuno.a $(flagon -Wl,--no-whole-archive) -o libuno.${dlext} -L${libdir} -l${OMP} -l${LBT} -ldmumps -lmetis -lhsl -lhighs
+${CXX} -shared $(flagon -Wl,--whole-archive) libuno.a $(flagon -Wl,--no-whole-archive) -o libuno.${dlext} -L${libdir} -l${OMP} -l${LBT} -ldmumps -lmetis -lhsl -lhighs -lbqpd
 # cp libuno.${dlext} ${libdir}/libuno.${dlext}
 
 # Uno


### PR DESCRIPTION
I expect that `libbqpd.a` is included in `libuno.a` but if we have again the issue to cross-compile UNO v2.0, this PR should definitively fix the problem.

Please do not merge if not needed.