### PR TITLE
Report the direction as INFEASIBLE if the augmented matrix is singular

### DIFF
--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -7,6 +7,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "linear_algebra/SymmetricMatrix.hpp"
 #include "linear_algebra/Vector.hpp"
+#include "optimization/Direction.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "tools/Logger.hpp"
 #include "fortran_interface.h"
@@ -262,6 +263,9 @@ namespace uno {
       this->solve_indefinite_system(this->augmented_matrix, this->rhs, this->solution);
       // assemble the full primal-dual direction
       subproblem.assemble_primal_dual_direction(this->solution, direction);
+      if (this->matrix_is_singular()) {
+         direction.status = SubproblemStatus::INFEASIBLE;
+      }
    }
 
    Inertia MA27Solver::get_inertia() const {

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -6,6 +6,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "linear_algebra/SymmetricMatrix.hpp"
 #include "linear_algebra/Vector.hpp"
+#include "optimization/Direction.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "tools/Logger.hpp"
 #include "fortran_interface.h"
@@ -176,6 +177,9 @@ namespace uno {
       this->solve_indefinite_system(this->augmented_matrix, this->rhs, this->solution);
       // assemble the full primal-dual direction
       subproblem.assemble_primal_dual_direction(this->solution, direction);
+      if (this->matrix_is_singular()) {
+         direction.status = SubproblemStatus::INFEASIBLE;
+      }
    }
 
    Inertia MA57Solver::get_inertia() const {

--- a/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.cpp
@@ -4,7 +4,7 @@
 #include "MUMPSSolver.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "linear_algebra/SymmetricMatrix.hpp"
-#include "optimization/OptimizationProblem.hpp"
+#include "optimization/Direction.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #if defined(HAS_MPI) && defined(MUMPS_PARALLEL)
 #include "mpi.h"
@@ -119,6 +119,9 @@ namespace uno {
       this->solve_indefinite_system(this->augmented_matrix, this->rhs, this->solution);
       // assemble the full primal-dual direction
       subproblem.assemble_primal_dual_direction(this->solution, direction);
+      if (this->matrix_is_singular()) {
+         direction.status = SubproblemStatus::INFEASIBLE;
+      }
    }
 
    Inertia MUMPSSolver::get_inertia() const {


### PR DESCRIPTION
Report the direction as INFEASIBLE if the augmented matrix in MA57, MA27 and MUMPS is singular.
Singularity of the augmented matrix may happen if the regularization strategy is not primal-dual.