### PR TITLE
[WIP] Compute the residuals wrt the problem (original or feasibility) being currently solved

### DIFF
--- a/.github/julia/runtests_uno_filterslp_highs.jl
+++ b/.github/julia/runtests_uno_filterslp_highs.jl
@@ -22,7 +22,7 @@ function Optimizer(options)
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_Uno_filterslp() = Optimizer(["logger=INFO", "preset=filterslp", "LP_solver=HiGHS", "max_iterations=10000", "unbounded_objective_threshold=-1e15"])
+Optimizer_Uno_filterslp() = Optimizer(["logger=SILENT", "preset=filterslp", "LP_solver=HiGHS", "max_iterations=10000", "unbounded_objective_threshold=-1e15"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 @testset "MINLPTests" begin

--- a/.github/julia/runtests_uno_filterslp_highs.jl
+++ b/.github/julia/runtests_uno_filterslp_highs.jl
@@ -22,7 +22,7 @@ function Optimizer(options)
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_Uno_filterslp() = Optimizer(["logger=SILENT", "preset=filterslp", "LP_solver=HiGHS", "max_iterations=10000", "unbounded_objective_threshold=-1e15"])
+Optimizer_Uno_filterslp() = Optimizer(["logger=INFO", "preset=filterslp", "LP_solver=HiGHS", "max_iterations=10000", "unbounded_objective_threshold=-1e15"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 @testset "MINLPTests" begin

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -69,6 +69,7 @@ namespace uno {
                this->globalization_mechanism->compute_next_iterate(statistics, *this->constraint_relaxation_strategy,
                   *this->globalization_strategy, model, current_iterate, trial_iterate, this->direction, warmstart_information,
                   user_callbacks);
+               GlobalizationMechanism::set_dual_residuals_statistics(statistics, trial_iterate);
                termination = this->termination_criteria(trial_iterate.status, major_iterations, timer.get_duration(), optimization_status);
                user_callbacks.notify_new_primals(trial_iterate.primals);
                user_callbacks.notify_new_multipliers(trial_iterate.multipliers);
@@ -102,6 +103,8 @@ namespace uno {
       statistics.set("iter", 0);
       statistics.set("status", "initial point");
       this->constraint_relaxation_strategy->initialize(statistics, model, current_iterate, this->direction, options);
+      GlobalizationMechanism::set_primal_statistics(statistics, model, current_iterate);
+      GlobalizationMechanism::set_dual_residuals_statistics(statistics, current_iterate);
       this->globalization_strategy->initialize(statistics, current_iterate, options);
       this->globalization_mechanism->initialize(statistics, options);
       options.print_used();
@@ -149,7 +152,7 @@ namespace uno {
    }
 
    Result Uno::create_result(const Model& model, OptimizationStatus optimization_status, Iterate& current_iterate, size_t major_iterations,
-         const Timer& timer) {
+         const Timer& timer) const {
       const size_t number_subproblems_solved = this->constraint_relaxation_strategy->get_number_subproblems_solved();
       const size_t number_hessian_evaluations = this->constraint_relaxation_strategy->get_hessian_evaluation_count();
       return {optimization_status, std::move(current_iterate), model.number_variables, model.number_constraints, major_iterations,

--- a/uno/Uno.hpp
+++ b/uno/Uno.hpp
@@ -45,10 +45,10 @@ namespace uno {
       void initialize(Statistics& statistics, const Model& model, Iterate& current_iterate, const Options& options);
       [[nodiscard]] static Statistics create_statistics(const Model& model, const Options& options);
       [[nodiscard]] bool termination_criteria(IterateStatus current_status, size_t iteration, double current_time,
-            OptimizationStatus& optimization_status) const;
+         OptimizationStatus& optimization_status) const;
       static void postprocess_iterate(const Model& model, Iterate& iterate, IterateStatus termination_status);
       [[nodiscard]] Result create_result(const Model& model, OptimizationStatus optimization_status, Iterate& current_iterate,
-            size_t major_iterations, const Timer& timer);
+         size_t major_iterations, const Timer& timer) const;
    };
 } // namespace
 

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -138,7 +138,7 @@ namespace uno {
 
       problem.evaluate_lagrangian_gradient(iterate.residuals.lagrangian_gradient, iterate, multipliers);
       iterate.residuals.stationarity = OptimizationProblem::stationarity_error(iterate.residuals.lagrangian_gradient,
-         iterate.objective_multiplier, this->residual_norm);
+         problem.get_objective_multiplier(), this->residual_norm);
 
       // constraint violation of the original problem
       iterate.primal_feasibility = problem.model.constraint_violation(iterate.evaluations.constraints, this->residual_norm);

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -186,16 +186,4 @@ namespace uno {
          return std::max(1., bound_multiplier_norm / scaling_factor);
       }
    }
-
-   void ConstraintRelaxationStrategy::set_statistics(Statistics& statistics, const Model& model, const Iterate& iterate) const {
-      this->set_primal_statistics(statistics, model, iterate);
-      this->set_dual_residuals_statistics(statistics, iterate);
-   }
-
-   void ConstraintRelaxationStrategy::set_primal_statistics(Statistics& statistics, const Model& model, const Iterate& iterate) const {
-      statistics.set("objective", iterate.evaluations.objective);
-      if (model.is_constrained()) {
-         statistics.set("primal feas", iterate.progress.infeasibility);
-      }
-   }
 } // namespace

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -38,11 +38,6 @@ namespace uno {
       virtual void compute_feasible_direction(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          const Model& model, Iterate& current_iterate, Direction& direction, double trust_region_radius,
          WarmstartInformation& warmstart_information) = 0;
-      /*
-      void compute_feasible_direction(Statistics& statistics, GlobalizationStrategy& globalization_strategy, const Model& model,
-         Iterate& current_iterate, Direction& direction, const Vector<double>& initial_point, double trust_region_radius,
-         WarmstartInformation& warmstart_information);
-      */
       [[nodiscard]] virtual bool solving_feasibility_problem() const = 0;
       virtual void switch_to_feasibility_problem(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          const Model& model, Iterate& current_iterate, WarmstartInformation& warmstart_information) = 0;
@@ -52,9 +47,6 @@ namespace uno {
          const Model& model, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) = 0;
       [[nodiscard]] virtual IterateStatus check_termination(const Model& model, Iterate& iterate) = 0;
-
-      // primal-dual residuals
-      virtual void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const = 0;
 
       [[nodiscard]] virtual std::string get_name() const = 0;
       [[nodiscard]] virtual size_t get_hessian_evaluation_count() const = 0;
@@ -95,9 +87,6 @@ namespace uno {
 
       template <typename Problem>
       [[nodiscard]] IterateStatus check_termination(const Problem& problem, Iterate& iterate);
-
-      void set_statistics(Statistics& statistics, const Model& model, const Iterate& iterate) const;
-      void set_primal_statistics(Statistics& statistics, const Model& model, const Iterate& iterate) const;
    };
 
    template <typename Problem>

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -184,7 +184,7 @@ namespace uno {
             trial_iterate.multipliers, direction, step_length, user_callbacks);
       }
       else {
-         const l1RelaxedProblem feasibility_problem{model, 0, this->constraint_violation_coefficient};
+         const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};
          accept_iterate = ConstraintRelaxationStrategy::is_iterate_acceptable(statistics, globalization_strategy,
             feasibility_problem, *this->feasibility_inequality_handling_method, current_iterate, trial_iterate,
             trial_iterate.feasibility_multipliers, direction, step_length, user_callbacks);
@@ -210,7 +210,7 @@ namespace uno {
          return ConstraintRelaxationStrategy::check_termination(optimality_problem, iterate);
       }
       else {
-         const l1RelaxedProblem feasibility_problem{model, 0, this->constraint_violation_coefficient};
+         const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};
          ConstraintRelaxationStrategy::compute_primal_dual_residuals(feasibility_problem, iterate, iterate.feasibility_multipliers);
          return ConstraintRelaxationStrategy::check_termination(feasibility_problem, iterate);
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -213,7 +213,7 @@ namespace uno {
       }
       else {
          const l1RelaxedProblem feasibility_problem{model, 0, this->constraint_violation_coefficient};
-         ConstraintRelaxationStrategy::compute_primal_dual_residuals(feasibility_problem, iterate, iterate.multipliers);
+         ConstraintRelaxationStrategy::compute_primal_dual_residuals(feasibility_problem, iterate, iterate.feasibility_multipliers);
          return ConstraintRelaxationStrategy::check_termination(feasibility_problem, iterate);
       }
    }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -71,7 +71,6 @@ namespace uno {
       this->optimality_inequality_handling_method->generate_initial_iterate(optimality_problem, initial_iterate);
       this->evaluate_progress_measures(*this->optimality_inequality_handling_method, optimality_problem, initial_iterate);
       ConstraintRelaxationStrategy::compute_primal_dual_residuals(optimality_problem, initial_iterate, initial_iterate.multipliers);
-      this->set_statistics(statistics, model, initial_iterate);
    }
 
    void FeasibilityRestoration::compute_feasible_direction(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
@@ -201,7 +200,6 @@ namespace uno {
       else {
          warmstart_information.no_changes();
       }
-      ConstraintRelaxationStrategy::set_primal_statistics(statistics, model, trial_iterate);
       return accept_iterate;
    }
 
@@ -223,11 +221,6 @@ namespace uno {
       this->set_infeasibility_measure(problem.model, iterate);
       this->set_objective_measure(problem.model, iterate);
       inequality_handling_method.set_auxiliary_measure(problem, iterate);
-   }
-
-   void FeasibilityRestoration::set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const {
-      statistics.set("stationarity", iterate.residuals.stationarity);
-      statistics.set("complementarity", iterate.residuals.complementarity);
    }
 
    std::string FeasibilityRestoration::get_name() const {

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -34,9 +34,6 @@ namespace uno {
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
       [[nodiscard]] IterateStatus check_termination(const Model& model, Iterate& iterate) override;
 
-      // primal-dual residuals
-      void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const override;
-
       [[nodiscard]] std::string get_name() const override;
       [[nodiscard]] size_t get_hessian_evaluation_count() const override;
       [[nodiscard]] size_t get_number_subproblems_solved() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -32,9 +32,9 @@ namespace uno {
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          const Model& model, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
+      [[nodiscard]] IterateStatus check_termination(const Model& model, Iterate& iterate) override;
 
       // primal-dual residuals
-      void compute_primal_dual_residuals(const Model& model, Iterate& iterate) override;
       void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const override;
 
       [[nodiscard]] std::string get_name() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.cpp
@@ -38,7 +38,7 @@ namespace uno {
       // initial iterate
       this->inequality_handling_method->generate_initial_iterate(problem, initial_iterate);
       this->evaluate_progress_measures(*this->inequality_handling_method, problem, initial_iterate);
-      this->compute_primal_dual_residuals(model, initial_iterate);
+      this->compute_primal_dual_residuals(problem, initial_iterate, initial_iterate.multipliers);
       this->set_statistics(statistics, model, initial_iterate);
    }
 
@@ -83,9 +83,10 @@ namespace uno {
       return accept_iterate;
    }
 
-   void UnconstrainedStrategy::compute_primal_dual_residuals(const Model& model, Iterate& iterate) {
+   IterateStatus UnconstrainedStrategy::check_termination(const Model& model, Iterate& iterate) {
       const OptimizationProblem problem{model};
-      ConstraintRelaxationStrategy::compute_primal_dual_residuals(model, problem, problem, iterate);
+      ConstraintRelaxationStrategy::compute_primal_dual_residuals(problem, iterate, iterate.multipliers);
+      return ConstraintRelaxationStrategy::check_termination(problem, iterate);
    }
 
    void UnconstrainedStrategy::evaluate_progress_measures(InequalityHandlingMethod& inequality_handling_method,

--- a/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.cpp
@@ -12,7 +12,6 @@
 #include "optimization/WarmstartInformation.hpp"
 #include "symbolic/VectorView.hpp"
 #include "tools/Logger.hpp"
-#include "tools/Statistics.hpp"
 
 namespace uno {
    UnconstrainedStrategy::UnconstrainedStrategy(const Options& options) :

--- a/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.cpp
@@ -39,7 +39,6 @@ namespace uno {
       this->inequality_handling_method->generate_initial_iterate(problem, initial_iterate);
       this->evaluate_progress_measures(*this->inequality_handling_method, problem, initial_iterate);
       this->compute_primal_dual_residuals(problem, initial_iterate, initial_iterate.multipliers);
-      this->set_statistics(statistics, model, initial_iterate);
    }
 
    void UnconstrainedStrategy::compute_feasible_direction(Statistics& statistics, GlobalizationStrategy& /*globalization_strategy*/,
@@ -78,7 +77,6 @@ namespace uno {
       const bool accept_iterate = ConstraintRelaxationStrategy::is_iterate_acceptable(statistics, globalization_strategy,
          problem, *this->inequality_handling_method, current_iterate, trial_iterate, trial_iterate.multipliers,
          direction, step_length, user_callbacks);
-      ConstraintRelaxationStrategy::set_primal_statistics(statistics, model, trial_iterate);
       warmstart_information.no_changes();
       return accept_iterate;
    }
@@ -94,11 +92,6 @@ namespace uno {
       this->set_infeasibility_measure(problem.model, iterate);
       this->set_objective_measure(problem.model, iterate);
       inequality_handling_method.set_auxiliary_measure(problem, iterate);
-   }
-
-   void UnconstrainedStrategy::set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const {
-      statistics.set("stationarity", iterate.residuals.stationarity);
-      statistics.set("complementarity", iterate.residuals.complementarity);
    }
 
    std::string UnconstrainedStrategy::get_name() const {

--- a/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.hpp
@@ -29,9 +29,9 @@ namespace uno {
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy, const Model& model,
          Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
+      [[nodiscard]] IterateStatus check_termination(const Model& model, Iterate& iterate) override;
 
       // primal-dual residuals
-      void compute_primal_dual_residuals(const Model& model, Iterate& iterate) override;
       void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const override;
 
       [[nodiscard]] std::string get_name() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.hpp
@@ -31,9 +31,6 @@ namespace uno {
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
       [[nodiscard]] IterateStatus check_termination(const Model& model, Iterate& iterate) override;
 
-      // primal-dual residuals
-      void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const override;
-
       [[nodiscard]] std::string get_name() const override;
       [[nodiscard]] size_t get_hessian_evaluation_count() const override;
       [[nodiscard]] size_t get_number_subproblems_solved() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
@@ -81,7 +81,6 @@ namespace uno {
       this->inequality_handling_method->generate_initial_iterate(l1_relaxed_problem, initial_iterate);
       this->evaluate_progress_measures(*this->inequality_handling_method, l1_relaxed_problem, initial_iterate);
       this->compute_primal_dual_residuals(l1_relaxed_problem, initial_iterate, initial_iterate.multipliers);
-      this->set_statistics(statistics, model, initial_iterate);
    }
 
    void l1Relaxation::compute_feasible_direction(Statistics& statistics, GlobalizationStrategy& /*globalization_strategy*/, const Model& model,
@@ -279,7 +278,6 @@ namespace uno {
       if (accept_iterate) {
          this->check_exact_relaxation(trial_iterate);
       }
-      ConstraintRelaxationStrategy::set_primal_statistics(statistics, model, trial_iterate);
       warmstart_information.no_changes();
       return accept_iterate;
    }
@@ -302,11 +300,6 @@ namespace uno {
       if (0. < norm_inf_multipliers && this->penalty_parameter <= 1./norm_inf_multipliers) {
          DEBUG << "The value of the penalty parameter is consistent with an exact relaxation\n\n";
       }
-   }
-
-   void l1Relaxation::set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const {
-      statistics.set("stationarity", iterate.residuals.stationarity);
-      statistics.set("complementarity", iterate.residuals.complementarity);
    }
 
    std::string l1Relaxation::get_name() const {

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.cpp
@@ -75,13 +75,12 @@ namespace uno {
       statistics.set("penalty", this->penalty_parameter);
 
       // initial iterate
-      initial_iterate.feasibility_residuals.lagrangian_gradient.resize(l1_relaxed_problem.number_variables);
       initial_iterate.feasibility_multipliers.lower_bounds.resize(l1_relaxed_problem.number_variables);
       initial_iterate.feasibility_multipliers.upper_bounds.resize(l1_relaxed_problem.number_variables);
       this->inequality_handling_method->set_elastic_variable_values(l1_relaxed_problem, initial_iterate);
       this->inequality_handling_method->generate_initial_iterate(l1_relaxed_problem, initial_iterate);
       this->evaluate_progress_measures(*this->inequality_handling_method, l1_relaxed_problem, initial_iterate);
-      this->compute_primal_dual_residuals(model, initial_iterate);
+      this->compute_primal_dual_residuals(l1_relaxed_problem, initial_iterate, initial_iterate.multipliers);
       this->set_statistics(statistics, model, initial_iterate);
    }
 
@@ -204,7 +203,8 @@ namespace uno {
    double l1Relaxation::compute_infeasible_dual_error(const Model& model, Iterate& current_iterate) const {
       const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};
       // stationarity error
-      feasibility_problem.evaluate_lagrangian_gradient(current_iterate.feasibility_residuals.lagrangian_gradient, current_iterate, this->trial_multipliers);
+      // TODO correct residuals?
+      feasibility_problem.evaluate_lagrangian_gradient(current_iterate.residuals.lagrangian_gradient, current_iterate, this->trial_multipliers);
       double error = norm_1(current_iterate.residuals.lagrangian_gradient.constraints_contribution);
 
       // complementarity error
@@ -284,10 +284,9 @@ namespace uno {
       return accept_iterate;
    }
 
-   void l1Relaxation::compute_primal_dual_residuals(const Model& model, Iterate& iterate) {
-      const l1RelaxedProblem l1_relaxed_problem{model, this->penalty_parameter, this->constraint_violation_coefficient};
-      const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};
-      ConstraintRelaxationStrategy::compute_primal_dual_residuals(model, l1_relaxed_problem, feasibility_problem, iterate);
+   IterateStatus l1Relaxation::check_termination(const Model& model, Iterate& iterate) {
+      // ConstraintRelaxationStrategy::compute_primal_dual_residuals(problem, iterate, iterate.multipliers);
+      throw std::runtime_error("l1Relaxation::check_termination not implemented yet");
    }
 
    void l1Relaxation::evaluate_progress_measures(InequalityHandlingMethod& inequality_handling_method,

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
@@ -39,9 +39,6 @@ namespace uno {
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
       [[nodiscard]] IterateStatus check_termination(const Model& model, Iterate& iterate) override;
 
-      // primal-dual residuals
-      void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const override;
-
       [[nodiscard]] std::string get_name() const override;
       [[nodiscard]] size_t get_hessian_evaluation_count() const override;
       [[nodiscard]] size_t get_number_subproblems_solved() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1Relaxation.hpp
@@ -37,9 +37,9 @@ namespace uno {
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy, const Model& model,
          Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
+      [[nodiscard]] IterateStatus check_termination(const Model& model, Iterate& iterate) override;
 
       // primal-dual residuals
-      void compute_primal_dual_residuals(const Model& model, Iterate& iterate) override;
       void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) const override;
 
       [[nodiscard]] std::string get_name() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
@@ -8,7 +8,6 @@
 #include "model/Model.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/LagrangianGradient.hpp"
-#include "symbolic/VectorExpression.hpp"
 #include "symbolic/Concatenation.hpp"
 #include "tools/Infinity.hpp"
 

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
@@ -198,6 +198,27 @@ namespace uno {
       }
    }
 
+   IterateStatus l1RelaxedProblem::check_first_order_convergence(const Iterate& current_iterate, double tolerance) const {
+      // evaluate termination conditions based on optimality conditions
+      const bool feasibility_stationarity = (current_iterate.residuals.stationarity <= tolerance);
+      const bool primal_feasibility = (current_iterate.primal_feasibility <= tolerance);
+      const bool feasibility_complementarity = (current_iterate.residuals.complementarity <= tolerance);
+      const bool no_trivial_duals = current_iterate.feasibility_multipliers.not_all_zero(this->model.number_variables, tolerance);
+
+      DEBUG << "\nTermination criteria for tolerance = " << tolerance << ":\n";
+      DEBUG << "Primal feasibility: " << std::boolalpha << primal_feasibility << '\n';
+      DEBUG << "Feasibility stationarity: " << std::boolalpha << feasibility_stationarity << '\n';
+      DEBUG << "Feasibility complementarity: " << std::boolalpha << feasibility_complementarity << '\n';
+      DEBUG << "Not all zero multipliers: " << std::boolalpha << no_trivial_duals << "\n\n";
+
+      if (this->model.is_constrained() && feasibility_stationarity && !primal_feasibility && feasibility_complementarity &&
+            no_trivial_duals) {
+         // no primal feasibility, stationary point of constraint violation
+         return IterateStatus::INFEASIBLE_STATIONARY_POINT;
+      }
+      return IterateStatus::NOT_OPTIMAL;
+   }
+
    double l1RelaxedProblem::variable_lower_bound(size_t variable_index) const {
       if (variable_index < this->model.number_variables) { // model variable
          return this->model.variable_lower_bound(variable_index);

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
@@ -21,6 +21,8 @@ namespace uno {
       void evaluate_objective_gradient(Iterate& iterate, Vector<double>& objective_gradient) const override;
       void evaluate_constraints(Iterate& iterate, std::vector<double>& constraints) const override;
       void evaluate_constraint_jacobian(Iterate& iterate, RectangularMatrix<double>& constraint_jacobian) const override;
+      void evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate,
+         const Multipliers& multipliers) const override;
       void evaluate_lagrangian_hessian(Statistics& statistics, HessianModel& hessian_model, const Vector<double>& primal_variables,
          const Multipliers& multipliers, SymmetricMatrix<size_t, double>& hessian) const override;
       void compute_hessian_vector_product(HessianModel& hessian_model, const double* vector, const Multipliers& multipliers,
@@ -44,7 +46,6 @@ namespace uno {
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;
       [[nodiscard]] size_t number_hessian_nonzeros(const HessianModel& hessian_model) const override;
 
-      void evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate, const Multipliers& multipliers) const override;
       [[nodiscard]] IterateStatus check_first_order_convergence(const Iterate& current_iterate, double tolerance) const;
 
       // parameterization

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
@@ -45,6 +45,7 @@ namespace uno {
       [[nodiscard]] size_t number_hessian_nonzeros(const HessianModel& hessian_model) const override;
 
       void evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate, const Multipliers& multipliers) const override;
+      [[nodiscard]] IterateStatus check_first_order_convergence(const Iterate& current_iterate, double tolerance) const;
 
       // parameterization
       void set_proximal_multiplier(double new_proximal_coefficient);

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
@@ -26,14 +26,13 @@ namespace uno {
 
       void backtrack_along_direction(Statistics& statistics, ConstraintRelaxationStrategy& constraint_relaxation_strategy,
          GlobalizationStrategy& globalization_strategy, const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
-         Direction& direction, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks);
+         Direction& direction, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) const;
       [[nodiscard]] static bool terminate_with_small_step_length(Statistics& statistics, ConstraintRelaxationStrategy& constraint_relaxation_strategy,
          const Model& model, Iterate& trial_iterate);
       [[nodiscard]] double decrease_step_length(double step_length) const;
       static void check_unboundedness(const Direction& direction);
-      void set_statistics(Statistics& statistics, size_t number_iterations) const;
-      void set_statistics(Statistics& statistics, const Iterate& trial_iterate, const Direction& direction, double primal_dual_step_length,
-         size_t number_iterations) const;
+
+      static void set_LS_statistics(Statistics& statistics, size_t number_iterations);
    };
 } // namespace
 

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
@@ -6,6 +6,7 @@
 #include "optimization/Direction.hpp"
 #include "optimization/Iterate.hpp"
 #include "symbolic/Expression.hpp"
+#include "tools/Statistics.hpp"
 
 namespace uno {
    void GlobalizationMechanism::assemble_trial_iterate(const Model& model, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
@@ -28,5 +29,19 @@ namespace uno {
       trial_iterate.are_constraints_computed = false;
       trial_iterate.is_constraint_jacobian_computed = false;
       trial_iterate.status = IterateStatus::NOT_OPTIMAL;
+   }
+
+   void GlobalizationMechanism::set_primal_statistics(Statistics& statistics, const Model& model, const Iterate& iterate) {
+      if (iterate.is_objective_computed) {
+         statistics.set("objective", iterate.evaluations.objective);
+      }
+      if (model.is_constrained()) {
+         statistics.set("primal feas", iterate.progress.infeasibility);
+      }
+   }
+
+   void GlobalizationMechanism::set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) {
+      statistics.set("stationarity", iterate.residuals.stationarity);
+      statistics.set("complementarity", iterate.residuals.complementarity);
    }
 } // namespace

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
@@ -28,6 +28,9 @@ namespace uno {
          GlobalizationStrategy& globalization_strategy, const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
          Direction& direction, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) = 0;
 
+      static void set_primal_statistics(Statistics& statistics, const Model& model, const Iterate& iterate);
+      static void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate);
+
       [[nodiscard]] virtual std::string get_name() const = 0;
 
    protected:

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -152,13 +152,11 @@ namespace uno {
       // terminate with a feasible point
       if (trial_iterate.progress.infeasibility <= this->tolerance) {
          trial_iterate.status = IterateStatus::FEASIBLE_SMALL_STEP;
-         throw std::runtime_error("TrustRegionStrategy::check_termination_with_small_step feasible not implemented");
          // TODO constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
          return true;
       }
       else if (constraint_relaxation_strategy.solving_feasibility_problem()) { // terminate with an infeasible point
          trial_iterate.status = IterateStatus::INFEASIBLE_SMALL_STEP;
-         throw std::runtime_error("TrustRegionStrategy::check_termination_with_small_step infeasible not implemented");
          // TODO constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
          return true;
       }

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -142,22 +142,20 @@ namespace uno {
          this->possibly_increase_radius(direction.norm);
       }
       else if (this->radius < this->minimum_radius) { // rejected, but small radius
-         accept_iterate = this->check_termination_with_small_step(constraint_relaxation_strategy, model, trial_iterate);
+         accept_iterate = this->check_termination_with_small_step(trial_iterate);
       }
       return accept_iterate;
    }
 
-   bool TrustRegionStrategy::check_termination_with_small_step(const ConstraintRelaxationStrategy& constraint_relaxation_strategy,
-         const Model& /*model*/, Iterate& trial_iterate) const {
+   // check whether a rejected step with very small norm can be tolerated
+   bool TrustRegionStrategy::check_termination_with_small_step(Iterate& trial_iterate) const {
       // terminate with a feasible point
       if (trial_iterate.progress.infeasibility <= this->tolerance) {
          trial_iterate.status = IterateStatus::FEASIBLE_SMALL_STEP;
-         // TODO constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
          return true;
       }
-      else if (constraint_relaxation_strategy.solving_feasibility_problem()) { // terminate with an infeasible point
+      else if (trial_iterate.objective_multiplier == 0.) { // terminate with an infeasible point
          trial_iterate.status = IterateStatus::INFEASIBLE_SMALL_STEP;
-         // TODO constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
          return true;
       }
       else { // do not terminate, infeasible non stationary

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -152,12 +152,12 @@ namespace uno {
       // terminate with a feasible point
       if (trial_iterate.progress.infeasibility <= this->tolerance) {
          trial_iterate.status = IterateStatus::FEASIBLE_SMALL_STEP;
-         constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
+         // TODO constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
          return true;
       }
       else if (constraint_relaxation_strategy.solving_feasibility_problem()) { // terminate with an infeasible point
          trial_iterate.status = IterateStatus::INFEASIBLE_SMALL_STEP;
-         constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
+         // TODO constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
          return true;
       }
       else { // do not terminate, infeasible non stationary

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -152,11 +152,13 @@ namespace uno {
       // terminate with a feasible point
       if (trial_iterate.progress.infeasibility <= this->tolerance) {
          trial_iterate.status = IterateStatus::FEASIBLE_SMALL_STEP;
+         throw std::runtime_error("TrustRegionStrategy::check_termination_with_small_step feasible not implemented");
          // TODO constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
          return true;
       }
       else if (constraint_relaxation_strategy.solving_feasibility_problem()) { // terminate with an infeasible point
          trial_iterate.status = IterateStatus::INFEASIBLE_SMALL_STEP;
+         throw std::runtime_error("TrustRegionStrategy::check_termination_with_small_step infeasible not implemented");
          // TODO constraint_relaxation_strategy.compute_primal_dual_residuals(model, trial_iterate);
          return true;
       }

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
@@ -29,7 +29,7 @@ namespace uno {
       const double radius_reset_threshold;
       const double tolerance;
 
-      bool is_iterate_acceptable(Statistics& statistics, ConstraintRelaxationStrategy& constraint_relaxation_strategy,
+      [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, ConstraintRelaxationStrategy& constraint_relaxation_strategy,
          GlobalizationStrategy& globalization_strategy, const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
          const Direction& direction, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks);
       void possibly_increase_radius(double step_norm);
@@ -38,8 +38,7 @@ namespace uno {
       void decrease_radius_aggressively();
       void reset_radius();
       void reset_active_trust_region_multipliers(const Model& model, const Direction& direction, Iterate& trial_iterate) const;
-      bool check_termination_with_small_step(const ConstraintRelaxationStrategy& constraint_relaxation_strategy, const Model& model,
-         Iterate& trial_iterate) const;
+      [[nodiscard]] bool check_termination_with_small_step(Iterate& trial_iterate) const;
       void set_TR_statistics(Statistics& statistics, size_t number_iterations) const;
    };
 } // namespace

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
@@ -38,11 +38,9 @@ namespace uno {
       void decrease_radius_aggressively();
       void reset_radius();
       void reset_active_trust_region_multipliers(const Model& model, const Direction& direction, Iterate& trial_iterate) const;
-      bool check_termination_with_small_step(ConstraintRelaxationStrategy& constraint_relaxation_strategy, const Model& model,
+      bool check_termination_with_small_step(const ConstraintRelaxationStrategy& constraint_relaxation_strategy, const Model& model,
          Iterate& trial_iterate) const;
-      void set_trust_region_statistics(Statistics& statistics, size_t number_iterations) const;
-      void set_statistics(Statistics& statistics, const Direction& direction) const;
-      void set_statistics(Statistics& statistics, const Iterate& trial_iterate, const Direction& direction) const;
+      void set_TR_statistics(Statistics& statistics, size_t number_iterations) const;
    };
 } // namespace
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
@@ -120,10 +120,9 @@ namespace uno {
 
 
       // possibly update the barrier parameter
-      const auto& residuals = this->solving_feasibility_problem ? current_iterate.feasibility_residuals : current_iterate.residuals;
       if (!this->first_feasibility_iteration) {
          const PrimalDualInteriorPointProblem barrier_problem(problem, this->barrier_parameter(), this->parameters);
-         this->update_barrier_parameter(barrier_problem, current_iterate, current_multipliers, residuals);
+         this->update_barrier_parameter(barrier_problem, current_iterate, current_multipliers, current_iterate.residuals);
       }
       else {
          this->first_feasibility_iteration = false;

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
@@ -5,6 +5,7 @@
 #define UNO_BQPDSOLVER_H
 
 #include <array>
+#include <memory>
 #include <vector>
 #include "ingredients/subproblem_solvers/QPSolver.hpp"
 #include "ingredients/subproblem_solvers/SubproblemStatus.hpp"

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2024 Charlie Vanaret
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
-#include <cassert>
 #include "HiGHSSolver.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
 #include "ingredients/regularization_strategies/RegularizationStrategy.hpp"

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
@@ -132,7 +132,7 @@ namespace uno {
    void HiGHSSolver::solve_subproblem(const Subproblem& subproblem, Direction& direction) {
       // solve the LP
       HighsStatus return_status = this->highs_solver.passModel(this->model);
-      assert(return_status == HighsStatus::kOk);
+      //assert(return_status == HighsStatus::kOk);
 
       return_status = this->highs_solver.run(); // solve
       DEBUG << "HiGHS status: " << static_cast<int>(return_status) << '\n';

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
@@ -10,7 +10,6 @@
 #include "linear_algebra/COOFormat.hpp"
 #include "linear_algebra/RectangularMatrix.hpp"
 #include "linear_algebra/SparseSymmetricMatrix.hpp"
-#include "linear_algebra/SparseVector.hpp"
 #include "linear_algebra/Vector.hpp"
 
 namespace uno {

--- a/uno/linear_algebra/SparseSymmetricMatrix.hpp
+++ b/uno/linear_algebra/SparseSymmetricMatrix.hpp
@@ -5,7 +5,6 @@
 #define UNO_SPARSESYMMETRICMATRIX_H
 
 #include <algorithm>
-#include <memory>
 #include <vector>
 #include "SymmetricMatrix.hpp"
 

--- a/uno/linear_algebra/SparseVector.hpp
+++ b/uno/linear_algebra/SparseVector.hpp
@@ -132,7 +132,8 @@ namespace uno {
    template <typename Vector>
    typename Vector::value_type dot(const Vector& x, const Vector& y) {
       typename Vector::value_type dot_product = 0;
-      for (size_t index: Range(x.size())) {
+      const size_t size = std::min(x.size(), y.size());
+      for (size_t index: Range(size)) {
          dot_product += x[index] * y[index];
       }
       return dot_product;

--- a/uno/optimization/Iterate.cpp
+++ b/uno/optimization/Iterate.cpp
@@ -17,7 +17,7 @@ namespace uno {
    Iterate::Iterate(size_t number_variables, size_t number_constraints) :
          number_variables(number_variables), number_constraints(number_constraints),
          primals(number_variables), multipliers(number_variables, number_constraints), feasibility_multipliers(number_variables, number_constraints),
-         evaluations(number_variables, number_constraints), residuals(number_variables), feasibility_residuals(number_variables) {
+         evaluations(number_variables, number_constraints), residuals(number_variables) {
    }
 
    void Iterate::evaluate_objective(const Model& model) {
@@ -93,9 +93,6 @@ namespace uno {
       stream << "          ┌ Stationarity: " << iterate.residuals.stationarity << '\n';
       stream << "Residuals │ Complementarity: " << iterate.residuals.complementarity << '\n';
       stream << "          └ Lagrangian gradient: " << iterate.residuals.lagrangian_gradient;
-      stream << "Feasibility residuals ┌ Stationarity: " << iterate.feasibility_residuals.stationarity << '\n';
-      stream << "                      │ Complementarity: " << iterate.feasibility_residuals.complementarity << '\n';
-      stream << "                      └ Lagrangian gradient: " << iterate.feasibility_residuals.lagrangian_gradient;
 
       stream << "                  ┌ Infeasibility: " << iterate.progress.infeasibility << '\n';
       stream << "Progress measures │ Optimality: " << iterate.progress.objective(1.) << '\n';

--- a/uno/optimization/Iterate.hpp
+++ b/uno/optimization/Iterate.hpp
@@ -43,7 +43,6 @@ namespace uno {
       // primal-dual residuals
       double primal_feasibility{INF<double>};
       DualResiduals residuals;
-      DualResiduals feasibility_residuals;
 
       // measures of progress (infeasibility, objective, auxiliary)
       ProgressMeasures progress{INF<double>, {}, INF<double>};

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -41,6 +41,8 @@ namespace uno {
       virtual void evaluate_objective_gradient(Iterate& iterate, Vector<double>& objective_gradient) const;
       virtual void evaluate_constraints(Iterate& iterate, std::vector<double>& constraints) const;
       virtual void evaluate_constraint_jacobian(Iterate& iterate, RectangularMatrix<double>& constraint_jacobian) const;
+      virtual void evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate,
+         const Multipliers& multipliers) const;
       virtual void evaluate_lagrangian_hessian(Statistics& statistics, HessianModel& hessian_model, const Vector<double>& primal_variables,
          const Multipliers& multipliers, SymmetricMatrix<size_t, double>& hessian) const;
       virtual void compute_hessian_vector_product(HessianModel& hessian_model, const double* vector,
@@ -71,7 +73,6 @@ namespace uno {
 
       [[nodiscard]] static double stationarity_error(const LagrangianGradient<double>& lagrangian_gradient, double objective_multiplier,
          Norm residual_norm);
-      virtual void evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate, const Multipliers& multipliers) const;
       [[nodiscard]] virtual double complementarity_error(const Vector<double>& primals, const std::vector<double>& constraints,
          const Multipliers& multipliers, double shift_value, Norm residual_norm) const;
 

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include "linear_algebra/Norm.hpp"
 #include "model/Model.hpp"
+#include "optimization/IterateStatus.hpp"
 #include "optimization/LagrangianGradient.hpp"
 
 namespace uno {
@@ -66,13 +67,15 @@ namespace uno {
 
       virtual void assemble_primal_dual_direction(const Iterate& current_iterate, const Multipliers& current_multipliers,
          const Vector<double>& solution, Direction& direction) const;
+      [[nodiscard]] virtual double dual_regularization_factor() const;
 
       [[nodiscard]] static double stationarity_error(const LagrangianGradient<double>& lagrangian_gradient, double objective_multiplier,
          Norm residual_norm);
       virtual void evaluate_lagrangian_gradient(LagrangianGradient<double>& lagrangian_gradient, Iterate& iterate, const Multipliers& multipliers) const;
       [[nodiscard]] virtual double complementarity_error(const Vector<double>& primals, const std::vector<double>& constraints,
          const Multipliers& multipliers, double shift_value, Norm residual_norm) const;
-      [[nodiscard]] virtual double dual_regularization_factor() const;
+
+      [[nodiscard]] IterateStatus check_first_order_convergence(const Iterate& current_iterate, double tolerance) const;
 
    protected:
       const ForwardRange primal_regularization_variables;

--- a/uno/optimization/Result.cpp
+++ b/uno/optimization/Result.cpp
@@ -18,9 +18,6 @@ namespace uno {
       DISCRETE << "┌ Stationarity residual:\t\t" << this->solution.residuals.stationarity << '\n';
       DISCRETE << "└ Complementarity residual:\t\t" << this->solution.residuals.complementarity << '\n';
 
-      DISCRETE << "┌ Feasibility stationarity residual:\t" << this->solution.residuals.stationarity << '\n';
-      DISCRETE << "└ Feasibility complementarity residual:\t" << this->solution.residuals.complementarity << '\n';
-
       DISCRETE << "┌ Infeasibility measure:\t\t" << this->solution.progress.infeasibility << '\n';
       DISCRETE << "│ Objective measure:\t\t\t" << this->solution.progress.objective(1.) << '\n';
       DISCRETE << "└ Auxiliary measure:\t\t\t" << this->solution.progress.auxiliary << '\n';


### PR DESCRIPTION
Instead of computing the residuals wrt the original problem AND the feasibility problem at every iteration, only compute them based on the problem being currently solved.
- [x] for `FeasibilityRestoration`, this depends on the phase
- [x] for `l1Relaxation`, test wrt the original problem then, if necessary, wrt the feasibility problem