### PR TITLE
Got rid of feasibility multipliers, maintain a second set in FeasibilityRestoration

### DIFF
--- a/bindings/AMPL/uno_ampl.cpp
+++ b/bindings/AMPL/uno_ampl.cpp
@@ -40,7 +40,6 @@ namespace uno {
          model->initial_primal_point(initial_iterate.primals);
          model->project_onto_variable_bounds(initial_iterate.primals);
          model->initial_dual_point(initial_iterate.multipliers.constraints);
-         initial_iterate.feasibility_multipliers.reset();
 
          // solve the instance
          Uno uno{model->number_constraints, options};

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -66,8 +66,6 @@ namespace uno {
       statistics.set("phase", "OPT");
 
       // initial iterate
-      initial_iterate.feasibility_multipliers.lower_bounds.resize(feasibility_problem.number_variables);
-      initial_iterate.feasibility_multipliers.upper_bounds.resize(feasibility_problem.number_variables);
       this->optimality_inequality_handling_method->generate_initial_iterate(optimality_problem, initial_iterate);
       this->evaluate_progress_measures(*this->optimality_inequality_handling_method, optimality_problem, initial_iterate);
       ConstraintRelaxationStrategy::compute_primal_dual_residuals(optimality_problem, initial_iterate, initial_iterate.multipliers);
@@ -84,8 +82,8 @@ namespace uno {
             DEBUG << "Solving the optimality subproblem\n";
             const OptimizationProblem optimality_problem{model};
             this->solve_subproblem(statistics, *this->optimality_inequality_handling_method, optimality_problem, current_iterate,
-               current_iterate.multipliers, direction, *this->optimality_hessian_model, *this->optimality_regularization_strategy,
-               trust_region_radius, warmstart_information);
+               direction, *this->optimality_hessian_model, *this->optimality_regularization_strategy, trust_region_radius,
+               warmstart_information);
             if (direction.status == SubproblemStatus::INFEASIBLE) {
                // switch to the feasibility problem, starting from the current direction
                statistics.set("status", std::string("infeasible subproblem"));
@@ -111,9 +109,8 @@ namespace uno {
       feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
       feasibility_problem.set_proximal_multiplier(this->feasibility_inequality_handling_method->proximal_coefficient());
       this->solve_subproblem(statistics, *this->feasibility_inequality_handling_method, feasibility_problem, current_iterate,
-         current_iterate.feasibility_multipliers, direction, *this->feasibility_hessian_model,
-         *this->feasibility_regularization_strategy, trust_region_radius, warmstart_information);
-      std::swap(direction.multipliers, direction.feasibility_multipliers);
+         direction, *this->feasibility_hessian_model, *this->feasibility_regularization_strategy, trust_region_radius,
+         warmstart_information);
    }
 
    bool FeasibilityRestoration::solving_feasibility_problem() const {
@@ -126,14 +123,21 @@ namespace uno {
       DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       globalization_strategy.notify_switch_to_feasibility(current_iterate.progress);
-      const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};
-      this->feasibility_inequality_handling_method->initialize_feasibility_problem(feasibility_problem, current_iterate);
+
       // save the current point (progress and primals) upon switching
       this->reference_optimality_progress = current_iterate.progress;
       this->reference_optimality_primals = current_iterate.primals;
 
+      const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};
       current_iterate.set_number_variables(feasibility_problem.number_variables);
+      // swap the iterate's multipliers and the feasibility multipliers maintained by the class
+      this->other_phase_multipliers.constraints.resize(feasibility_problem.number_constraints);
+      this->other_phase_multipliers.lower_bounds.resize(feasibility_problem.number_variables);
+      this->other_phase_multipliers.upper_bounds.resize(feasibility_problem.number_variables);
+      std::swap(current_iterate.multipliers, this->other_phase_multipliers);
       this->feasibility_inequality_handling_method->set_elastic_variable_values(feasibility_problem, current_iterate);
+      this->feasibility_inequality_handling_method->initialize_feasibility_problem(feasibility_problem, current_iterate);
+
       DEBUG2 << "Current iterate:\n" << current_iterate << '\n';
 
       if (Logger::level == INFO) statistics.print_current_line();
@@ -141,12 +145,12 @@ namespace uno {
    }
 
    void FeasibilityRestoration::solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
-         const OptimizationProblem& problem, Iterate& current_iterate, const Multipliers& current_multipliers, Direction& direction,
-         HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius,
+         const OptimizationProblem& problem, Iterate& current_iterate, Direction& direction, HessianModel& hessian_model,
+         RegularizationStrategy<double>& regularization_strategy, double trust_region_radius,
          WarmstartInformation& warmstart_information) {
       direction.set_dimensions(problem.number_variables, problem.number_constraints);
-      inequality_handling_method.solve(statistics, problem, current_iterate, current_multipliers, direction,
-         hessian_model, regularization_strategy, trust_region_radius, warmstart_information);
+      inequality_handling_method.solve(statistics, problem, current_iterate, direction, hessian_model, regularization_strategy,
+         trust_region_radius, warmstart_information);
       direction.norm = norm_inf(view(direction.primals, 0, problem.get_number_original_variables()));
       DEBUG3 << direction << '\n';
    }
@@ -166,6 +170,8 @@ namespace uno {
       globalization_strategy.notify_switch_to_optimality(current_iterate.progress);
       const OptimizationProblem optimality_problem{model};
       current_iterate.set_number_variables(optimality_problem.number_variables);
+      // swap the iterate's multipliers and the optimality multipliers maintained by the class
+      std::swap(current_iterate.multipliers, this->other_phase_multipliers);
       trial_iterate.set_number_variables(optimality_problem.number_variables);
       current_iterate.objective_multiplier = trial_iterate.objective_multiplier = 1.;
 
@@ -187,7 +193,7 @@ namespace uno {
          const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};
          accept_iterate = ConstraintRelaxationStrategy::is_iterate_acceptable(statistics, globalization_strategy,
             feasibility_problem, *this->feasibility_inequality_handling_method, current_iterate, trial_iterate,
-            trial_iterate.feasibility_multipliers, direction, step_length, user_callbacks);
+            trial_iterate.multipliers, direction, step_length, user_callbacks);
       }
 
       // possibly go from restoration phase to optimality phase
