### PR TITLE
CMake: removed WITH_GTEST flag

### DIFF
--- a/.github/workflows/unit-tests-ubuntu.yml
+++ b/.github/workflows/unit-tests-ubuntu.yml
@@ -67,7 +67,6 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-                                                -DWITH_GTEST=ON \
                                                 -DMUMPS_INCLUDE_DIR=${{github.workspace}}/deps/include \
                                                 -DMETIS_INCLUDE_DIR=${{github.workspace}}/deps/include \
                                                 -DBQPD=${{github.workspace}}/deps/lib/libbqpd.a \
@@ -87,4 +86,3 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute unit tests
       run: ./run_unotest
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 if(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
    message(FATAL_ERROR "At least one of BUILD_SHARED_LIBS or BUILD_STATIC_LIBS must be ON.")
 endif()
-option(WITH_GTEST "Enable GoogleTest" OFF)
 
 # determine whether a Fortran compiler is required, based on the available optional dependencies
 find_library(HSL hsl)
@@ -270,14 +269,11 @@ endif()
 ##################################
 # optional GoogleTest unit tests #
 ##################################
-message(STATUS "GoogleTest: WITH_GTEST=${WITH_GTEST}")
-if(WITH_GTEST)
-   find_package(GTest CONFIG REQUIRED)
-   if(GTest_DIR)
-      add_executable(run_unotest EXCLUDE_FROM_ALL ${TESTS_UNO_SOURCE_FILES})
-      target_include_directories(run_unotest PUBLIC ${DIRECTORIES})
-      target_link_libraries(run_unotest PUBLIC GTest::gtest ${DEFAULT_UNO_LIB} ${LIBRARIES})
-   endif()
+find_package(GTest CONFIG REQUIRED)
+if(GTest_DIR)
+   add_executable(run_unotest EXCLUDE_FROM_ALL ${TESTS_UNO_SOURCE_FILES})
+   target_include_directories(run_unotest PUBLIC ${DIRECTORIES})
+   target_link_libraries(run_unotest PUBLIC GTest::gtest ${DEFAULT_UNO_LIB} ${LIBRARIES})
 endif()
 
 #########################################

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,15 +79,11 @@ sudo make install
 ```console
 sudo apt install googletest
 ```
-7. Perform step 2 with the flag
-```console
--DWITH_GTEST=ON
-```
-8. Compile the test suite:
+7. Compile the test suite:
 ```console
 make run_unotest -jn
 ```
-9. Run the test suite:
+8. Run the test suite:
 ```console
 ./run_unotest
 ```


### PR DESCRIPTION
Removed the `WITH_GTEST` flag in the CMakeLists. The target `run_unotest` is excluded from `make all` and is built with `make run_unotest`.