### PR TITLE
[CI] Only compile Uno in debug mode

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,6 +16,10 @@ on:
       - 'LICENSE'
       - '*.cff'
 
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
@@ -27,8 +31,6 @@ jobs:
         os: [macos-latest]
         architecture: [x64, arm64]
         compiler: [gcc]
-        # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-        BUILD_TYPE: [Release, Debug]
 
     steps:
     - name: Checkout repository
@@ -60,7 +62,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} \
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                                                 -DMUMPS_INCLUDE_DIR=${{github.workspace}}/deps/include \
                                                 -DMETIS_INCLUDE_DIR=${{github.workspace}}/deps/include \
                                                 -DBQPD=${{github.workspace}}/deps/lib/libbqpd.a \
@@ -74,4 +76,4 @@ jobs:
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -15,7 +15,11 @@ on:
       - '*.md'
       - 'LICENSE'
       - '*.cff'
-    
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
@@ -25,11 +29,8 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        architecture: [x64, x86]
+        architecture: [x64]
         library: [shared, static]
-        # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-        BUILD_TYPE: [Release, Debug]
-
 
     steps:
     - name: Checkout repository
@@ -66,7 +67,7 @@ jobs:
       run: |
         if "%{{matrix.library}}"=="static" (
           cmake -G "NMake Makefiles" ^
-                -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} ^
+                -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ^
                 -DCMAKE_C_COMPILER=cl ^
                 -DCMAKE_CXX_COMPILER=cl ^
                 -DCMAKE_Fortran_COMPILER=ifx ^
@@ -84,7 +85,7 @@ jobs:
                 -DBUILD_SHARED_LIBS=OFF .
         ) else (
           cmake -G "NMake Makefiles" ^
-                -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} ^
+                -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ^
                 -DCMAKE_C_COMPILER=cl ^
                 -DCMAKE_CXX_COMPILER=cl ^
                 -DCMAKE_Fortran_COMPILER=ifx ^

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,7 +15,11 @@ on:
       - '*.md'
       - 'LICENSE'
       - '*.cff'
-    
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
@@ -25,9 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        architecture: [x64, x86]
-        # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-        BUILD_TYPE: [Release, Debug]
+        architecture: [x64]
 
     steps:
     - name: Checkout repository
@@ -54,7 +56,7 @@ jobs:
       run: |
         cmake -G "MinGW Makefiles" ^
           -B ${{github.workspace}}\build ^
-          -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} ^
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ^
           -DMUMPS_INCLUDE_DIR=${{github.workspace}}\deps\include ^
           -DMETIS_INCLUDE_DIR=${{github.workspace}}\deps\include ^
           -DBQPD=${{github.workspace}}\deps\lib\libbqpd.a ^
@@ -68,4 +70,4 @@ jobs:
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}


### PR DESCRIPTION
I also removed the builds for `x86`, we already have one with the cross-compiler.