### PR TITLE
Do not overwrite debug flags for gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ else()
 endif()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmaybe-uninitialized")
-   set(CMAKE_CXX_FLAGS_DEBUG "-pg")
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_CURRENT_SOURCE_DIR}/cmake-library/finders)


### PR DESCRIPTION
Flag `-pg` generates extra code for profiling with gprof which should probably not be enabled by default in Debug builds. More importantly it should probably not overwrite the CMake default `-g` for `CMAKE_CXX_FLAGS_DEBUG`, as it means that the default Debug builds do not have any debug information, which can be quite surprising.

If `-pg` was indeed intended, it should probably be added to `CMAKE_CXX_FLAGS_DEBUG` instead of overwriting it (ideally through `CMakePresets.json` rather than `CMakeLists.txt`, but that's another topic).