### PR TITLE
Proper resize in MA27Solver::do_numerical_factorization()

### DIFF
--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -205,14 +205,14 @@ namespace uno {
 
          if (this->workspace.info[eINFO::IFLAG] == eIFLAG::INSUFFICIENTINTEGER) {
             DEBUG << "MA27: insufficient integer workspace, resizing and retrying. \n";
-            // increase the size of iw
-            this->workspace.iw.resize(static_cast<size_t>(this->workspace.info[eINFO::IERROR]));
+            // increase the size of iw by 50%
+            this->workspace.iw.resize(static_cast<size_t>(3 * this->workspace.info[eINFO::IERROR] / 2));
             factorization_done = false;
          }
          if (this->workspace.info[eINFO::IFLAG] == eIFLAG::INSUFFICIENTREAL) {
             DEBUG << "MA27: insufficient real workspace, resizing and retrying. \n";
-            // increase the size of factor
-            this->workspace.factor.resize(static_cast<size_t>(this->workspace.info[eINFO::IERROR]));
+            // increase the size of factor by 50%
+            this->workspace.factor.resize(static_cast<size_t>(3 * this->workspace.info[eINFO::IERROR] / 2));
             factorization_done = false;
          }
       }

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.hpp
@@ -9,7 +9,6 @@
 #include "../DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "linear_algebra/COOFormat.hpp"
 #include "linear_algebra/RectangularMatrix.hpp"
-#include "linear_algebra/SparseVector.hpp"
 #include "linear_algebra/SparseSymmetricMatrix.hpp"
 #include "linear_algebra/Vector.hpp"
 


### PR DESCRIPTION
Properly resize the MA27 workspace by +50%.