### PR TITLE
Determine the presence of curvature in the subproblem

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
@@ -280,6 +280,11 @@ namespace uno {
       return this->model.number_jacobian_nonzeros() + this->number_elastic_variables;
    }
 
+   bool l1RelaxedProblem::has_curvature(const HessianModel& hessian_model) const {
+      // the l1 relaxation does not introduce curvature
+      return hessian_model.has_curvature(this->model);
+   }
+
    size_t l1RelaxedProblem::number_hessian_nonzeros(const HessianModel& hessian_model) const {
       size_t number_nonzeros = hessian_model.number_nonzeros(this->model);
       // proximal contribution

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
@@ -44,6 +44,7 @@ namespace uno {
       [[nodiscard]] const Collection<size_t>& get_dual_regularization_constraints() const override;
 
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;
+      [[nodiscard]] bool has_curvature(const HessianModel& hessian_model) const override;
       [[nodiscard]] size_t number_hessian_nonzeros(const HessianModel& hessian_model) const override;
 
       [[nodiscard]] IterateStatus check_first_order_convergence(const Iterate& current_iterate, double tolerance) const;

--- a/uno/ingredients/hessian_models/ExactHessian.cpp
+++ b/uno/ingredients/hessian_models/ExactHessian.cpp
@@ -17,7 +17,8 @@ namespace uno {
       return true;
    }
 
-   void ExactHessian::initialize(const Model& /*model*/) {
+   bool ExactHessian::has_curvature(const Model& model) const {
+      return (0 < model.number_hessian_nonzeros());
    }
 
    size_t ExactHessian::number_nonzeros(const Model& model) const {
@@ -26,6 +27,9 @@ namespace uno {
 
    bool ExactHessian::is_positive_definite() const {
       return false;
+   }
+
+   void ExactHessian::initialize(const Model& /*model*/) {
    }
 
    void ExactHessian::evaluate_hessian(Statistics& /*statistics*/, const Model& model, const Vector<double>& primal_variables,

--- a/uno/ingredients/hessian_models/ExactHessian.hpp
+++ b/uno/ingredients/hessian_models/ExactHessian.hpp
@@ -11,10 +11,11 @@ namespace uno {
 
       [[nodiscard]] bool has_implicit_representation() const override;
       [[nodiscard]] bool has_explicit_representation() const override;
-
-      void initialize(const Model& model) override;
+      [[nodiscard]] bool has_curvature(const Model& model) const override;
       [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
       [[nodiscard]] bool is_positive_definite() const override;
+
+      void initialize(const Model& model) override;
       void evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables, double objective_multiplier,
          const Vector<double>& constraint_multipliers, SymmetricMatrix<size_t, double>& hessian) override;
       void compute_hessian_vector_product(const Model& model, const double* vector, double objective_multiplier,

--- a/uno/ingredients/hessian_models/HessianModel.hpp
+++ b/uno/ingredients/hessian_models/HessianModel.hpp
@@ -25,10 +25,11 @@ namespace uno {
 
       [[nodiscard]] virtual bool has_implicit_representation() const = 0;
       [[nodiscard]] virtual bool has_explicit_representation() const = 0;
-
-      virtual void initialize(const Model& model) = 0;
+      [[nodiscard]] virtual bool has_curvature(const Model& model) const = 0;
       [[nodiscard]] virtual size_t number_nonzeros(const Model& model) const = 0;
       [[nodiscard]] virtual bool is_positive_definite() const = 0;
+
+      virtual void initialize(const Model& model) = 0;
       virtual void evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables,
          double objective_multiplier, const Vector<double>& constraint_multipliers, SymmetricMatrix<size_t, double>& hessian) = 0;
       virtual void compute_hessian_vector_product(const Model& model, const double* vector, double objective_multiplier,

--- a/uno/ingredients/hessian_models/IdentityHessian.cpp
+++ b/uno/ingredients/hessian_models/IdentityHessian.cpp
@@ -16,8 +16,8 @@ namespace uno {
       return true;
    }
 
-   void IdentityHessian::initialize(const Model& /*model*/) {
-      // do nothing
+   bool IdentityHessian::has_curvature(const Model& /*model*/) const {
+      return true;
    }
 
    size_t IdentityHessian::number_nonzeros(const Model& model) const {
@@ -26,6 +26,10 @@ namespace uno {
 
    bool IdentityHessian::is_positive_definite() const {
       return true;
+   }
+
+   void IdentityHessian::initialize(const Model& /*model*/) {
+      // do nothing
    }
 
    void IdentityHessian::evaluate_hessian(Statistics& /*statistics*/, const Model& model, const Vector<double>& /*primal_variables*/,

--- a/uno/ingredients/hessian_models/IdentityHessian.hpp
+++ b/uno/ingredients/hessian_models/IdentityHessian.hpp
@@ -13,10 +13,11 @@ namespace uno {
 
       [[nodiscard]] bool has_implicit_representation() const override;
       [[nodiscard]] bool has_explicit_representation() const override;
-
-      void initialize(const Model& model) override;
+      [[nodiscard]] bool has_curvature(const Model& model) const override;
       [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
       [[nodiscard]] bool is_positive_definite() const override;
+
+      void initialize(const Model& model) override;
       void evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables,
          double objective_multiplier, const Vector<double>& constraint_multipliers, SymmetricMatrix<size_t, double>& hessian) override;
       void compute_hessian_vector_product(const Model& model, const double* vector, double objective_multiplier,

--- a/uno/ingredients/hessian_models/ZeroHessian.cpp
+++ b/uno/ingredients/hessian_models/ZeroHessian.cpp
@@ -15,7 +15,8 @@ namespace uno {
       return true;
    }
 
-   void ZeroHessian::initialize(const Model& /*model*/) {
+   bool ZeroHessian::has_curvature(const Model& /*model*/) const {
+      return false;
    }
 
    size_t ZeroHessian::number_nonzeros(const Model& /*model*/) const {
@@ -24,6 +25,9 @@ namespace uno {
 
    bool ZeroHessian::is_positive_definite() const {
       return false;
+   }
+
+   void ZeroHessian::initialize(const Model& /*model*/) {
    }
 
    void ZeroHessian::evaluate_hessian(Statistics& /*statistics*/, const Model& model, const Vector<double>& /*primal_variables*/,

--- a/uno/ingredients/hessian_models/ZeroHessian.hpp
+++ b/uno/ingredients/hessian_models/ZeroHessian.hpp
@@ -13,10 +13,11 @@ namespace uno {
 
       [[nodiscard]] bool has_implicit_representation() const override;
       [[nodiscard]] bool has_explicit_representation() const override;
-
-      void initialize(const Model& model) override;
+      [[nodiscard]] bool has_curvature(const Model& model) const override;
       [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
       [[nodiscard]] bool is_positive_definite() const override;
+
+      void initialize(const Model& model) override;
       void evaluate_hessian(Statistics& statistics, const Model& model, const Vector<double>& primal_variables, double objective_multiplier,
          const Vector<double>& constraint_multipliers, SymmetricMatrix<size_t, double>& hessian) override;
       void compute_hessian_vector_product(const Model& model, const double* vector, double objective_multiplier,

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
@@ -24,11 +24,16 @@ namespace uno {
       regularization_strategy.initialize_memory(problem, hessian_model);
 
       // allocate the LP/QP solver, depending on the presence of curvature in the subproblem
-      const size_t number_hessian_nonzeros = problem.number_hessian_nonzeros(hessian_model);
-      const size_t regularization_size = (!hessian_model.is_positive_definite() &&
-         regularization_strategy.performs_primal_regularization()) ? problem.get_number_original_variables() : 0;
-      const size_t number_regularized_hessian_nonzeros = number_hessian_nonzeros + regularization_size;
-      if (number_regularized_hessian_nonzeros == 0) {
+      bool subproblem_has_curvature = problem.has_curvature(hessian_model);
+      if (!subproblem_has_curvature) {
+         if (!hessian_model.is_positive_definite() && regularization_strategy.performs_primal_regularization()) {
+            subproblem_has_curvature = !problem.get_primal_regularization_variables().empty();
+         }
+         else {
+            subproblem_has_curvature = false;
+         }
+      }
+      if (!subproblem_has_curvature) {
          DEBUG << "No curvature in the subproblems, allocating an LP solver\n";
          this->solver = LPSolverFactory::create(this->options);
       }

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include "PrimalDualInteriorPointProblem.hpp"
+
+#include "ingredients/hessian_models/HessianModel.hpp"
 #include "linear_algebra/SymmetricMatrix.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Iterate.hpp"
@@ -157,6 +159,21 @@ namespace uno {
 
    size_t PrimalDualInteriorPointProblem::number_jacobian_nonzeros() const {
       return this->first_reformulation.number_jacobian_nonzeros();
+   }
+
+   bool PrimalDualInteriorPointProblem::has_curvature(const HessianModel& hessian_model) const {
+      if (hessian_model.has_curvature(this->model)) {
+         return true;
+      }
+      else {
+         // barrier terms
+         for (size_t variable_index: Range(this->first_reformulation.number_variables)) {
+            if (is_finite(this->first_reformulation.variable_lower_bound(variable_index)) || is_finite(this->first_reformulation.variable_upper_bound(variable_index))) {
+               return true;
+            }
+         }
+         return false;
+      }
    }
 
    size_t PrimalDualInteriorPointProblem::number_hessian_nonzeros(const HessianModel& hessian_model) const {

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
@@ -40,6 +40,7 @@ namespace uno {
       [[nodiscard]] const Collection<size_t>& get_dual_regularization_constraints() const override;
 
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;
+      [[nodiscard]] bool has_curvature(const HessianModel& hessian_model) const override;
       [[nodiscard]] size_t number_hessian_nonzeros(const HessianModel& hessian_model) const override;
 
       void assemble_primal_dual_direction(const Iterate& current_iterate, const Vector<double>& solution, Direction& direction) const override;

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -128,6 +128,21 @@ namespace uno {
       return this->hessian_model.has_explicit_representation();
    }
 
+   // two sources of curvature: the problem and the regularization strategy
+   bool Subproblem::has_curvature() const {
+      // the problem may have some curvature
+      if (this->problem.has_curvature(this->hessian_model)) {
+         return true;
+      }
+      else {
+         // otherwise, the regularization strategy may introduce curvature
+         if (!this->hessian_model.is_positive_definite() && this->regularization_strategy.performs_primal_regularization()) {
+            return !this->problem.get_primal_regularization_variables().empty();
+         }
+         return false;
+      }
+   }
+
    double Subproblem::dual_regularization_factor() const {
       return this->problem.dual_regularization_factor();
    }

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -58,6 +58,7 @@ namespace uno {
 
       [[nodiscard]] bool has_implicit_hessian_representation() const;
       [[nodiscard]] bool has_explicit_hessian_representation() const;
+      [[nodiscard]] bool has_curvature() const;
 
       [[nodiscard]] double dual_regularization_factor() const;
 

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -134,6 +134,10 @@ namespace uno {
       return this->model.number_jacobian_nonzeros();
    }
 
+   bool OptimizationProblem::has_curvature(const HessianModel& hessian_model) const {
+      return hessian_model.has_curvature(this->model);
+   }
+
    size_t OptimizationProblem::number_hessian_nonzeros(const HessianModel& hessian_model) const {
       return hessian_model.number_nonzeros(this->model);
    }

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -65,6 +65,7 @@ namespace uno {
       [[nodiscard]] virtual const Collection<size_t>& get_dual_regularization_constraints() const;
 
       [[nodiscard]] virtual size_t number_jacobian_nonzeros() const;
+      [[nodiscard]] virtual bool has_curvature(const HessianModel& hessian_model) const;
       [[nodiscard]] virtual size_t number_hessian_nonzeros(const HessianModel& hessian_model) const;
 
       virtual void assemble_primal_dual_direction(const Iterate& current_iterate, const Vector<double>& solution, Direction& direction) const;


### PR DESCRIPTION
Determine the presence of curvature in models, problems, Hessian models and subproblem. We then compute the number of nonzeros only when curvature is detected.
This is important to avoid evaluating the number of nonzero elements in a quasi-Newton Hessian model (in this case, we only admit an implicit representation, so the number of nonzeros is irrelevant).