@@ -211,7 +217,7 @@ namespace uno {
       }
       else {
          const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};
-         ConstraintRelaxationStrategy::compute_primal_dual_residuals(feasibility_problem, iterate, iterate.feasibility_multipliers);
+         ConstraintRelaxationStrategy::compute_primal_dual_residuals(feasibility_problem, iterate, iterate.multipliers);
          return ConstraintRelaxationStrategy::check_termination(feasibility_problem, iterate);
       }
    }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -123,7 +123,7 @@ namespace uno {
    // precondition: this->current_phase == Phase::OPTIMALITY
    void FeasibilityRestoration::switch_to_feasibility_problem(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          const Model& model, Iterate& current_iterate, WarmstartInformation& warmstart_information) {
-      DEBUG << "Switching from optimality to restoration phase\n";
+      DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       globalization_strategy.notify_switch_to_feasibility(current_iterate.progress);
       const l1RelaxedProblem feasibility_problem{model, 0., this->constraint_violation_coefficient};

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -47,14 +47,17 @@ namespace uno {
       std::unique_ptr<RegularizationStrategy<double>> feasibility_regularization_strategy;
       std::unique_ptr<InequalityHandlingMethod> optimality_inequality_handling_method;
       std::unique_ptr<InequalityHandlingMethod> feasibility_inequality_handling_method;
+      // the class maintains multipliers for the other phase (feasibility multipliers if we are in the optimality phase,
+      // and vice versa). These multipliers and those of the iterate are swapped whenever we switch phases.
+      Multipliers other_phase_multipliers;
       const double linear_feasibility_tolerance;
       const bool switch_to_optimality_requires_linearized_feasibility;
       ProgressMeasures reference_optimality_progress{};
       Vector<double> reference_optimality_primals{};
 
       void solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method, const OptimizationProblem& problem,
-         Iterate& current_iterate, const Multipliers& current_multipliers, Direction& direction, HessianModel& hessian_model,
-         RegularizationStrategy<double>& regularization_strategy, double trust_region_radius, WarmstartInformation& warmstart_information);
+         Iterate& current_iterate, Direction& direction, HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy,
+         double trust_region_radius, WarmstartInformation& warmstart_information);
       void switch_to_optimality_phase(Iterate& current_iterate, GlobalizationStrategy& globalization_strategy, const Model& model,
          Iterate& trial_iterate);
 

--- a/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.cpp
@@ -46,8 +46,7 @@ namespace uno {
       direction.reset();
       DEBUG << "Solving the subproblem\n";
       const OptimizationProblem problem{model};
-      this->solve_subproblem(statistics, problem, current_iterate, current_iterate.multipliers, direction, trust_region_radius,
-         warmstart_information);
+      this->solve_subproblem(statistics, problem, current_iterate, direction, trust_region_radius, warmstart_information);
       warmstart_information.no_changes();
    }
 
@@ -61,10 +60,10 @@ namespace uno {
    }
 
    void UnconstrainedStrategy::solve_subproblem(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,
-         const Multipliers& current_multipliers, Direction& direction, double trust_region_radius, WarmstartInformation& warmstart_information) {
+         Direction& direction, double trust_region_radius, WarmstartInformation& warmstart_information) {
       direction.set_dimensions(problem.number_variables, problem.number_constraints);
-      this->inequality_handling_method->solve(statistics, problem, current_iterate, current_multipliers, direction,
-         *this->hessian_model, *this->regularization_strategy, trust_region_radius, warmstart_information);
+      this->inequality_handling_method->solve(statistics, problem, current_iterate, direction, *this->hessian_model,
+         *this->regularization_strategy, trust_region_radius, warmstart_information);
       direction.norm = norm_inf(view(direction.primals, 0, problem.get_number_original_variables()));
       DEBUG3 << direction << '\n';
    }

--- a/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/UnconstrainedStrategy.hpp
@@ -41,8 +41,7 @@ namespace uno {
       std::unique_ptr<RegularizationStrategy<double>> regularization_strategy;
 
       void solve_subproblem(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,
-         const Multipliers& current_multipliers, Direction& direction, double trust_region_radius,
-         WarmstartInformation& warmstart_information);
+         Direction& direction, double trust_region_radius, WarmstartInformation& warmstart_information);
 
       void evaluate_progress_measures(InequalityHandlingMethod& inequality_handling_method, const OptimizationProblem& problem,
          Iterate& iterate) const override;

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
@@ -202,7 +202,7 @@ namespace uno {
       const bool feasibility_stationarity = (current_iterate.residuals.stationarity <= tolerance);
       const bool primal_feasibility = (current_iterate.primal_feasibility <= tolerance);
       const bool feasibility_complementarity = (current_iterate.residuals.complementarity <= tolerance);
-      const bool no_trivial_duals = current_iterate.feasibility_multipliers.not_all_zero(this->model.number_variables, tolerance);
+      const bool no_trivial_duals = current_iterate.multipliers.not_all_zero(this->model.number_variables, tolerance);
 
       DEBUG << "Termination criteria for tolerance = " << tolerance << ":\n";
       DEBUG << "Primal feasibility: " << std::boolalpha << primal_feasibility << '\n';

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
@@ -204,7 +204,7 @@ namespace uno {
       const bool feasibility_complementarity = (current_iterate.residuals.complementarity <= tolerance);
       const bool no_trivial_duals = current_iterate.feasibility_multipliers.not_all_zero(this->model.number_variables, tolerance);
 
-      DEBUG << "\nTermination criteria for tolerance = " << tolerance << ":\n";
+      DEBUG << "Termination criteria for tolerance = " << tolerance << ":\n";
       DEBUG << "Primal feasibility: " << std::boolalpha << primal_feasibility << '\n';
       DEBUG << "Feasibility stationarity: " << std::boolalpha << feasibility_stationarity << '\n';
       DEBUG << "Feasibility complementarity: " << std::boolalpha << feasibility_complementarity << '\n';

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
@@ -12,6 +12,10 @@ namespace uno {
    void GlobalizationMechanism::assemble_trial_iterate(const Model& model, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
          double primal_step_length, double dual_step_length) {
       trial_iterate.set_number_variables(current_iterate.primals.size());
+      trial_iterate.multipliers.constraints.resize(current_iterate.multipliers.constraints.size());
+      trial_iterate.multipliers.lower_bounds.resize(current_iterate.multipliers.lower_bounds.size());
+      trial_iterate.multipliers.upper_bounds.resize(current_iterate.multipliers.upper_bounds.size());
+
       // take primal step
       trial_iterate.primals = current_iterate.primals + primal_step_length * direction.primals;
       // project the trial iterate onto the bounds to avoid numerical errors
@@ -20,9 +24,6 @@ namespace uno {
       trial_iterate.multipliers.constraints = current_iterate.multipliers.constraints + dual_step_length * direction.multipliers.constraints;
       trial_iterate.multipliers.lower_bounds = current_iterate.multipliers.lower_bounds + direction.multipliers.lower_bounds;
       trial_iterate.multipliers.upper_bounds = current_iterate.multipliers.upper_bounds + direction.multipliers.upper_bounds;
-      trial_iterate.feasibility_multipliers.constraints = current_iterate.feasibility_multipliers.constraints + dual_step_length * direction.feasibility_multipliers.constraints;
-      trial_iterate.feasibility_multipliers.lower_bounds = current_iterate.feasibility_multipliers.lower_bounds + direction.feasibility_multipliers.lower_bounds;
-      trial_iterate.feasibility_multipliers.upper_bounds = current_iterate.feasibility_multipliers.upper_bounds + direction.feasibility_multipliers.upper_bounds;
       trial_iterate.progress.reset();
       trial_iterate.is_objective_computed = false;
       trial_iterate.is_objective_gradient_computed = false;

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -119,12 +119,10 @@ namespace uno {
          if (std::abs(direction.primals[variable_index] + this->radius) <= this->activity_tolerance &&
                this->activity_tolerance < std::abs(trial_iterate.primals[variable_index] - model.variable_lower_bound(variable_index))) {
             trial_iterate.multipliers.lower_bounds[variable_index] = 0.;
-            trial_iterate.feasibility_multipliers.lower_bounds[variable_index] = 0.;
          }
          if (std::abs(direction.primals[variable_index] - this->radius) <= this->activity_tolerance &&
                this->activity_tolerance < std::abs(model.variable_upper_bound(variable_index) - trial_iterate.primals[variable_index])) {
             trial_iterate.multipliers.upper_bounds[variable_index] = 0.;
-            trial_iterate.feasibility_multipliers.upper_bounds[variable_index] = 0.;
          }
       }
    }

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -34,9 +34,8 @@ namespace uno {
       virtual void initialize_statistics(Statistics& statistics, const Options& options) = 0;
       virtual void generate_initial_iterate(const OptimizationProblem& problem, Iterate& initial_iterate) = 0;
       virtual void solve(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,
-         const Multipliers& current_multipliers, Direction& direction, HessianModel& hessian_model,
-         RegularizationStrategy<double>& regularization_strategy, double trust_region_radius,
-         WarmstartInformation& warmstart_information) = 0;
+         Direction& direction, HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy,
+         double trust_region_radius, WarmstartInformation& warmstart_information) = 0;
 
       virtual void initialize_feasibility_problem(const l1RelaxedProblem& problem, Iterate& current_iterate) = 0;
       virtual void exit_feasibility_problem(const OptimizationProblem& problem, Iterate& trial_iterate) = 0;

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
@@ -52,13 +52,12 @@ namespace uno {
    }
 
    void InequalityConstrainedMethod::solve(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,
-         const Multipliers& current_multipliers, Direction& direction, HessianModel& hessian_model,
-         RegularizationStrategy<double>& regularization_strategy, double trust_region_radius, WarmstartInformation& warmstart_information) {
+         Direction& direction, HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy,
+         double trust_region_radius, WarmstartInformation& warmstart_information) {
       // create the subproblem and solve it
-      Subproblem subproblem{problem, current_iterate, current_multipliers, hessian_model, regularization_strategy,
-         trust_region_radius};
+      Subproblem subproblem{problem, current_iterate, hessian_model, regularization_strategy, trust_region_radius};
       this->solver->solve(statistics, subproblem, this->initial_point, direction, warmstart_information);
-      InequalityConstrainedMethod::compute_dual_displacements(current_multipliers, direction.multipliers);
+      InequalityConstrainedMethod::compute_dual_displacements(current_iterate.multipliers, direction.multipliers);
       this->number_subproblems_solved++;
       // reset the initial point
       this->initial_point.fill(0.);
@@ -75,8 +74,8 @@ namespace uno {
    void InequalityConstrainedMethod::set_elastic_variable_values(const l1RelaxedProblem& problem, Iterate& current_iterate) {
       problem.set_elastic_variable_values(current_iterate, [&](Iterate& iterate, size_t /*j*/, size_t elastic_index, double /*jacobian_coefficient*/) {
          iterate.primals[elastic_index] = 0.;
-         iterate.feasibility_multipliers.lower_bounds[elastic_index] = 1.;
-         iterate.feasibility_multipliers.upper_bounds[elastic_index] = 0.;
+         iterate.multipliers.lower_bounds[elastic_index] = 1.;
+         iterate.multipliers.upper_bounds[elastic_index] = 0.;
       });
    }
 

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.hpp
@@ -20,9 +20,8 @@ namespace uno {
       void initialize_statistics(Statistics& statistics, const Options& options) override;
       void generate_initial_iterate(const OptimizationProblem& problem, Iterate& initial_iterate) override;
       void solve(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,
-         const Multipliers& current_multipliers, Direction& direction, HessianModel& hessian_model,
-         RegularizationStrategy<double>& regularization_strategy, double trust_region_radius,
-         WarmstartInformation& warmstart_information) override;
+         Direction& direction, HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy,
+         double trust_region_radius, WarmstartInformation& warmstart_information) override;
 
       void initialize_feasibility_problem(const l1RelaxedProblem& problem, Iterate& current_iterate) override;
       void exit_feasibility_problem(const OptimizationProblem& problem, Iterate& trial_iterate) override;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/BarrierParameterUpdateStrategy.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/BarrierParameterUpdateStrategy.cpp
@@ -31,7 +31,7 @@ namespace uno {
    }
 
    bool BarrierParameterUpdateStrategy::update_barrier_parameter(const PrimalDualInteriorPointProblem& barrier_problem,
-         const Iterate& current_iterate, const Multipliers& current_multipliers, const DualResiduals& residuals) {
+         const Iterate& current_iterate, const DualResiduals& residuals) {
       // primal-dual errors
       const double scaled_stationarity = residuals.stationarity / residuals.stationarity_scaling;
       const double primal_feasibility = (barrier_problem.get_objective_multiplier() == 0.) ? 0. : current_iterate.primal_feasibility;
@@ -51,7 +51,7 @@ namespace uno {
          DEBUG << "Barrier parameter mu updated to " << this->barrier_parameter << '\n';
          // update complementarity error
          double scaled_complementarity_error = barrier_problem.compute_centrality_error(current_iterate.primals,
-            current_multipliers, this->barrier_parameter) / residuals.complementarity_scaling;
+            current_iterate.multipliers, this->barrier_parameter) / residuals.complementarity_scaling;
          primal_dual_error = std::max({
             scaled_stationarity,
             primal_feasibility,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/BarrierParameterUpdateStrategy.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/BarrierParameterUpdateStrategy.hpp
@@ -9,11 +9,8 @@ namespace uno {
    class DualResiduals;
    class Iterate;
    class Multipliers;
-   class OptimizationProblem;
    class Options;
    class PrimalDualInteriorPointProblem;
-   template <typename ElementType>
-   class Vector;
 
    struct UpdateParameters {
       double k_mu;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/BarrierParameterUpdateStrategy.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/BarrierParameterUpdateStrategy.hpp
@@ -25,7 +25,7 @@ namespace uno {
       [[nodiscard]] double get_barrier_parameter() const;
       void set_barrier_parameter(double new_barrier_parameter);
       [[nodiscard]] bool update_barrier_parameter(const PrimalDualInteriorPointProblem& barrier_problem,
-         const Iterate& current_iterate, const Multipliers& current_multipliers, const DualResiduals& residuals);
+         const Iterate& current_iterate, const DualResiduals& residuals);
 
    protected:
       double barrier_parameter;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.hpp
@@ -30,9 +30,9 @@ namespace uno {
       void set_elastic_variable_values(const l1RelaxedProblem& problem, Iterate& constraint_index) override;
       [[nodiscard]] double proximal_coefficient() const override;
 
-      void solve(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate,  const Multipliers& current_multipliers,
-         Direction& direction, HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy,
-         double trust_region_radius, WarmstartInformation& warmstart_information) override;
+      void solve(Statistics& statistics, const OptimizationProblem& problem, Iterate& current_iterate, Direction& direction,
+         HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius,
+         WarmstartInformation& warmstart_information) override;
       [[nodiscard]] double hessian_quadratic_product(const Vector<double>& vector) const override;
 
       void set_auxiliary_measure(const OptimizationProblem& problem, Iterate& iterate) override;
@@ -57,7 +57,7 @@ namespace uno {
 
       [[nodiscard]] double barrier_parameter() const;
       void update_barrier_parameter(const PrimalDualInteriorPointProblem& barrier_problem, const Iterate& current_iterate,
-         const Multipliers& current_multipliers, const DualResiduals& residuals);
+         const DualResiduals& residuals);
       [[nodiscard]] bool is_small_step(const OptimizationProblem& problem, const Vector<double>& current_primals, const Vector<double>& direction_primals) const;
       [[nodiscard]] double evaluate_subproblem_objective(const Direction& direction) const;
    };

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
@@ -42,8 +42,7 @@ namespace uno {
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;
       [[nodiscard]] size_t number_hessian_nonzeros(const HessianModel& hessian_model) const override;
 
-      void assemble_primal_dual_direction(const Iterate& current_iterate, const Multipliers& current_multipliers,
-         const Vector<double>& solution, Direction& direction) const override;
+      void assemble_primal_dual_direction(const Iterate& current_iterate, const Vector<double>& solution, Direction& direction) const override;
 
       [[nodiscard]] double push_variable_to_interior(double variable_value, double lower_bound, double upper_bound) const;
       void set_auxiliary_measure(Iterate& iterate) const;
@@ -64,8 +63,7 @@ namespace uno {
       const ForwardRange equality_constraints;
       const ForwardRange inequality_constraints{0};
 
-      void compute_bound_dual_direction(const Vector<double>& current_primals, const Multipliers& current_multipliers,
-         const Vector<double>& primal_direction, Multipliers& direction_multipliers) const;
+      void compute_bound_dual_direction(const Iterate& current_iterate, Direction& direction) const;
       [[nodiscard]] double primal_fraction_to_boundary(const Vector<double>& current_primals, const Vector<double>& primal_direction,
          double tau) const;
       [[nodiscard]] double dual_fraction_to_boundary(const Multipliers& current_multipliers, const Multipliers& direction_multipliers,

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
 #include "Subproblem.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
 #include "ingredients/regularization_strategies/RegularizationStrategy.hpp"

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -13,10 +13,10 @@
 #include "tools/Logger.hpp"
 
 namespace uno {
-   Subproblem::Subproblem(const OptimizationProblem& problem, Iterate& current_iterate, const Multipliers& current_multipliers,
-      HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius):
+   Subproblem::Subproblem(const OptimizationProblem& problem, Iterate& current_iterate, HessianModel& hessian_model,
+      RegularizationStrategy<double>& regularization_strategy, double trust_region_radius):
          number_variables(problem.number_variables), number_constraints(problem.number_constraints),
-         problem(problem), current_iterate(current_iterate), current_multipliers(current_multipliers), hessian_model(hessian_model),
+         problem(problem), current_iterate(current_iterate), hessian_model(hessian_model),
          regularization_strategy(regularization_strategy), trust_region_radius(trust_region_radius) {
    }
 
@@ -35,7 +35,7 @@ namespace uno {
    void Subproblem::compute_regularized_hessian(Statistics& statistics, SymmetricMatrix<size_t, double>& hessian) const {
       // evaluate the Lagrangian Hessian of the problem at the current primal-dual point
       this->problem.evaluate_lagrangian_hessian(statistics, this->hessian_model, this->current_iterate.primals,
-         this->current_multipliers, hessian);
+         this->current_iterate.multipliers, hessian);
       // regularize the Hessian only if necessary
       if (!this->hessian_model.is_positive_definite() && this->regularization_strategy.performs_primal_regularization()) {
          const Inertia expected_inertia{this->problem.get_number_original_variables(), 0,
@@ -47,7 +47,7 @@ namespace uno {
 
    void Subproblem::compute_hessian_vector_product(const double* vector, double* result) const {
       // unregularized Hessian-vector product
-      this->problem.compute_hessian_vector_product(this->hessian_model, vector, this->current_multipliers, result);
+      this->problem.compute_hessian_vector_product(this->hessian_model, vector, this->current_iterate.multipliers, result);
       // contribution of the regularization strategy
       const double regularization_factor = this->regularization_strategy.get_primal_regularization_factor();
       if (0. < regularization_factor) {
@@ -61,7 +61,7 @@ namespace uno {
          RectangularMatrix<double>& constraint_jacobian) const {
       // evaluate the Lagrangian Hessian of the problem at the current primal-dual point
       this->problem.evaluate_lagrangian_hessian(statistics, this->hessian_model, this->current_iterate.primals,
-         this->current_multipliers, augmented_matrix);
+         this->current_iterate.multipliers, augmented_matrix);
 
       // Jacobian of general constraints
       for (size_t column_index: Range(this->problem.number_constraints)) {
@@ -90,9 +90,9 @@ namespace uno {
       // constraint: evaluations and gradients
       for (size_t constraint_index: Range(this->number_constraints)) {
          // Lagrangian
-         if (this->current_multipliers.constraints[constraint_index] != 0.) {
+         if (this->current_iterate.multipliers.constraints[constraint_index] != 0.) {
             for (const auto [variable_index, derivative]: constraint_jacobian[constraint_index]) {
-               rhs[variable_index] += this->current_multipliers.constraints[constraint_index] * derivative;
+               rhs[variable_index] += this->current_iterate.multipliers.constraints[constraint_index] * derivative;
             }
          }
          // constraints
@@ -102,7 +102,7 @@ namespace uno {
    }
 
    void Subproblem::assemble_primal_dual_direction(const Vector<double>& solution, Direction& direction) const {
-      this->problem.assemble_primal_dual_direction(this->current_iterate, this->current_multipliers, solution, direction);
+      this->problem.assemble_primal_dual_direction(this->current_iterate, solution, direction);
    }
 
    void Subproblem::set_variables_bounds(std::vector<double>& variables_lower_bounds, std::vector<double>& variables_upper_bounds) const {

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -18,8 +18,6 @@ namespace uno {
    class RectangularMatrix;
    template <typename ElementType>
    class RegularizationStrategy;
-   template <typename ElementType>
-   class SparseVector;
    class Statistics;
    template <typename IndexType, typename ElementType>
    class SymmetricMatrix;

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -13,7 +13,6 @@ namespace uno {
    class DirectSymmetricIndefiniteLinearSolver;
    class HessianModel;
    class Iterate;
-   class Multipliers;
    template <typename ElementType>
    class RectangularMatrix;
    template <typename ElementType>
@@ -28,8 +27,8 @@ namespace uno {
    public:
       const size_t number_variables, number_constraints;
 
-      Subproblem(const OptimizationProblem& problem, Iterate& current_iterate, const Multipliers& current_multipliers,
-         HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius);
+      Subproblem(const OptimizationProblem& problem, Iterate& current_iterate, HessianModel& hessian_model,
+         RegularizationStrategy<double>& regularization_strategy, double trust_region_radius);
 
       // constraints, objective gradient and Jacobian
       void evaluate_objective_gradient(Vector<double>& linear_objective) const;
@@ -65,7 +64,6 @@ namespace uno {
    protected:
       const OptimizationProblem& problem;
       Iterate& current_iterate;
-      const Multipliers& current_multipliers;
       HessianModel& hessian_model;
       RegularizationStrategy<double>& regularization_strategy;
       const double trust_region_radius;

--- a/uno/optimization/Direction.cpp
+++ b/uno/optimization/Direction.cpp
@@ -8,9 +8,7 @@
 namespace uno {
    Direction::Direction(size_t number_variables, size_t number_constraints) :
          number_variables(number_variables), number_constraints(number_constraints),
-         primals(number_variables), multipliers(number_variables, number_constraints)
-         //feasibility_multipliers(number_variables, number_constraints)
-         {
+         primals(number_variables), multipliers(number_variables, number_constraints) {
    }
 
    void Direction::set_dimensions(size_t new_number_variables, size_t new_number_constraints) {
@@ -21,7 +19,6 @@ namespace uno {
    void Direction::reset() {
       this->primals.fill(0.);
       this->multipliers.reset();
-      //this->feasibility_multipliers.reset();
    }
 
    std::string status_to_string(SubproblemStatus status) {
@@ -40,16 +37,10 @@ namespace uno {
    std::ostream& operator<<(std::ostream& stream, const Direction& direction) {
       stream << "Direction:\n";
       stream << "│ status: " << status_to_string(direction.status) << '\n';
-
       stream << "│ primals = "; print_vector(stream, view(direction.primals, 0, direction.number_variables));
       stream << "│ constraint multipliers = "; print_vector(stream, direction.multipliers.constraints);
       stream << "│ lower bound multipliers = "; print_vector(stream, direction.multipliers.lower_bounds);
       stream << "│ upper bound multipliers = "; print_vector(stream, direction.multipliers.upper_bounds);
-      /*
-      stream << "│ feasibility constraint multipliers = "; print_vector(stream, direction.feasibility_multipliers.constraints);
-      stream << "│ feasibility lower bound multipliers = "; print_vector(stream, direction.feasibility_multipliers.lower_bounds);
-      stream << "│ feasibility upper bound multipliers = "; print_vector(stream, direction.feasibility_multipliers.upper_bounds);
-*/
       stream << "│ objective = " << direction.subproblem_objective << '\n';
       stream << "│ norm = " << direction.norm << '\n';
       return stream;

--- a/uno/optimization/Direction.cpp
+++ b/uno/optimization/Direction.cpp
@@ -8,8 +8,9 @@
 namespace uno {
    Direction::Direction(size_t number_variables, size_t number_constraints) :
          number_variables(number_variables), number_constraints(number_constraints),
-         primals(number_variables), multipliers(number_variables, number_constraints),
-         feasibility_multipliers(number_variables, number_constraints)  {
+         primals(number_variables), multipliers(number_variables, number_constraints)
+         //feasibility_multipliers(number_variables, number_constraints)
+         {
    }
 
    void Direction::set_dimensions(size_t new_number_variables, size_t new_number_constraints) {
@@ -20,7 +21,7 @@ namespace uno {
    void Direction::reset() {
       this->primals.fill(0.);
       this->multipliers.reset();
-      this->feasibility_multipliers.reset();
+      //this->feasibility_multipliers.reset();
    }
 
    std::string status_to_string(SubproblemStatus status) {
@@ -40,21 +41,15 @@ namespace uno {
       stream << "Direction:\n";
       stream << "│ status: " << status_to_string(direction.status) << '\n';
 
-      stream << "│ primals = ";
-      print_vector(stream, view(direction.primals, 0, direction.number_variables));
-      stream << "│ constraint multipliers = ";
-      print_vector(stream, direction.multipliers.constraints);
-      stream << "│ lower bound multipliers = ";
-      print_vector(stream, direction.multipliers.lower_bounds);
-      stream << "│ upper bound multipliers = ";
-      print_vector(stream, direction.multipliers.upper_bounds);
-      stream << "│ feasibility constraint multipliers = ";
-      print_vector(stream, direction.feasibility_multipliers.constraints);
-      stream << "│ feasibility lower bound multipliers = ";
-      print_vector(stream, direction.feasibility_multipliers.lower_bounds);
-      stream << "│ feasibility upper bound multipliers = ";
-      print_vector(stream, direction.feasibility_multipliers.upper_bounds);
-
+      stream << "│ primals = "; print_vector(stream, view(direction.primals, 0, direction.number_variables));
+      stream << "│ constraint multipliers = "; print_vector(stream, direction.multipliers.constraints);
+      stream << "│ lower bound multipliers = "; print_vector(stream, direction.multipliers.lower_bounds);
+      stream << "│ upper bound multipliers = "; print_vector(stream, direction.multipliers.upper_bounds);
+      /*
+      stream << "│ feasibility constraint multipliers = "; print_vector(stream, direction.feasibility_multipliers.constraints);
+      stream << "│ feasibility lower bound multipliers = "; print_vector(stream, direction.feasibility_multipliers.lower_bounds);
+      stream << "│ feasibility upper bound multipliers = "; print_vector(stream, direction.feasibility_multipliers.upper_bounds);
+*/
       stream << "│ objective = " << direction.subproblem_objective << '\n';
       stream << "│ norm = " << direction.norm << '\n';
       return stream;

--- a/uno/optimization/Direction.hpp
+++ b/uno/optimization/Direction.hpp
@@ -20,7 +20,6 @@ namespace uno {
 
       Vector<double> primals{}; /*!< Primal variables */
       Multipliers multipliers{}; /*!< Multipliers */
-      Multipliers feasibility_multipliers{}; /*!< Multipliers */
 
       SubproblemStatus status{SubproblemStatus::OPTIMAL}; /*!< Status of the solution */
 

--- a/uno/optimization/Iterate.cpp
+++ b/uno/optimization/Iterate.cpp
@@ -16,7 +16,7 @@ namespace uno {
 
    Iterate::Iterate(size_t number_variables, size_t number_constraints) :
          number_variables(number_variables), number_constraints(number_constraints),
-         primals(number_variables), multipliers(number_variables, number_constraints), //feasibility_multipliers(number_variables, number_constraints),
+         primals(number_variables), multipliers(number_variables, number_constraints),
          evaluations(number_variables, number_constraints), residuals(number_variables) {
    }
 

--- a/uno/optimization/Iterate.cpp
+++ b/uno/optimization/Iterate.cpp
@@ -16,7 +16,7 @@ namespace uno {
 
    Iterate::Iterate(size_t number_variables, size_t number_constraints) :
          number_variables(number_variables), number_constraints(number_constraints),
-         primals(number_variables), multipliers(number_variables, number_constraints), feasibility_multipliers(number_variables, number_constraints),
+         primals(number_variables), multipliers(number_variables, number_constraints), //feasibility_multipliers(number_variables, number_constraints),
          evaluations(number_variables, number_constraints), residuals(number_variables) {
    }
 
@@ -73,8 +73,6 @@ namespace uno {
    void Iterate::set_number_variables(size_t new_number_variables) {
       this->number_variables = new_number_variables;
       this->primals.resize(new_number_variables);
-      this->multipliers.lower_bounds.resize(new_number_variables);
-      this->multipliers.upper_bounds.resize(new_number_variables);
       this->evaluations.objective_gradient.reserve(new_number_variables);
       this->residuals.lagrangian_gradient.resize(new_number_variables);
    }
@@ -84,9 +82,6 @@ namespace uno {
       stream << "            ┌ Constraint: " << iterate.multipliers.constraints << '\n';
       stream << "Multipliers │ Lower bound: " << iterate.multipliers.lower_bounds << '\n';
       stream << "            └ Upper bound: " << iterate.multipliers.upper_bounds << '\n';
-      stream << "                        ┌ Constraint: " << iterate.feasibility_multipliers.constraints << '\n';
-      stream << "Feasibility multipliers │ Lower bound: " << iterate.feasibility_multipliers.lower_bounds << '\n';
-      stream << "                        └ Upper bound: " << iterate.feasibility_multipliers.upper_bounds << '\n';
       stream << "Objective value: " << iterate.evaluations.objective << '\n';
       stream << "Primal feasibility: " << iterate.primal_feasibility << '\n';
 

--- a/uno/optimization/Iterate.hpp
+++ b/uno/optimization/Iterate.hpp
@@ -25,7 +25,6 @@ namespace uno {
       size_t number_constraints;
       Vector<double> primals;
       Multipliers multipliers; /*!< \f$\mathbb{R}^n\f$ Lagrange multipliers/dual variables */
-      Multipliers feasibility_multipliers; /*!< \f$\mathbb{R}^n\f$ Lagrange multipliers/dual variables */
       double objective_multiplier{1.};
 
       // evaluations

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -138,8 +138,8 @@ namespace uno {
       return hessian_model.number_nonzeros(this->model);
    }
 
-   void OptimizationProblem::assemble_primal_dual_direction(const Iterate& /*current_iterate*/, const Multipliers& /*current_multipliers*/,
-         const Vector<double>& /*solution*/, Direction& /*direction*/) const {
+   void OptimizationProblem::assemble_primal_dual_direction(const Iterate& /*current_iterate*/, const Vector<double>& /*solution*/,
+         Direction& /*direction*/) const {
       // do nothing
    }
 

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -196,7 +196,7 @@ namespace uno {
       const bool primal_feasibility = (current_iterate.primal_feasibility <= tolerance);
       const bool complementarity = (current_iterate.residuals.complementarity / current_iterate.residuals.complementarity_scaling <= tolerance);
 
-      DEBUG << "\nTermination criteria for tolerance = " << tolerance << ":\n";
+      DEBUG << "Termination criteria for tolerance = " << tolerance << ":\n";
       DEBUG << "Stationarity: " << std::boolalpha << stationarity << '\n';
       DEBUG << "Primal feasibility: " << std::boolalpha << primal_feasibility << '\n';
       DEBUG << "Complementarity: " << std::boolalpha << complementarity << '\n';

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -67,8 +67,7 @@ namespace uno {
       [[nodiscard]] virtual size_t number_jacobian_nonzeros() const;
       [[nodiscard]] virtual size_t number_hessian_nonzeros(const HessianModel& hessian_model) const;
 
-      virtual void assemble_primal_dual_direction(const Iterate& current_iterate, const Multipliers& current_multipliers,
-         const Vector<double>& solution, Direction& direction) const;
+      virtual void assemble_primal_dual_direction(const Iterate& current_iterate, const Vector<double>& solution, Direction& direction) const;
       [[nodiscard]] virtual double dual_regularization_factor() const;
 
       [[nodiscard]] static double stationarity_error(const LagrangianGradient<double>& lagrangian_gradient, double objective_multiplier,

--- a/uno/optimization/Result.cpp
+++ b/uno/optimization/Result.cpp
@@ -29,11 +29,6 @@ namespace uno {
                this->number_variables));
          DISCRETE << "└ Upper bound multipliers:\t\t"; print_vector(DISCRETE, view(this->solution.multipliers.upper_bounds, 0,
                this->number_variables));
-         DISCRETE << "┌ Constraint feasibility multipliers:\t"; print_vector(DISCRETE, this->solution.feasibility_multipliers.constraints);
-         DISCRETE << "│ Lower bound feasibility multipliers:\t"; print_vector(DISCRETE, view(this->solution.feasibility_multipliers.lower_bounds, 0,
-               this->number_variables));
-         DISCRETE << "└ Upper bound feasibility multipliers:\t"; print_vector(DISCRETE, view(this->solution.feasibility_multipliers.upper_bounds, 0,
-               this->number_variables));
          DISCRETE << "Objective multiplier:\t\t\t" << this->solution.objective_multiplier << '\n';
       }
 


### PR DESCRIPTION
Got rid of `feasibility_multipliers` in `Iterate` and `Direction`, and have the `FeasibilityRestoration` class maintain a second set of multipliers (called `other_phase_multipliers`) that are swapped whenever we switch phases.