### PR TITLE
Fix bad argv access with omitted -AMPL flag

### DIFF
--- a/bindings/AMPL/uno_ampl.cpp
+++ b/bindings/AMPL/uno_ampl.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]) {
          options.overwrite_with(solvers_options);
          // the -AMPL flag indicates that the solution should be written to the AMPL solution file
          size_t offset = 2;
-         if (std::string(argv[2]) == "-AMPL") {
+         if (argc > 2 && std::string(argv[2]) == "-AMPL") {
             options["AMPL_write_solution_to_file"] = "yes";
             ++offset;
          }


### PR DESCRIPTION
Seems to have been missed in b5a79a4ca. Got me the cryptic exception message "basic_string::_M_construct null not valid" when trying to run it without the `-AMPL` flag (I suppose `argv[2]` happens to be `nullptr` if `argc <= 2`).