### PR TITLE
[WIP] Improve hierarchy of subproblem solvers

### DIFF
--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
@@ -57,7 +57,7 @@ namespace uno {
       // create the subproblem and solve it
       Subproblem subproblem{problem, current_iterate, current_multipliers, hessian_model, regularization_strategy,
          trust_region_radius};
-      this->solver->solve(statistics, subproblem, this->initial_point, direction, warmstart_information);
+      this->solver->solve_inequality_constrained_subproblem(statistics, subproblem, this->initial_point, direction, warmstart_information);
       InequalityConstrainedMethod::compute_dual_displacements(current_multipliers, direction.multipliers);
       this->number_subproblems_solved++;
       // reset the initial point

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.hpp
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include "../InequalityHandlingMethod.hpp"
-#include "ingredients/subproblem_solvers/LPSolver.hpp"
+#include "ingredients/subproblem_solvers/InequalityConstrainedSubproblemSolver.hpp"
 #include "linear_algebra/Vector.hpp"
 
 namespace uno {
@@ -43,7 +43,7 @@ namespace uno {
 
    protected:
       // pointer to allow polymorphism
-      std::unique_ptr<LPSolver> solver{};
+      std::unique_ptr<InequalityConstrainedSubproblemSolver> solver{};
       Vector<double> initial_point{};
       const Options& options; // copy of the options for delayed allocation of solver
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.hpp
@@ -44,7 +44,7 @@ namespace uno {
       [[nodiscard]] std::string get_name() const override;
 
    protected:
-      const std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<size_t, double>> linear_solver;
+      const std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<size_t, double>> solver;
       BarrierParameterUpdateStrategy barrier_parameter_update_strategy;
       double previous_barrier_parameter;
       const double default_multiplier;

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -109,7 +109,7 @@ namespace uno {
       this->lws.resize(this->mxlws);
    }
 
-   void BQPDSolver::solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
+   void BQPDSolver::solve_inequality_constrained_subproblem(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
          Direction& direction, const WarmstartInformation& warmstart_information) {
       this->set_up_subproblem(statistics, subproblem, warmstart_information);
       if (this->print_subproblem) {

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
@@ -54,7 +54,7 @@ namespace uno {
       void initialize_memory(const OptimizationProblem& problem, const HessianModel& hessian_model,
          const RegularizationStrategy<double>& regularization_strategy) override;
 
-      void solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
+      void solve_inequality_constrained_subproblem(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
          Direction& direction, const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override;

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
@@ -53,7 +53,7 @@ namespace uno {
       // this->hessian = SymmetricMatrix<size_t, double>("CSC", problem.number_variables, 0, 0); // TODO
    }
 
-   void HiGHSSolver::solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& /*initial_point*/,
+   void HiGHSSolver::solve_inequality_constrained_subproblem(Statistics& statistics, Subproblem& subproblem, const Vector<double>& /*initial_point*/,
          Direction& direction, const WarmstartInformation& warmstart_information) {
       this->set_up_subproblem(statistics, subproblem, warmstart_information);
       this->solve_subproblem(subproblem, direction);

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
@@ -22,7 +22,7 @@ namespace uno {
       void initialize_memory(const OptimizationProblem& problem, const HessianModel& hessian_model,
          const RegularizationStrategy<double>& regularization_strategy) override;
 
-      void solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
+      void solve_inequality_constrained_subproblem(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
          Direction& direction, const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override;

--- a/uno/ingredients/subproblem_solvers/InequalityConstrainedSubproblemSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/InequalityConstrainedSubproblemSolver.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2018-2024 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_INEQUALITYCONSTRAINEDSUBPROBLEMSOLVER_H
+#define UNO_INEQUALITYCONSTRAINEDSUBPROBLEMSOLVER_H
+
+namespace uno {
+   // forward declarations
+   class Direction;
+   class HessianModel;
+   class OptimizationProblem;
+   template <typename ElementType>
+   class RegularizationStrategy;
+   class Statistics;
+   class Subproblem;
+   template <typename ElementType>
+   class Vector;
+   class WarmstartInformation;
+
+   class InequalityConstrainedSubproblemSolver {
+   public:
+      InequalityConstrainedSubproblemSolver() = default;
+      virtual ~InequalityConstrainedSubproblemSolver() = default;
+
+      virtual void initialize_memory(const OptimizationProblem& problem, const HessianModel& hessian_model,
+         const RegularizationStrategy<double>& regularization_strategy) = 0;
+
+      virtual void solve_inequality_constrained_subproblem(Statistics& statistics, Subproblem& subproblem,
+         const Vector<double>& initial_point, Direction& direction, const WarmstartInformation& warmstart_information) = 0;
+
+      [[nodiscard]] virtual double hessian_quadratic_product(const Vector<double>& vector) const = 0;
+   };
+} // namespace
+
+#endif // UNO_INEQUALITYCONSTRAINEDSUBPROBLEMSOLVER_H

--- a/uno/ingredients/subproblem_solvers/LPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/LPSolver.hpp
@@ -4,31 +4,21 @@
 #ifndef UNO_LPSOLVER_H
 #define UNO_LPSOLVER_H
 
-namespace uno {
-   // forward declarations
-   class Direction;
-   class HessianModel;
-   class OptimizationProblem;
-   template <typename ElementType>
-   class RegularizationStrategy;
-   class Statistics;
-   class Subproblem;
-   template <typename ElementType>
-   class Vector;
-   class WarmstartInformation;
+#include "InequalityConstrainedSubproblemSolver.hpp"
 
-   class LPSolver {
+namespace uno {
+   class LPSolver: public InequalityConstrainedSubproblemSolver {
    public:
       LPSolver() = default;
-      virtual ~LPSolver() = default;
+      ~LPSolver() override = default;
 
-      virtual void initialize_memory(const OptimizationProblem& problem, const HessianModel& hessian_model,
-         const RegularizationStrategy<double>& regularization_strategy) = 0;
+      void initialize_memory(const OptimizationProblem& problem, const HessianModel& hessian_model,
+         const RegularizationStrategy<double>& regularization_strategy) override = 0;
 
-      virtual void solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
-         Direction& direction, const WarmstartInformation& warmstart_information) = 0;
+      void solve_inequality_constrained_subproblem(Statistics& statistics, Subproblem& subproblem,
+         const Vector<double>& initial_point, Direction& direction, const WarmstartInformation& warmstart_information) override = 0;
 
-      [[nodiscard]] virtual double hessian_quadratic_product(const Vector<double>& vector) const = 0;
+      [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override = 0;
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -5,8 +5,10 @@
 #include <stdexcept>
 #include "MA27Solver.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
+#include "ingredients/subproblem_solvers/SubproblemStatus.hpp"
 #include "linear_algebra/SymmetricMatrix.hpp"
 #include "linear_algebra/Vector.hpp"
+#include "optimization/Direction.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "tools/Logger.hpp"
 #include "fortran_interface.h"
@@ -238,7 +240,7 @@ namespace uno {
       }
    }
 
-   void MA27Solver::solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
+   void MA27Solver::solve_equality_constrained_subproblem(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) {
       // evaluate the functions at the current iterate
       if (warmstart_information.objective_changed) {
@@ -262,6 +264,9 @@ namespace uno {
       this->solve_indefinite_system(this->augmented_matrix, this->rhs, this->solution);
       // assemble the full primal-dual direction
       subproblem.assemble_primal_dual_direction(this->solution, direction);
+      if (this->matrix_is_singular()) {
+         direction.status = SubproblemStatus::INFEASIBLE;
+      }
    }
 
    Inertia MA27Solver::get_inertia() const {

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.hpp
@@ -49,7 +49,7 @@ namespace uno {
       void do_symbolic_analysis(const SymmetricMatrix<size_t, double>& matrix) override;
       void do_numerical_factorization(const SymmetricMatrix<size_t, double>& matrix) override;
       void solve_indefinite_system(const SymmetricMatrix<size_t, double>& matrix, const Vector<double>& rhs, Vector<double>& result) override;
-      void solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
+      void solve_equality_constrained_subproblem(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] Inertia get_inertia() const override;

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -4,8 +4,10 @@
 #include <cassert>
 #include "MA57Solver.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
+#include "ingredients/subproblem_solvers/SubproblemStatus.hpp"
 #include "linear_algebra/SymmetricMatrix.hpp"
 #include "linear_algebra/Vector.hpp"
+#include "optimization/Direction.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "tools/Logger.hpp"
 #include "fortran_interface.h"
@@ -152,7 +154,7 @@ namespace uno {
       }
    }
 
-   void MA57Solver::solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
+   void MA57Solver::solve_equality_constrained_subproblem(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) {
       // evaluate the functions at the current iterate
       if (warmstart_information.objective_changed) {
@@ -176,6 +178,9 @@ namespace uno {
       this->solve_indefinite_system(this->augmented_matrix, this->rhs, this->solution);
       // assemble the full primal-dual direction
       subproblem.assemble_primal_dual_direction(this->solution, direction);
+      if (this->matrix_is_singular()) {
+         direction.status = SubproblemStatus::INFEASIBLE;
+      }
    }
 
    Inertia MA57Solver::get_inertia() const {

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
@@ -61,7 +61,7 @@ namespace uno {
       void do_symbolic_analysis(const SymmetricMatrix<size_t, double>& matrix) override;
       void do_numerical_factorization(const SymmetricMatrix<size_t, double>& matrix) override;
       void solve_indefinite_system(const SymmetricMatrix<size_t, double>& matrix, const Vector<double>& rhs, Vector<double>& result) override;
-      void solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
+      void solve_equality_constrained_subproblem(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] Inertia get_inertia() const override;

--- a/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.cpp
@@ -3,7 +3,9 @@
 
 #include "MUMPSSolver.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
+#include "ingredients/subproblem_solvers/SubproblemStatus.hpp"
 #include "linear_algebra/SymmetricMatrix.hpp"
+#include "optimization/Direction.hpp"
 #include "optimization/OptimizationProblem.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #if defined(HAS_MPI) && defined(MUMPS_PARALLEL)
@@ -95,7 +97,7 @@ namespace uno {
       dmumps_c(&this->mumps_structure);
    }
 
-   void MUMPSSolver::solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
+   void MUMPSSolver::solve_equality_constrained_subproblem(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) {
       // evaluate the functions at the current iterate
       if (warmstart_information.objective_changed) {
@@ -119,6 +121,9 @@ namespace uno {
       this->solve_indefinite_system(this->augmented_matrix, this->rhs, this->solution);
       // assemble the full primal-dual direction
       subproblem.assemble_primal_dual_direction(this->solution, direction);
+      if (this->matrix_is_singular()) {
+         direction.status = SubproblemStatus::INFEASIBLE;
+      }
    }
 
    Inertia MUMPSSolver::get_inertia() const {

--- a/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.hpp
@@ -25,7 +25,7 @@ namespace uno {
       void do_symbolic_analysis(const SymmetricMatrix<size_t, double>& matrix) override;
       void do_numerical_factorization(const SymmetricMatrix<size_t, double>& matrix) override;
       void solve_indefinite_system(const SymmetricMatrix<size_t, double>& matrix, const Vector<double>& rhs, Vector<double>& result) override;
-      void solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
+      void solve_equality_constrained_subproblem(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] Inertia get_inertia() const override;

--- a/uno/ingredients/subproblem_solvers/QPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/QPSolver.hpp
@@ -9,14 +9,16 @@
 namespace uno {
    class QPSolver : public LPSolver {
    public:
-      QPSolver(): LPSolver() { }
+      QPSolver() = default;
       ~QPSolver() override = default;
 
       void initialize_memory(const OptimizationProblem& problem, const HessianModel& hessian_model,
          const RegularizationStrategy<double>& regularization_strategy) override = 0;
 
-      void solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
-         Direction& direction, const WarmstartInformation& warmstart_information) override = 0;
+      void solve_inequality_constrained_subproblem(Statistics& statistics, Subproblem& subproblem,
+         const Vector<double>& initial_point, Direction& direction, const WarmstartInformation& warmstart_information) override = 0;
+
+      [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override = 0;
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolver.hpp
@@ -28,7 +28,7 @@ namespace uno {
 
       virtual void solve_indefinite_system(const SymmetricMatrix<IndexType, ElementType>& matrix, const Vector<ElementType>& rhs,
          Vector<ElementType>& result) = 0;
-      virtual void solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
+      virtual void solve_equality_constrained_subproblem(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) = 0;
    };
 } // namespace


### PR DESCRIPTION
- [x] introduce abstract class `InequalityConstrainedSubproblemSolver`, inherited by `LPSolver` and `QPSolver`
- [ ] introduce abstract class `EqualityConstrainedSubproblemSolver`, inherited by `DirectSymmetricIndefiniteLinearSolver`, `IterativeSymmetricIndefiniteLinearSolver` and `QPSolver`
- [ ] introduce abstract class `BoxSubproblemSolver` inherited by `ProjectedGradientSolver`