### PR TITLE
Introduce evaluation spaces for subproblem solvers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,9 @@ endif()
 # BQPD
 find_library(BQPD bqpd)
 if(BQPD)
-   list(APPEND UNO_SOURCE_FILES uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp)
+   list(APPEND UNO_SOURCE_FILES
+		uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+		uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp)
    list(APPEND TESTS_UNO_SOURCE_FILES unotest/functional_tests/BQPDSolverTests.cpp)
    link_to_uno(bqpd ${BQPD})
 endif()
@@ -159,7 +161,9 @@ endif()
 # HiGHS
 find_package(HIGHS)
 if(HIGHS_FOUND)
-   list(APPEND UNO_SOURCE_FILES uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp)
+   list(APPEND UNO_SOURCE_FILES
+		uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
+		uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.cpp)
    list(APPEND TESTS_UNO_SOURCE_FILES unotest/functional_tests/HiGHSSolverTests.cpp)
    list(APPEND LIBRARIES highs::highs)
    add_definitions("-D HAS_HIGHS")

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -5,12 +5,12 @@
 #define UNO_INEQUALITYHANDLINGMETHOD_H
 
 #include <string>
-
 #include "optimization/OptimizationProblem.hpp"
 
 namespace uno {
    // forward declarations
    class Direction;
+   class EvaluationSpace;
    class HessianModel;
    class Iterate;
    class l1RelaxedProblem;
@@ -44,6 +44,7 @@ namespace uno {
       [[nodiscard]] virtual double proximal_coefficient() const = 0;
 
       // matrix computations
+      [[nodiscard]] virtual EvaluationSpace& get_evaluation_space() const = 0;
       virtual void evaluate_constraint_jacobian(const OptimizationProblem& problem, Iterate& iterate,
          HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius) = 0;
       virtual void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
@@ -9,6 +9,7 @@
 #include "ingredients/subproblem_solvers/LPSolverFactory.hpp"
 #include "ingredients/subproblem_solvers/QPSolverFactory.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/EvaluationSpace.hpp"
 #include "symbolic/VectorView.hpp"
 #include "tools/Logger.hpp"
 
@@ -74,22 +75,30 @@ namespace uno {
       return 0.;
    }
 
+   EvaluationSpace& InequalityConstrainedMethod::get_evaluation_space() const {
+      return this->solver->get_evaluation_space();
+   }
+
    void InequalityConstrainedMethod::evaluate_constraint_jacobian(const OptimizationProblem& problem, Iterate& iterate,
          HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius) {
       const Subproblem subproblem{problem, iterate, hessian_model, regularization_strategy, trust_region_radius};
-      this->solver->evaluate_constraint_jacobian(subproblem);
+      auto& evaluation_space = this->solver->get_evaluation_space();
+      evaluation_space.evaluate_constraint_jacobian(subproblem);
    }
 
    void InequalityConstrainedMethod::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      this->solver->compute_constraint_jacobian_vector_product(vector, result);
+      auto& evaluation_space = this->solver->get_evaluation_space();
+      evaluation_space.compute_constraint_jacobian_vector_product(vector, result);
    }
 
    void InequalityConstrainedMethod::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      this->solver->compute_constraint_jacobian_transposed_vector_product(vector, result);
+      auto& evaluation_space = this->solver->get_evaluation_space();
+      evaluation_space.compute_constraint_jacobian_transposed_vector_product(vector, result);
    }
 
    double InequalityConstrainedMethod::compute_hessian_quadratic_product(const Vector<double>& vector) const {
-      return this->solver->compute_hessian_quadratic_product(vector);
+      auto& evaluation_space = this->solver->get_evaluation_space();
+      return evaluation_space.compute_hessian_quadratic_product(vector);
    }
 
    // compute dual *displacements*

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.cpp
@@ -87,17 +87,17 @@ namespace uno {
    }
 
    void InequalityConstrainedMethod::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      auto& evaluation_space = this->solver->get_evaluation_space();
+      const auto& evaluation_space = this->solver->get_evaluation_space();
       evaluation_space.compute_constraint_jacobian_vector_product(vector, result);
    }
 
    void InequalityConstrainedMethod::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      auto& evaluation_space = this->solver->get_evaluation_space();
+      const auto& evaluation_space = this->solver->get_evaluation_space();
       evaluation_space.compute_constraint_jacobian_transposed_vector_product(vector, result);
    }
 
    double InequalityConstrainedMethod::compute_hessian_quadratic_product(const Vector<double>& vector) const {
-      auto& evaluation_space = this->solver->get_evaluation_space();
+      const auto& evaluation_space = this->solver->get_evaluation_space();
       return evaluation_space.compute_hessian_quadratic_product(vector);
    }
 

--- a/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/inequality_constrained_methods/InequalityConstrainedMethod.hpp
@@ -29,6 +29,7 @@ namespace uno {
       [[nodiscard]] double proximal_coefficient() const override;
 
       // matrix computations
+      [[nodiscard]] EvaluationSpace& get_evaluation_space() const override;
       void evaluate_constraint_jacobian(const OptimizationProblem& problem, Iterate& iterate,
          HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius) override;
       void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
@@ -9,6 +9,7 @@
 #include "ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.hpp"
 #include "linear_algebra/SparseVector.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/EvaluationSpace.hpp"
 #include "optimization/Iterate.hpp"
 #include "options/Options.hpp"
 #include "tools/Logger.hpp"
@@ -205,20 +206,27 @@ namespace uno {
       return std::sqrt(this->barrier_parameter());
    }
 
+   EvaluationSpace& PrimalDualInteriorPointMethod::get_evaluation_space() const {
+      return this->linear_solver->get_evaluation_space();
+   }
+
    void PrimalDualInteriorPointMethod::evaluate_constraint_jacobian(const OptimizationProblem& problem, Iterate& iterate,
          HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius) {
       // create the subproblem
       const PrimalDualInteriorPointProblem barrier_problem(problem, this->barrier_parameter(), this->parameters);
       const Subproblem subproblem{barrier_problem, iterate, hessian_model, regularization_strategy, trust_region_radius};
-      this->linear_solver->evaluate_constraint_jacobian(subproblem);
+      auto& evaluation_space = this->linear_solver->get_evaluation_space();
+      evaluation_space.evaluate_constraint_jacobian(subproblem);
    }
 
    void PrimalDualInteriorPointMethod::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      this->linear_solver->compute_constraint_jacobian_vector_product(vector, result);
+      auto& evaluation_space = this->linear_solver->get_evaluation_space();
+      evaluation_space.compute_constraint_jacobian_vector_product(vector, result);
    }
 
    void PrimalDualInteriorPointMethod::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      this->linear_solver->compute_constraint_jacobian_transposed_vector_product(vector, result);
+      auto& evaluation_space = this->linear_solver->get_evaluation_space();
+      evaluation_space.compute_constraint_jacobian_transposed_vector_product(vector, result);
    }
 
    double PrimalDualInteriorPointMethod::compute_hessian_quadratic_product(const Vector<double>& /*vector*/) const {

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.cpp
@@ -220,17 +220,18 @@ namespace uno {
    }
 
    void PrimalDualInteriorPointMethod::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      auto& evaluation_space = this->linear_solver->get_evaluation_space();
+      const auto& evaluation_space = this->linear_solver->get_evaluation_space();
       evaluation_space.compute_constraint_jacobian_vector_product(vector, result);
    }
 
    void PrimalDualInteriorPointMethod::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      auto& evaluation_space = this->linear_solver->get_evaluation_space();
+      const auto& evaluation_space = this->linear_solver->get_evaluation_space();
       evaluation_space.compute_constraint_jacobian_transposed_vector_product(vector, result);
    }
 
-   double PrimalDualInteriorPointMethod::compute_hessian_quadratic_product(const Vector<double>& /*vector*/) const {
-      return 0.; // TODO
+   double PrimalDualInteriorPointMethod::compute_hessian_quadratic_product(const Vector<double>& vector) const {
+      const auto& evaluation_space = this->linear_solver->get_evaluation_space();
+      return evaluation_space.compute_hessian_quadratic_product(vector);
    }
 
    void PrimalDualInteriorPointMethod::set_auxiliary_measure(const OptimizationProblem& problem, Iterate& iterate) {

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointMethod.hpp
@@ -33,6 +33,7 @@ namespace uno {
       [[nodiscard]] double proximal_coefficient() const override;
 
       // matrix computations
+      [[nodiscard]] EvaluationSpace& get_evaluation_space() const override;
       void evaluate_constraint_jacobian(const OptimizationProblem& problem, Iterate& iterate,
          HessianModel& hessian_model, RegularizationStrategy<double>& regularization_strategy, double trust_region_radius) override;
       void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#include "BQPDEvaluationSpace.hpp"
+#include "ingredients/subproblem/Subproblem.hpp"
+#include "linear_algebra/Vector.hpp"
+#include "optimization/WarmstartInformation.hpp"
+
+namespace uno {
+   void BQPDEvaluationSpace::evaluate_constraint_jacobian(const Subproblem& subproblem) {
+      subproblem.evaluate_constraint_jacobian(this->jacobian_values.data());
+
+      // copy the Jacobian with permutation into &this->gradients[subproblem.number_variables]
+      for (size_t nonzero_index: Range(subproblem.number_jacobian_nonzeros())) {
+         const size_t permutated_nonzero_index = this->permutation_vector[nonzero_index];
+         this->gradients[subproblem.number_variables + nonzero_index] = this->jacobian_values[permutated_nonzero_index];
+      }
+   }
+
+   void BQPDEvaluationSpace::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
+      result.fill(0.);
+      const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
+      for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
+         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
+         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const double derivative = this->jacobian_values[nonzero_index];
+
+         // a safeguard to make sure we take only the correct part of the Jacobian
+         if (variable_index < vector.size() && constraint_index < result.size()) {
+            result[constraint_index] += derivative * vector[variable_index];
+         }
+      }
+   }
+
+   void BQPDEvaluationSpace::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
+      result.fill(0.);
+      const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
+      for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
+         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
+         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const double derivative = this->jacobian_values[nonzero_index];
+         assert(constraint_index < vector.size());
+         assert(variable_index < result.size());
+
+         result[variable_index] += derivative * vector[constraint_index];
+      }
+   }
+
+   double BQPDEvaluationSpace::compute_hessian_quadratic_product(const Vector<double>& vector) const {
+      double quadratic_product = 0.;
+      const size_t number_hessian_nonzeros = this->hessian_values.size();
+      for (size_t nonzero_index: Range(number_hessian_nonzeros)) {
+         const size_t row_index = this->hessian_row_indices[nonzero_index];
+         const size_t column_index = this->hessian_column_indices[nonzero_index];
+         const double entry = this->hessian_values[nonzero_index];
+         assert(row_index < vector.size());
+         assert(column_index < vector.size());
+
+         const double factor = (row_index != column_index) ? 2. : 1.;
+         quadratic_product += factor * entry * vector[row_index] * vector[column_index];
+      }
+      return quadratic_product;
+   }
+
+   void BQPDEvaluationSpace::evaluate_functions(const Subproblem& subproblem, const WarmstartInformation& warmstart_information) {
+      // evaluate the functions based on warmstart information
+      // gradients is a concatenation of the dense objective gradient and the sparse Jacobian
+      if (warmstart_information.objective_changed) {
+         subproblem.evaluate_objective_gradient(this->gradients.data());
+      }
+      if (warmstart_information.constraints_changed) {
+         subproblem.evaluate_constraints(this->constraints);
+         this->evaluate_constraint_jacobian(subproblem);
+      }
+      if (warmstart_information.objective_changed || warmstart_information.constraints_changed) {
+         this->evaluate_hessian = true;
+      }
+   }
+} // namespace

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_BQPDEVALUATIONSPACE_H
+#define UNO_BQPDEVALUATIONSPACE_H
+
+#include <cstddef>
+#include <vector>
+#include "linear_algebra/Vector.hpp"
+#include "optimization/EvaluationSpace.hpp"
+
+namespace uno {
+   // forward declarations
+   class Subproblem;
+   class WarmstartInformation;
+
+   class BQPDEvaluationSpace: public EvaluationSpace {
+   public:
+      BQPDEvaluationSpace() = default;
+      ~BQPDEvaluationSpace() override = default;
+
+      void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
+      void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
+      void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector,
+         Vector<double>& result) const override;
+      [[nodiscard]] double compute_hessian_quadratic_product(const Vector<double>& vector) const override;
+
+      void evaluate_functions(const Subproblem& subproblem, const WarmstartInformation& warmstart_information);
+
+      std::vector<double> constraints{};
+      Vector<double> gradients{};
+      Vector<int> gradient_sparsity{};
+      // COO constraint Jacobian
+      Vector<size_t> jacobian_row_indices{};
+      Vector<size_t> jacobian_column_indices{};
+      Vector<double> jacobian_values{};
+      Vector<size_t> permutation_vector{};
+      // COO Hessian
+      Vector<size_t> hessian_row_indices{};
+      Vector<size_t> hessian_column_indices{};
+      Vector<double> hessian_values{};
+      bool evaluate_hessian{false};
+   };
+} // namespace
+
+#endif // UNO_BQPDEVALUATIONSPACE_H

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -122,6 +122,10 @@ namespace uno {
       this->solve_subproblem(subproblem, initial_point, direction, warmstart_information);
    }
 
+   EvaluationSpace& BQPDSolver::get_evaluation_space() {
+
+   }
+
    void BQPDSolver::evaluate_constraint_jacobian(const Subproblem& subproblem) {
       subproblem.evaluate_constraint_jacobian(this->jacobian_values.data());
 

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
@@ -49,6 +49,7 @@ namespace uno {
       void solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
          Direction& direction, const WarmstartInformation& warmstart_information) override;
 
+      [[nodiscard]] EvaluationSpace& get_evaluation_space() override;
       void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
       void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
       void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const override;

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
@@ -8,8 +8,8 @@
 #include <memory>
 #include <vector>
 #include "ingredients/subproblem_solvers/QPSolver.hpp"
+#include "BQPDEvaluationSpace.hpp"
 #include "ingredients/subproblem_solvers/SubproblemStatus.hpp"
-#include "linear_algebra/Vector.hpp"
 
 namespace uno {
    // forward declarations
@@ -50,25 +50,10 @@ namespace uno {
          Direction& direction, const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] EvaluationSpace& get_evaluation_space() override;
-      void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
-      void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
-      void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
-      [[nodiscard]] double compute_hessian_quadratic_product(const Vector<double>& vector) const override;
 
    private:
+      BQPDEvaluationSpace evaluation_space;
       std::vector<double> lower_bounds{}, upper_bounds{}; // lower and upper bounds of variables and constraints
-      std::vector<double> constraints{};
-      Vector<double> gradients{};
-      Vector<int> gradient_sparsity{};
-      // COO constraint Jacobian
-      Vector<size_t> jacobian_row_indices{};
-      Vector<size_t> jacobian_column_indices{};
-      Vector<double> jacobian_values{};
-      Vector<size_t> permutation_vector{};
-      // COO Hessian
-      Vector<size_t> hessian_row_indices{};
-      Vector<size_t> hessian_column_indices{};
-      Vector<double> hessian_values{};
 
       int kmax{0};
       int mlp{1000};
@@ -85,7 +70,6 @@ namespace uno {
       int iprint{0}, nout{6};
       double fmin{-1e20};
       int peq_solution{0}, ifail{0};
-      bool evaluate_hessian{false};
       const int fortran_shift{1};
 
       const bool print_subproblem;

--- a/uno/ingredients/subproblem_solvers/COOEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/COOEvaluationSpace.cpp
@@ -12,30 +12,6 @@ namespace uno {
       subproblem.evaluate_constraint_jacobian(this->matrix_values.data() + this->number_hessian_nonzeros);
    }
 
-   void COOEvaluationSpace::set_up_linear_system(Statistics& statistics, const Subproblem& subproblem,
-         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, const WarmstartInformation& warmstart_information) {
-      // evaluate the functions at the current iterate
-      if (warmstart_information.objective_changed) {
-         subproblem.evaluate_objective_gradient(this->objective_gradient.data());
-      }
-      if (warmstart_information.constraints_changed) {
-         subproblem.evaluate_constraints(this->constraints);
-      }
-
-      if (warmstart_information.objective_changed || warmstart_information.constraints_changed) {
-         // assemble the augmented matrix
-         subproblem.assemble_augmented_matrix(statistics, this->matrix_values.data());
-         // regularize the augmented matrix (this calls the analysis and the factorization)
-         subproblem.regularize_augmented_matrix(statistics, this->matrix_values.data(),
-            subproblem.dual_regularization_factor(), linear_solver);
-
-         // assemble the RHS
-         const COOMatrix jacobian{this->jacobian_row_indices.data(), this->jacobian_column_indices.data(),
-            this->matrix_values.data() + this->number_hessian_nonzeros};
-         subproblem.assemble_augmented_rhs(this->objective_gradient, this->constraints, jacobian, this->rhs);
-      }
-   }
-
    void COOEvaluationSpace::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
       result.fill(0.);
       const size_t offset = this->number_hessian_nonzeros;
@@ -66,5 +42,29 @@ namespace uno {
 
    double COOEvaluationSpace::compute_hessian_quadratic_product(const Vector<double>& /*vector*/) const {
       throw std::runtime_error("COOEvaluationSpace::compute_hessian_quadratic_product not implemented");
+   }
+
+   void COOEvaluationSpace::set_up_linear_system(Statistics& statistics, const Subproblem& subproblem,
+         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, const WarmstartInformation& warmstart_information) {
+      // evaluate the functions at the current iterate
+      if (warmstart_information.objective_changed) {
+         subproblem.evaluate_objective_gradient(this->objective_gradient.data());
+      }
+      if (warmstart_information.constraints_changed) {
+         subproblem.evaluate_constraints(this->constraints);
+      }
+
+      if (warmstart_information.objective_changed || warmstart_information.constraints_changed) {
+         // assemble the augmented matrix
+         subproblem.assemble_augmented_matrix(statistics, this->matrix_values.data());
+         // regularize the augmented matrix (this calls the analysis and the factorization)
+         subproblem.regularize_augmented_matrix(statistics, this->matrix_values.data(),
+            subproblem.dual_regularization_factor(), linear_solver);
+
+         // assemble the RHS
+         const COOMatrix jacobian{this->jacobian_row_indices.data(), this->jacobian_column_indices.data(),
+            this->matrix_values.data() + this->number_hessian_nonzeros};
+         subproblem.assemble_augmented_rhs(this->objective_gradient, this->constraints, jacobian, this->rhs);
+      }
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/COOEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/COOEvaluationSpace.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#include "COOEvaluationSpace.hpp"
+#include "ingredients/subproblem/Subproblem.hpp"
+#include "linear_algebra/COOMatrix.hpp"
+#include "linear_algebra/Vector.hpp"
+#include "optimization/WarmstartInformation.hpp"
+
+namespace uno {
+   void COOEvaluationSpace::evaluate_constraint_jacobian(const Subproblem& subproblem) {
+      subproblem.evaluate_constraint_jacobian(this->matrix_values.data() + this->number_hessian_nonzeros);
+   }
+
+   void COOEvaluationSpace::set_up_linear_system(Statistics& statistics, const Subproblem& subproblem,
+         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, const WarmstartInformation& warmstart_information) {
+      // evaluate the functions at the current iterate
+      if (warmstart_information.objective_changed) {
+         subproblem.evaluate_objective_gradient(this->objective_gradient.data());
+      }
+      if (warmstart_information.constraints_changed) {
+         subproblem.evaluate_constraints(this->constraints);
+      }
+
+      if (warmstart_information.objective_changed || warmstart_information.constraints_changed) {
+         // assemble the augmented matrix
+         subproblem.assemble_augmented_matrix(statistics, this->matrix_values.data());
+         // regularize the augmented matrix (this calls the analysis and the factorization)
+         subproblem.regularize_augmented_matrix(statistics, this->matrix_values.data(),
+            subproblem.dual_regularization_factor(), linear_solver);
+
+         // assemble the RHS
+         const COOMatrix jacobian{this->jacobian_row_indices.data(), this->jacobian_column_indices.data(),
+            this->matrix_values.data() + this->number_hessian_nonzeros};
+         subproblem.assemble_augmented_rhs(this->objective_gradient, this->constraints, jacobian, this->rhs);
+      }
+   }
+
+   void COOEvaluationSpace::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
+      result.fill(0.);
+      const size_t offset = this->number_hessian_nonzeros;
+      for (size_t nonzero_index: Range(this->number_jacobian_nonzeros)) {
+         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
+         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const double derivative = this->matrix_values[offset + nonzero_index];
+
+         if (constraint_index < result.size() && variable_index < vector.size()) {
+            result[constraint_index] += derivative * vector[variable_index];
+         }
+      }
+   }
+
+   void COOEvaluationSpace::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
+      result.fill(0.);
+      const size_t offset = this->number_hessian_nonzeros;
+      for (size_t nonzero_index: Range(this->number_jacobian_nonzeros)) {
+         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
+         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const double derivative = this->matrix_values[offset + nonzero_index];
+
+         if (variable_index < result.size() && constraint_index < vector.size()) {
+            result[variable_index] += derivative * vector[constraint_index];
+         }
+      }
+   }
+
+   double COOEvaluationSpace::compute_hessian_quadratic_product(const Vector<double>& /*vector*/) const {
+      throw std::runtime_error("COOEvaluationSpace::compute_hessian_quadratic_product not implemented");
+   }
+} // namespace

--- a/uno/ingredients/subproblem_solvers/COOEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/COOEvaluationSpace.cpp
@@ -41,7 +41,7 @@ namespace uno {
    }
 
    double COOEvaluationSpace::compute_hessian_quadratic_product(const Vector<double>& /*vector*/) const {
-      throw std::runtime_error("COOEvaluationSpace::compute_hessian_quadratic_product not implemented");
+      return 0.;
    }
 
    void COOEvaluationSpace::set_up_linear_system(Statistics& statistics, const Subproblem& subproblem,

--- a/uno/ingredients/subproblem_solvers/COOEvaluationSpace.hpp
+++ b/uno/ingredients/subproblem_solvers/COOEvaluationSpace.hpp
@@ -16,13 +16,13 @@ namespace uno {
       ~COOEvaluationSpace() override = default;
 
       void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
-
-      void set_up_linear_system(Statistics& statistics, const Subproblem& subproblem, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         const WarmstartInformation& warmstart_information) override;
       void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
       void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector,
          Vector<double>& result) const override;
       [[nodiscard]] double compute_hessian_quadratic_product(const Vector<double>& vector) const override;
+
+      void set_up_linear_system(Statistics& statistics, const Subproblem& subproblem, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
+         const WarmstartInformation& warmstart_information);
 
       Vector<double> objective_gradient{}; /*!< Sparse Jacobian of the objective */
       std::vector<double> constraints{}; /*!< Constraint values (size \f$m)\f$ */

--- a/uno/ingredients/subproblem_solvers/COOEvaluationSpace.hpp
+++ b/uno/ingredients/subproblem_solvers/COOEvaluationSpace.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_COOEVALUATIONSPACE_H
+#define UNO_COOEVALUATIONSPACE_H
+
+#include <cstddef>
+#include <vector>
+#include "linear_algebra/Vector.hpp"
+#include "optimization/EvaluationSpace.hpp"
+
+namespace uno {
+   class COOEvaluationSpace: public EvaluationSpace {
+   public:
+      COOEvaluationSpace() = default;
+      ~COOEvaluationSpace() override = default;
+
+      void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
+
+      void set_up_linear_system(Statistics& statistics, const Subproblem& subproblem, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
+         const WarmstartInformation& warmstart_information) override;
+      void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
+      void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector,
+         Vector<double>& result) const override;
+      [[nodiscard]] double compute_hessian_quadratic_product(const Vector<double>& vector) const override;
+
+      Vector<double> objective_gradient{}; /*!< Sparse Jacobian of the objective */
+      std::vector<double> constraints{}; /*!< Constraint values (size \f$m)\f$ */
+
+      // Jacobian
+      size_t number_jacobian_nonzeros{};
+      std::vector<size_t> jacobian_row_indices{};
+      std::vector<size_t> jacobian_column_indices{};
+
+      // symmetric matrix (Hessian or augmented system)
+      size_t number_hessian_nonzeros{};
+      size_t number_matrix_nonzeros{};
+      std::vector<int> matrix_row_indices{};
+      std::vector<int> matrix_column_indices{};
+      Vector<double> matrix_values;
+      Vector<double> rhs{};
+      Vector<double> solution{};
+   };
+} // namespace
+
+#endif // UNO_COOEVALUATIONSPACE_H

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#include "HiGHSEvaluationSpace.hpp"
+#include "ingredients/subproblem/Subproblem.hpp"
+#include "linear_algebra/Vector.hpp"
+#include "optimization/WarmstartInformation.hpp"
+
+namespace uno {
+   void HiGHSEvaluationSpace::evaluate_constraint_jacobian(const Subproblem& subproblem) {
+      subproblem.evaluate_constraint_jacobian(this->model.lp_.a_matrix_.value_.data());
+   }
+
+   void HiGHSEvaluationSpace::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
+      result.fill(0.);
+      const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
+      for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
+         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
+         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const double derivative = this->model.lp_.a_matrix_.value_[nonzero_index];
+
+         // a safeguard to make sure we take only the correct part of the Jacobian
+         if (variable_index < vector.size() && constraint_index < result.size()) {
+            result[constraint_index] += derivative * vector[variable_index];
+         }
+      }
+   }
+
+   void HiGHSEvaluationSpace::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
+      result.fill(0.);
+      const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
+      for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
+         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
+         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const double derivative = this->model.lp_.a_matrix_.value_[nonzero_index];
+         assert(constraint_index < vector.size());
+         assert(variable_index < result.size());
+
+         result[variable_index] += derivative * vector[constraint_index];
+      }
+   }
+
+   double HiGHSEvaluationSpace::compute_hessian_quadratic_product(const Vector<double>& vector) const {
+      double quadratic_product = 0.;
+      const size_t number_hessian_nonzeros = this->hessian_values.size();
+      for (size_t nonzero_index: Range(number_hessian_nonzeros)) {
+         const size_t row_index = this->hessian_row_indices[nonzero_index];
+         const size_t column_index = this->hessian_column_indices[nonzero_index];
+         const double entry = this->hessian_values[nonzero_index];
+         assert(row_index < vector.size());
+         assert(column_index < vector.size());
+
+         const double factor = (row_index != column_index) ? 2. : 1.;
+         quadratic_product += factor * entry * vector[row_index] * vector[column_index];
+      }
+      return quadratic_product;
+   }
+
+   void HiGHSEvaluationSpace::evaluate_functions(Statistics& statistics, const Subproblem& subproblem,
+         const WarmstartInformation& warmstart_information) {
+      // evaluate the functions based on warmstart information
+      if (warmstart_information.objective_changed) {
+         subproblem.evaluate_objective_gradient(this->model.lp_.col_cost_.data());
+      }
+      if (warmstart_information.constraints_changed) {
+         subproblem.evaluate_constraints(this->constraints);
+         this->evaluate_constraint_jacobian(subproblem);
+      }
+      // evaluate the Hessian and regularize it
+      if (warmstart_information.objective_changed || warmstart_information.constraints_changed) {
+         subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.data());
+         // copy the Hessian with permutation into this->model.hessian_.value_
+         for (size_t nonzero_index: Range(subproblem.number_regularized_hessian_nonzeros())) {
+            const size_t permutated_nonzero_index = this->permutation_vector[nonzero_index];
+            this->model.hessian_.value_[nonzero_index] = this->hessian_values[permutated_nonzero_index];
+         }
+         subproblem.regularize_lagrangian_hessian(statistics, this->model.hessian_.value_.data());
+      }
+   }
+} // namespace

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_HIGHSEVALUATIONSPACE_H
+#define UNO_HIGHSEVALUATIONSPACE_H
+
+#include <cstddef>
+#include <vector>
+#include "optimization/EvaluationSpace.hpp"
+#include "Highs.h"
+#include "linear_algebra/Vector.hpp"
+
+namespace uno {
+   // forward declarations
+   class Statistics;
+   class Subproblem;
+   class WarmstartInformation;
+
+   class HiGHSEvaluationSpace: public EvaluationSpace {
+   public:
+      HiGHSEvaluationSpace() = default;
+      ~HiGHSEvaluationSpace() override = default;
+
+      void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
+      void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
+      void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector,
+         Vector<double>& result) const override;
+      [[nodiscard]] double compute_hessian_quadratic_product(const Vector<double>& vector) const override;
+
+      void evaluate_functions(Statistics& statistics, const Subproblem& subproblem, const WarmstartInformation& warmstart_information);
+
+      HighsModel model;
+      std::vector<double> constraints{};
+      Vector<double> linear_objective{};
+      // constraint Jacobian in COO format
+      Vector<size_t> jacobian_row_indices{};
+      Vector<size_t> jacobian_column_indices{};
+      // Lagrangian Hessian in COO format
+      Vector<size_t> hessian_row_indices{};
+      Vector<size_t> hessian_column_indices{};
+      Vector<double> hessian_values{};
+      Vector<size_t> permutation_vector{};
+   };
+} // namespace
+
+#endif // UNO_HIGHSEVALUATIONSPACE_H

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
@@ -69,6 +69,10 @@ namespace uno {
       this->solve_subproblem(subproblem, direction);
    }
 
+   EvaluationSpace& HiGHSSolver::get_evaluation_space() {
+
+   }
+
    void HiGHSSolver::evaluate_constraint_jacobian(const Subproblem& subproblem) {
       subproblem.evaluate_constraint_jacobian(this->model.lp_.a_matrix_.value_.data());
    }

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
@@ -17,47 +17,50 @@ namespace uno {
    }
 
    void HiGHSSolver::initialize_memory(const Subproblem& subproblem) {
+      this->evaluation_space.model.lp_.num_col_ = static_cast<HighsInt>(subproblem.number_variables);
+      this->evaluation_space.model.lp_.num_row_ = static_cast<HighsInt>(subproblem.number_constraints);
+
       // determine whether the subproblem has curvature. For the moment, HiGHS can only solve LPs
-      this->constraints.resize(subproblem.number_constraints);
-      this->linear_objective.resize(subproblem.number_variables);
-      this->model.lp_.sense_ = ObjSense::kMinimize;
-      this->model.lp_.offset_ = 0.;
+      this->evaluation_space.constraints.resize(subproblem.number_constraints);
+      this->evaluation_space.linear_objective.resize(subproblem.number_variables);
+      this->evaluation_space.model.lp_.sense_ = ObjSense::kMinimize;
+      this->evaluation_space.model.lp_.offset_ = 0.;
       // the linear part of the objective is a dense vector
-      this->model.lp_.col_cost_.resize(subproblem.number_variables);
+      this->evaluation_space.model.lp_.col_cost_.resize(subproblem.number_variables);
       // variable bounds
-      this->model.lp_.col_lower_.resize(subproblem.number_variables);
-      this->model.lp_.col_upper_.resize(subproblem.number_variables);
+      this->evaluation_space.model.lp_.col_lower_.resize(subproblem.number_variables);
+      this->evaluation_space.model.lp_.col_upper_.resize(subproblem.number_variables);
       // constraint bounds
-      this->model.lp_.row_lower_.resize(subproblem.number_constraints);
-      this->model.lp_.row_upper_.resize(subproblem.number_constraints);
+      this->evaluation_space.model.lp_.row_lower_.resize(subproblem.number_constraints);
+      this->evaluation_space.model.lp_.row_upper_.resize(subproblem.number_constraints);
 
       // column-wise constraint Jacobian
-      this->model.lp_.a_matrix_.format_ = MatrixFormat::kColwise;
+      this->evaluation_space.model.lp_.a_matrix_.format_ = MatrixFormat::kColwise;
       const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
       // compute the COO sparsity pattern
-      this->jacobian_row_indices.resize(number_jacobian_nonzeros);
-      this->jacobian_column_indices.resize(number_jacobian_nonzeros);
-      subproblem.compute_constraint_jacobian_sparsity(this->jacobian_row_indices.data(), this->jacobian_column_indices.data(),
-         Indexing::C_indexing, MatrixOrder::COLUMN_MAJOR);
+      this->evaluation_space.jacobian_row_indices.resize(number_jacobian_nonzeros);
+      this->evaluation_space.jacobian_column_indices.resize(number_jacobian_nonzeros);
+      subproblem.compute_constraint_jacobian_sparsity(this->evaluation_space.jacobian_row_indices.data(),
+         this->evaluation_space.jacobian_column_indices.data(), Indexing::C_indexing, MatrixOrder::COLUMN_MAJOR);
       // HiGHS matrix in CSC format (variable after variable)
-      this->model.lp_.a_matrix_.index_.resize(number_jacobian_nonzeros); // constraint indices
-      this->model.lp_.a_matrix_.start_.resize(subproblem.number_variables + 1);
-      this->model.lp_.a_matrix_.value_.resize(number_jacobian_nonzeros);
+      this->evaluation_space.model.lp_.a_matrix_.index_.resize(number_jacobian_nonzeros); // constraint indices
+      this->evaluation_space.model.lp_.a_matrix_.start_.resize(subproblem.number_variables + 1);
+      this->evaluation_space.model.lp_.a_matrix_.value_.resize(number_jacobian_nonzeros);
       size_t current_variable = 0;
       for (size_t jacobian_nonzero_index: Range(number_jacobian_nonzeros)) {
          // constraint index is used as is
-         const size_t constraint_index = this->jacobian_row_indices[jacobian_nonzero_index];
-         this->model.lp_.a_matrix_.index_[jacobian_nonzero_index] = static_cast<HighsInt>(constraint_index);
+         const size_t constraint_index = this->evaluation_space.jacobian_row_indices[jacobian_nonzero_index];
+         this->evaluation_space.model.lp_.a_matrix_.index_[jacobian_nonzero_index] = static_cast<HighsInt>(constraint_index);
 
          // variable index is used to build the pointers to the column starts
-         const size_t variable_index = this->jacobian_column_indices[jacobian_nonzero_index];
+         const size_t variable_index = this->evaluation_space.jacobian_column_indices[jacobian_nonzero_index];
          assert(current_variable <= variable_index);
          while (current_variable < variable_index) {
             ++current_variable;
-            this->model.lp_.a_matrix_.start_[current_variable] = static_cast<HighsInt>(jacobian_nonzero_index);
+            this->evaluation_space.model.lp_.a_matrix_.start_[current_variable] = static_cast<HighsInt>(jacobian_nonzero_index);
          }
       }
-      this->model.lp_.a_matrix_.start_[subproblem.number_variables] = static_cast<HighsInt>(number_jacobian_nonzeros);
+      this->evaluation_space.model.lp_.a_matrix_.start_[subproblem.number_variables] = static_cast<HighsInt>(number_jacobian_nonzeros);
 
       // Lagrangian Hessian
       this->compute_hessian_sparsity(subproblem);
@@ -70,42 +73,7 @@ namespace uno {
    }
 
    EvaluationSpace& HiGHSSolver::get_evaluation_space() {
-
-   }
-
-   void HiGHSSolver::evaluate_constraint_jacobian(const Subproblem& subproblem) {
-      subproblem.evaluate_constraint_jacobian(this->model.lp_.a_matrix_.value_.data());
-   }
-
-   void HiGHSSolver::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
-      for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
-         const double derivative = this->model.lp_.a_matrix_.value_[nonzero_index];
-
-         // a safeguard to make sure we take only the correct part of the Jacobian
-         if (variable_index < vector.size() && constraint_index < result.size()) {
-            result[constraint_index] += derivative * vector[variable_index];
-         }
-      }
-   }
-
-   void HiGHSSolver::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
-      for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
-         const double derivative = this->model.lp_.a_matrix_.value_[nonzero_index];
-         assert(constraint_index < vector.size());
-         assert(variable_index < result.size());
-
-         result[variable_index] += derivative * vector[constraint_index];
-      }
-   }
-
-   double HiGHSSolver::compute_hessian_quadratic_product(const Vector<double>& /*vector*/) const {
-      return 0.;
+      return this->evaluation_space;
    }
 
    // protected member functions
@@ -113,120 +81,100 @@ namespace uno {
    // column-wise lower triangular Lagrangian Hessian
    void HiGHSSolver::compute_hessian_sparsity(const Subproblem& subproblem) {
       const size_t number_regularized_hessian_nonzeros = subproblem.number_regularized_hessian_nonzeros();
-      this->model.hessian_.dim_ = static_cast<HighsInt>(subproblem.number_variables);
-      this->model.hessian_.format_ = HessianFormat::kTriangular;
-      this->model.hessian_.index_.resize(number_regularized_hessian_nonzeros);
-      this->model.hessian_.start_.resize(subproblem.number_variables + 1);
-      this->model.hessian_.value_.resize(number_regularized_hessian_nonzeros);
+      this->evaluation_space.model.hessian_.dim_ = static_cast<HighsInt>(subproblem.number_variables);
+      this->evaluation_space.model.hessian_.format_ = HessianFormat::kTriangular;
+      this->evaluation_space.model.hessian_.index_.resize(number_regularized_hessian_nonzeros);
+      this->evaluation_space.model.hessian_.start_.resize(subproblem.number_variables + 1);
+      this->evaluation_space.model.hessian_.value_.resize(number_regularized_hessian_nonzeros);
 
       // get the Jacobian sparsity in COO format
-      this->hessian_row_indices.resize(number_regularized_hessian_nonzeros);
-      this->hessian_column_indices.resize(number_regularized_hessian_nonzeros);
-      subproblem.compute_regularized_hessian_sparsity(this->hessian_row_indices.data(), this->hessian_column_indices.data(),
-         Indexing::C_indexing);
+      this->evaluation_space.hessian_row_indices.resize(number_regularized_hessian_nonzeros);
+      this->evaluation_space.hessian_column_indices.resize(number_regularized_hessian_nonzeros);
+      subproblem.compute_regularized_hessian_sparsity(this->evaluation_space.hessian_row_indices.data(),
+         this->evaluation_space.hessian_column_indices.data(), Indexing::C_indexing);
 
       // HiGHS requires a lower-triangular CSC Hessian: the entries should be in increasing column indices.
       // Since the COO format does not require this, we need to convert from COO to CSC by permutating the entries. To
       // this end, we compute a permutation vector once and for all that contains the correct ordering of terms.
       // The permutation vector is initially filled with [0, 1, ..., number_regularized_hessian_nonzeros-1]
-      this->permutation_vector.resize(number_regularized_hessian_nonzeros);
-      std::iota(this->permutation_vector.begin(), this->permutation_vector.end(), 0);
+      this->evaluation_space.permutation_vector.resize(number_regularized_hessian_nonzeros);
+      std::iota(this->evaluation_space.permutation_vector.begin(), this->evaluation_space.permutation_vector.end(), 0);
       // sort the permutation vector such that the column indices are in increasing order
       // see https://stackoverflow.com/questions/17554242/how-to-obtain-the-index-permutation-after-the-sorting
-      std::sort(this->permutation_vector.begin(), this->permutation_vector.end(),
+      std::sort(this->evaluation_space.permutation_vector.begin(), this->evaluation_space.permutation_vector.end(),
           [&](const size_t& i, const size_t& j) {
-             if (this->hessian_column_indices[i] < this->hessian_column_indices[j]) {
+             if (this->evaluation_space.hessian_column_indices[i] < this->evaluation_space.hessian_column_indices[j]) {
                 return true;
              }
              // within a given column, have the row indices in increasing order
-             else if (this->hessian_column_indices[i] == this->hessian_column_indices[j]) {
-               return (this->hessian_row_indices[i] < this->hessian_row_indices[j]);
+             else if (this->evaluation_space.hessian_column_indices[i] == this->evaluation_space.hessian_column_indices[j]) {
+               return (this->evaluation_space.hessian_row_indices[i] < this->evaluation_space.hessian_row_indices[j]);
              }
              return false;
           }
       );
 
       // copy the COO format into HiGHS' CSC format
-      this->model.hessian_.start_[0] = 0;
+      this->evaluation_space.model.hessian_.start_[0] = 0;
       size_t current_column = 0;
       for (size_t hessian_nonzero_index: Range(number_regularized_hessian_nonzeros)) {
-         const size_t permutated_nonzero_index = this->permutation_vector[hessian_nonzero_index];
+         const size_t permutated_nonzero_index = this->evaluation_space.permutation_vector[hessian_nonzero_index];
          // row index
-         const size_t row_index = this->hessian_row_indices[permutated_nonzero_index];
-         this->model.hessian_.index_[hessian_nonzero_index] = static_cast<HighsInt>(row_index);
+         const size_t row_index = this->evaluation_space.hessian_row_indices[permutated_nonzero_index];
+         this->evaluation_space.model.hessian_.index_[hessian_nonzero_index] = static_cast<HighsInt>(row_index);
 
          // column index
-         const size_t column_index = this->hessian_column_indices[permutated_nonzero_index];
+         const size_t column_index = this->evaluation_space.hessian_column_indices[permutated_nonzero_index];
          assert(current_column <= column_index);
          while (current_column < column_index) {
             ++current_column;
-            this->model.hessian_.start_[current_column] = static_cast<HighsInt>(hessian_nonzero_index);
+            this->evaluation_space.model.hessian_.start_[current_column] = static_cast<HighsInt>(hessian_nonzero_index);
          }
       }
       // fill the remaining empty columns
       while (current_column < subproblem.number_variables) {
          ++current_column;
-         this->model.hessian_.start_[current_column] = static_cast<HighsInt>(number_regularized_hessian_nonzeros);
+         this->evaluation_space.model.hessian_.start_[current_column] = static_cast<HighsInt>(number_regularized_hessian_nonzeros);
       }
 
-      // the Hessian will be evaluated in this vector, and copied with permutation into this->model.hessian_.value_
-      this->hessian_values.resize(number_regularized_hessian_nonzeros);
+      // the Hessian will be evaluated in this vector, and copied with permutation into this->evaluation_space.model.hessian_.value_
+      this->evaluation_space.hessian_values.resize(number_regularized_hessian_nonzeros);
    }
 
    void HiGHSSolver::set_up_subproblem(Statistics& statistics, const Subproblem& subproblem, const WarmstartInformation& warmstart_information) {
-      this->model.lp_.num_col_ = static_cast<HighsInt>(subproblem.number_variables);
-      this->model.lp_.num_row_ = static_cast<HighsInt>(subproblem.number_constraints);
-
-      // evaluate the functions based on warmstart information
-      if (warmstart_information.objective_changed) {
-         subproblem.evaluate_objective_gradient(this->model.lp_.col_cost_.data());
-      }
-      if (warmstart_information.constraints_changed) {
-         subproblem.evaluate_constraints(this->constraints);
-         this->evaluate_constraint_jacobian(subproblem);
-      }
-      // evaluate the Hessian and regularize it
-      if (warmstart_information.objective_changed || warmstart_information.constraints_changed) {
-         subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.data());
-         // copy the Hessian with permutation into this->model.hessian_.value_
-         for (size_t nonzero_index: Range(subproblem.number_regularized_hessian_nonzeros())) {
-            const size_t permutated_nonzero_index = this->permutation_vector[nonzero_index];
-            this->model.hessian_.value_[nonzero_index] = this->hessian_values[permutated_nonzero_index];
-         }
-         subproblem.regularize_lagrangian_hessian(statistics, this->model.hessian_.value_.data());
-      }
+      this->evaluation_space.evaluate_functions(statistics, subproblem, warmstart_information);
 
       // variable bounds
       if (warmstart_information.variable_bounds_changed) {
-         subproblem.set_variables_bounds(this->model.lp_.col_lower_, this->model.lp_.col_upper_);
+         subproblem.set_variables_bounds(this->evaluation_space.model.lp_.col_lower_, this->evaluation_space.model.lp_.col_upper_);
       }
 
       // constraint bounds
       if (warmstart_information.constraint_bounds_changed || warmstart_information.constraints_changed) {
-         subproblem.set_constraints_bounds(this->model.lp_.row_lower_, this->model.lp_.row_upper_, this->constraints);
+         subproblem.set_constraints_bounds(this->evaluation_space.model.lp_.row_lower_, this->evaluation_space.model.lp_.row_upper_, this->evaluation_space.constraints);
       }
 
       if (this->print_subproblem) {
          DEBUG << "Subproblem:\n";
-         DEBUG << "Hessian: "; print_vector(DEBUG, this->model.hessian_.value_);
-         DEBUG << "Linear objective part: "; print_vector(DEBUG, this->model.lp_.col_cost_);
-         DEBUG << "Jacobian: "; print_vector(DEBUG, this->model.lp_.a_matrix_.value_);
-         // DEBUG << "with column start: "; print_vector(DEBUG, this->model.lp_.a_matrix_.start_);
-         // DEBUG << "and row index: "; print_vector(DEBUG, this->model.lp_.a_matrix_.index_);
+         DEBUG << "Hessian: "; print_vector(DEBUG, this->evaluation_space.model.hessian_.value_);
+         DEBUG << "Linear objective part: "; print_vector(DEBUG, this->evaluation_space.model.lp_.col_cost_);
+         DEBUG << "Jacobian: "; print_vector(DEBUG, this->evaluation_space.model.lp_.a_matrix_.value_);
+         // DEBUG << "with column start: "; print_vector(DEBUG, this->evaluation_space.model.lp_.a_matrix_.start_);
+         // DEBUG << "and row index: "; print_vector(DEBUG, this->evaluation_space.model.lp_.a_matrix_.index_);
          for (size_t variable_index = 0; variable_index < subproblem.number_variables; variable_index++) {
-            DEBUG << "d" << variable_index << " in [" << this->model.lp_.col_lower_[variable_index] << ", " <<
-               this->model.lp_.col_upper_[variable_index] << "]\n";
+            DEBUG << "d" << variable_index << " in [" << this->evaluation_space.model.lp_.col_lower_[variable_index] << ", " <<
+               this->evaluation_space.model.lp_.col_upper_[variable_index] << "]\n";
          }
          for (size_t constraint_index = 0; constraint_index < subproblem.number_constraints; constraint_index++) {
-            DEBUG << "linearized c" << constraint_index << " in [" << this->model.lp_.row_lower_[constraint_index] << ", " <<
-               this->model.lp_.row_upper_[constraint_index]<< "]\n";
+            DEBUG << "linearized c" << constraint_index << " in [" << this->evaluation_space.model.lp_.row_lower_[constraint_index] << ", " <<
+               this->evaluation_space.model.lp_.row_upper_[constraint_index]<< "]\n";
          }
       }
    }
 
    void HiGHSSolver::solve_subproblem(const Subproblem& subproblem, Direction& direction) {
       // solve the subproblem
-      HighsStatus return_status = this->highs_solver.passModel(this->model);
+      HighsStatus return_status = this->highs_solver.passModel(this->evaluation_space.model);
       //assert(return_status == HighsStatus::kOk);
 
       DEBUG2 << "Running HiGHS\n";

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
@@ -22,6 +22,7 @@ namespace uno {
       void solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
          Direction& direction, const WarmstartInformation& warmstart_information) override;
 
+      [[nodiscard]] EvaluationSpace& get_evaluation_space() override;
       void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
       void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
       void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const override;

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
@@ -6,6 +6,7 @@
 
 #include "ingredients/subproblem_solvers/QPSolver.hpp"
 #include "Highs.h"
+#include "HiGHSEvaluationSpace.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "linear_algebra/Vector.hpp"
 
@@ -23,24 +24,10 @@ namespace uno {
          Direction& direction, const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] EvaluationSpace& get_evaluation_space() override;
-      void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
-      void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
-      void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
-      [[nodiscard]] double compute_hessian_quadratic_product(const Vector<double>& vector) const override;
 
    protected:
-      HighsModel model;
       Highs highs_solver;
-      std::vector<double> constraints{};
-      Vector<double> linear_objective{};
-      // constraint Jacobian in COO format
-      Vector<size_t> jacobian_row_indices{};
-      Vector<size_t> jacobian_column_indices{};
-      // Lagrangian Hessian in COO format
-      Vector<size_t> hessian_row_indices{};
-      Vector<size_t> hessian_column_indices{};
-      Vector<double> hessian_values{};
-      Vector<size_t> permutation_vector{};
+      HiGHSEvaluationSpace evaluation_space;
 
       const bool print_subproblem;
 

--- a/uno/ingredients/subproblem_solvers/LPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/LPSolver.hpp
@@ -7,6 +7,7 @@
 namespace uno {
    // forward declarations
    class Direction;
+   class EvaluationSpace;
    class Iterate;
    class Statistics;
    class Subproblem;
@@ -24,6 +25,7 @@ namespace uno {
       virtual void solve(Statistics& statistics, Subproblem& subproblem, const Vector<double>& initial_point,
          Direction& direction, const WarmstartInformation& warmstart_information) = 0;
 
+      [[nodiscard]] virtual EvaluationSpace& get_evaluation_space() = 0;
       virtual void evaluate_constraint_jacobian(const Subproblem& subproblem) = 0;
       virtual void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;
       virtual void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;

--- a/uno/ingredients/subproblem_solvers/LPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/LPSolver.hpp
@@ -26,10 +26,6 @@ namespace uno {
          Direction& direction, const WarmstartInformation& warmstart_information) = 0;
 
       [[nodiscard]] virtual EvaluationSpace& get_evaluation_space() = 0;
-      virtual void evaluate_constraint_jacobian(const Subproblem& subproblem) = 0;
-      virtual void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;
-      virtual void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;
-      [[nodiscard]] virtual double compute_hessian_quadratic_product(const Vector<double>& vector) const = 0;
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -6,12 +6,10 @@
 #include <stdexcept>
 #include "MA27Solver.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
-#include "linear_algebra/COOMatrix.hpp"
 #include "linear_algebra/Indexing.hpp"
 #include "linear_algebra/MatrixOrder.hpp"
 #include "linear_algebra/Vector.hpp"
 #include "optimization/Direction.hpp"
-#include "optimization/WarmstartInformation.hpp"
 #include "tools/Logger.hpp"
 #include "fortran_interface.h"
 
@@ -130,27 +128,27 @@ namespace uno {
       const size_t dimension = subproblem.number_variables;
 
       // Hessian
-      this->number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-      this->number_matrix_nonzeros = subproblem.number_regularized_hessian_nonzeros();
-      this->matrix_row_indices.resize(this->number_matrix_nonzeros);
-      this->matrix_column_indices.resize(this->number_matrix_nonzeros);
+      this->evaluation_space.number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      this->evaluation_space.number_matrix_nonzeros = subproblem.number_regularized_hessian_nonzeros();
+      this->evaluation_space.matrix_row_indices.resize(this->evaluation_space.number_matrix_nonzeros);
+      this->evaluation_space.matrix_column_indices.resize(this->evaluation_space.number_matrix_nonzeros);
       // compute the COO sparse representation: use temporary vectors of size_t
-      Vector<size_t> tmp_row_indices(this->number_matrix_nonzeros);
-      Vector<size_t> tmp_column_indices(this->number_matrix_nonzeros);
+      Vector<size_t> tmp_row_indices(this->evaluation_space.number_matrix_nonzeros);
+      Vector<size_t> tmp_column_indices(this->evaluation_space.number_matrix_nonzeros);
       subproblem.compute_regularized_hessian_sparsity(tmp_row_indices.data(), tmp_column_indices.data(), Indexing::Fortran_indexing);
       // build vectors of int
-      for (size_t nonzero_index: Range(this->number_matrix_nonzeros)) {
-         this->matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
-         this->matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
+      for (size_t nonzero_index: Range(this->evaluation_space.number_matrix_nonzeros)) {
+         this->evaluation_space.matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
+         this->evaluation_space.matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
       }
-      this->matrix_values.resize(this->number_matrix_nonzeros);
-      this->rhs.resize(dimension);
-      this->solution.resize(dimension);
+      this->evaluation_space.matrix_values.resize(this->evaluation_space.number_matrix_nonzeros);
+      this->evaluation_space.rhs.resize(dimension);
+      this->evaluation_space.solution.resize(dimension);
 
       // workspace
       this->workspace.n = static_cast<int>(dimension);
-      this->workspace.nnz = static_cast<int>(this->number_matrix_nonzeros);
-      this->workspace.iw.resize((2 * this->number_matrix_nonzeros + 3 * dimension + 1) * 6 / 5); // 20% more than 2*nnz + 3*n + 1
+      this->workspace.nnz = static_cast<int>(this->evaluation_space.number_matrix_nonzeros);
+      this->workspace.iw.resize((2 * this->evaluation_space.number_matrix_nonzeros + 3 * dimension + 1) * 6 / 5); // 20% more than 2*nnz + 3*n + 1
       this->workspace.ikeep.resize(3 * dimension);
       this->workspace.iw1.resize(2 * dimension);
    }
@@ -159,39 +157,39 @@ namespace uno {
       const size_t dimension = subproblem.number_variables + subproblem.number_constraints;
 
       // evaluations
-      this->objective_gradient.resize(subproblem.number_variables);
-      this->constraints.resize(subproblem.number_constraints);
+      this->evaluation_space.objective_gradient.resize(subproblem.number_variables);
+      this->evaluation_space.constraints.resize(subproblem.number_constraints);
 
       // Jacobian
-      this->number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
-      this->jacobian_row_indices.resize(number_jacobian_nonzeros);
-      this->jacobian_column_indices.resize(number_jacobian_nonzeros);
-      subproblem.compute_constraint_jacobian_sparsity(this->jacobian_row_indices.data(), this->jacobian_column_indices.data(),
+      this->evaluation_space.number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
+      this->evaluation_space.jacobian_row_indices.resize(this->evaluation_space.number_jacobian_nonzeros);
+      this->evaluation_space.jacobian_column_indices.resize(this->evaluation_space.number_jacobian_nonzeros);
+      subproblem.compute_constraint_jacobian_sparsity(this->evaluation_space.jacobian_row_indices.data(), this->evaluation_space.jacobian_column_indices.data(),
          Indexing::C_indexing, MatrixOrder::COLUMN_MAJOR);
 
       // augmented system
-      this->number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-      this->number_matrix_nonzeros = subproblem.number_regularized_augmented_system_nonzeros();
-      this->matrix_row_indices.resize(this->number_matrix_nonzeros);
-      this->matrix_column_indices.resize(this->number_matrix_nonzeros);
+      this->evaluation_space.number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      this->evaluation_space.number_matrix_nonzeros = subproblem.number_regularized_augmented_system_nonzeros();
+      this->evaluation_space.matrix_row_indices.resize(this->evaluation_space.number_matrix_nonzeros);
+      this->evaluation_space.matrix_column_indices.resize(this->evaluation_space.number_matrix_nonzeros);
       // compute the COO sparse representation: use temporary vectors of size_t
-      Vector<size_t> tmp_row_indices(this->number_matrix_nonzeros);
-      Vector<size_t> tmp_column_indices(this->number_matrix_nonzeros);
+      Vector<size_t> tmp_row_indices(this->evaluation_space.number_matrix_nonzeros);
+      Vector<size_t> tmp_column_indices(this->evaluation_space.number_matrix_nonzeros);
       subproblem.compute_regularized_augmented_matrix_sparsity(tmp_row_indices.data(), tmp_column_indices.data(),
-         this->jacobian_row_indices.data(), this->jacobian_column_indices.data(), Indexing::Fortran_indexing);
+         this->evaluation_space.jacobian_row_indices.data(), this->evaluation_space.jacobian_column_indices.data(), Indexing::Fortran_indexing);
       // build vectors of int
-      for (size_t nonzero_index: Range(this->number_matrix_nonzeros)) {
-         this->matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
-         this->matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
+      for (size_t nonzero_index: Range(this->evaluation_space.number_matrix_nonzeros)) {
+         this->evaluation_space.matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
+         this->evaluation_space.matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
       }
-      this->matrix_values.resize(this->number_matrix_nonzeros);
-      this->rhs.resize(dimension);
-      this->solution.resize(dimension);
+      this->evaluation_space.matrix_values.resize(this->evaluation_space.number_matrix_nonzeros);
+      this->evaluation_space.rhs.resize(dimension);
+      this->evaluation_space.solution.resize(dimension);
 
       // workspace
       this->workspace.n = static_cast<int>(dimension);
-      this->workspace.nnz = static_cast<int>(this->number_matrix_nonzeros);
-      this->workspace.iw.resize((2 * this->number_matrix_nonzeros + 3 * dimension + 1) * 6 / 5); // 20% more than 2*nnz + 3*n + 1
+      this->workspace.nnz = static_cast<int>(this->evaluation_space.number_matrix_nonzeros);
+      this->workspace.iw.resize((2 * this->evaluation_space.number_matrix_nonzeros + 3 * dimension + 1) * 6 / 5); // 20% more than 2*nnz + 3*n + 1
       this->workspace.ikeep.resize(3 * dimension);
       this->workspace.iw1.resize(2 * dimension);
    }
@@ -199,7 +197,7 @@ namespace uno {
    void MA27Solver::do_symbolic_analysis() {
       int liw = static_cast<int>(this->workspace.iw.size());
       MA27_symbolic_analysis(&this->workspace.n, &this->workspace.nnz,              /* size info */
-         this->matrix_row_indices.data(), this->matrix_column_indices.data(),                     /* matrix indices */
+         this->evaluation_space.matrix_row_indices.data(), this->evaluation_space.matrix_column_indices.data(),                     /* matrix indices */
          this->workspace.iw.data(), &liw, this->workspace.ikeep.data(), this->workspace.iw1.data(),  /* solver workspace */
          &this->workspace.nsteps, &this->workspace.iflag, this->workspace.icntl.data(), this->workspace.cntl.data(),
          this->workspace.info.data(), &this->workspace.ops);
@@ -230,8 +228,8 @@ namespace uno {
 
          int la = static_cast<int>(this->workspace.factor.size());
          int liw = static_cast<int>(this->workspace.iw.size());
-         MA27_numerical_factorization(&this->workspace.n, &this->workspace.nnz, this->matrix_row_indices.data(),
-            this->matrix_column_indices.data(), this->workspace.factor.data(), &la, this->workspace.iw.data(), &liw,
+         MA27_numerical_factorization(&this->workspace.n, &this->workspace.nnz, this->evaluation_space.matrix_row_indices.data(),
+            this->evaluation_space.matrix_column_indices.data(), this->workspace.factor.data(), &la, this->workspace.iw.data(), &liw,
             this->workspace.ikeep.data(), &this->workspace.nsteps, &this->workspace.maxfrt, this->workspace.iw1.data(),
             this->workspace.icntl.data(), this->workspace.cntl.data(), this->workspace.info.data());
          factorization_done = true;
@@ -273,29 +271,12 @@ namespace uno {
 
    void MA27Solver::solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) {
-      // evaluate the functions at the current iterate
-      if (warmstart_information.objective_changed) {
-         subproblem.evaluate_objective_gradient(this->objective_gradient.data());
-      }
-      if (warmstart_information.constraints_changed) {
-         subproblem.evaluate_constraints(this->constraints);
-      }
-
-      if (warmstart_information.objective_changed || warmstart_information.constraints_changed) {
-         // assemble the augmented matrix
-         subproblem.assemble_augmented_matrix(statistics, this->matrix_values.data());
-         // regularize the augmented matrix (this calls the analysis and the factorization)
-         subproblem.regularize_augmented_matrix(statistics, this->matrix_values.data(),
-            subproblem.dual_regularization_factor(), *this);
-
-         // assemble the RHS
-         const COOMatrix jacobian{this->jacobian_row_indices.data(), this->jacobian_column_indices.data(),
-            this->matrix_values.data() + this->number_hessian_nonzeros};
-         subproblem.assemble_augmented_rhs(this->objective_gradient, this->constraints, jacobian, this->rhs);
-      }
-      this->solve_indefinite_system(this->matrix_values, this->rhs, this->solution);
+      // set up the linear system by evaluating the functions at the current iterate
+      this->evaluation_space.set_up_linear_system(statistics, subproblem, *this, warmstart_information);
+      // solve the linear system
+      this->solve_indefinite_system(this->evaluation_space.matrix_values, this->evaluation_space.rhs, this->evaluation_space.solution);
       // assemble the full primal-dual direction
-      subproblem.assemble_primal_dual_direction(this->solution, direction);
+      subproblem.assemble_primal_dual_direction(this->evaluation_space.solution, direction);
       if (this->matrix_is_singular()) {
          direction.status = SubproblemStatus::INFEASIBLE;
       }
@@ -325,34 +306,8 @@ namespace uno {
          static_cast<size_t>(this->workspace.n);
    }
 
-   void MA27Solver::evaluate_constraint_jacobian(const Subproblem& subproblem) {
-      subproblem.evaluate_constraint_jacobian(this->matrix_values.data() + this->number_hessian_nonzeros);
-   }
-
-   void MA27Solver::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      result.fill(0.);
-      const size_t offset = this->number_hessian_nonzeros;
-      for (size_t nonzero_index: Range(this->number_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
-         const double derivative = this->matrix_values[offset + nonzero_index];
-         if (constraint_index < result.size()) {
-            result[constraint_index] += derivative * vector[variable_index];
-         }
-      }
-   }
-
-   void MA27Solver::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      result.fill(0.);
-      const size_t offset = this->number_hessian_nonzeros;
-      for (size_t nonzero_index: Range(this->number_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
-         const double derivative = this->matrix_values[offset + nonzero_index];
-         if (variable_index < result.size()) {
-            result[variable_index] += derivative * vector[constraint_index];
-         }
-      }
+   EvaluationSpace& MA27Solver::get_evaluation_space() {
+      return this->evaluation_space;
    }
 
    void MA27Solver::check_factorization_status() {

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.hpp
@@ -7,7 +7,7 @@
 #include <array>
 #include <vector>
 #include "../DirectSymmetricIndefiniteLinearSolver.hpp"
-#include "linear_algebra/Vector.hpp"
+#include "../COOEvaluationSpace.hpp"
 
 namespace uno {
    // forward declaration
@@ -54,30 +54,11 @@ namespace uno {
       [[nodiscard]] bool matrix_is_singular() const override;
       [[nodiscard]] size_t rank() const override;
 
-      void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
-      void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
-      void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
+      [[nodiscard]] EvaluationSpace& get_evaluation_space() override;
 
    private:
       MA27Workspace workspace{};
-
-      // evaluations
-      Vector<double> objective_gradient; /*!< Sparse Jacobian of the objective */
-      std::vector<double> constraints; /*!< Constraint values (size \f$m)\f$ */
-
-      // Jacobian
-      size_t number_jacobian_nonzeros{};
-      std::vector<size_t> jacobian_row_indices{};
-      std::vector<size_t> jacobian_column_indices{};
-
-      // symmetric matrix (Hessian or augmented system)
-      size_t number_hessian_nonzeros{};
-      size_t number_matrix_nonzeros{};
-      std::vector<int> matrix_row_indices{};          // row index of input
-      std::vector<int> matrix_column_indices{};          // col index of input
-      Vector<double> matrix_values{};
-      Vector<double> rhs{};
-      Vector<double> solution{};
+      COOEvaluationSpace evaluation_space{};
 
       static constexpr size_t fortran_shift{1};
 

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
@@ -7,7 +7,7 @@
 #include <array>
 #include <vector>
 #include "ingredients/subproblem_solvers/DirectSymmetricIndefiniteLinearSolver.hpp"
-#include "linear_algebra/Vector.hpp"
+#include "ingredients/subproblem_solvers/COOEvaluationSpace.hpp"
 
 namespace uno {
    // forward declarations
@@ -61,30 +61,11 @@ namespace uno {
       [[nodiscard]] bool matrix_is_singular() const override;
       [[nodiscard]] size_t rank() const override;
 
-      void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
-      void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
-      void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
+      [[nodiscard]] EvaluationSpace& get_evaluation_space() override;
 
    private:
       MA57Workspace workspace{};
-
-      // evaluations
-      Vector<double> objective_gradient; /*!< Sparse Jacobian of the objective */
-      std::vector<double> constraints; /*!< Constraint values (size \f$m)\f$ */
-
-      // Jacobian
-      size_t number_jacobian_nonzeros{};
-      std::vector<size_t> jacobian_row_indices{};
-      std::vector<size_t> jacobian_column_indices{};
-
-      // symmetric matrix (Hessian or augmented system)
-      size_t number_hessian_nonzeros{};
-      size_t number_matrix_nonzeros{};
-      std::vector<int> matrix_row_indices{};
-      std::vector<int> matrix_column_indices{};
-      Vector<double> matrix_values{};
-      Vector<double> rhs{};
-      Vector<double> solution{};
+      COOEvaluationSpace evaluation_space{};
 
       static constexpr size_t fortran_shift{1};
 

--- a/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.cpp
@@ -54,71 +54,71 @@ namespace uno {
       const size_t dimension = subproblem.number_variables;
 
       // Hessian
-      this->number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-      this->number_matrix_nonzeros = subproblem.number_regularized_hessian_nonzeros();
-      this->matrix_row_indices.resize(this->number_matrix_nonzeros);
-      this->matrix_column_indices.resize(this->number_matrix_nonzeros);
+      this->evaluation_space.number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      this->evaluation_space.number_matrix_nonzeros = subproblem.number_regularized_hessian_nonzeros();
+      this->evaluation_space.matrix_row_indices.resize(this->evaluation_space.number_matrix_nonzeros);
+      this->evaluation_space.matrix_column_indices.resize(this->evaluation_space.number_matrix_nonzeros);
       // compute the COO sparse representation: use temporary vectors of size_t
-      Vector<size_t> tmp_row_indices(this->number_matrix_nonzeros);
-      Vector<size_t> tmp_column_indices(this->number_matrix_nonzeros);
+      Vector<size_t> tmp_row_indices(this->evaluation_space.number_matrix_nonzeros);
+      Vector<size_t> tmp_column_indices(this->evaluation_space.number_matrix_nonzeros);
       subproblem.compute_regularized_hessian_sparsity(tmp_row_indices.data(), tmp_column_indices.data(), Indexing::Fortran_indexing);
       // build vectors of int
-      for (size_t nonzero_index: Range(this->number_matrix_nonzeros)) {
-         this->matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
-         this->matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
+      for (size_t nonzero_index: Range(this->evaluation_space.number_matrix_nonzeros)) {
+         this->evaluation_space.matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
+         this->evaluation_space.matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
       }
-      this->matrix_values.resize(this->number_matrix_nonzeros);
-      this->rhs.resize(dimension);
-      this->solution.resize(dimension);
+      this->evaluation_space.matrix_values.resize(this->evaluation_space.number_matrix_nonzeros);
+      this->evaluation_space.rhs.resize(dimension);
+      this->evaluation_space.solution.resize(dimension);
 
       // workspace
       this->workspace.n = static_cast<int>(dimension);
-      this->workspace.nnz = static_cast<int>(this->number_matrix_nonzeros);
+      this->workspace.nnz = static_cast<int>(this->evaluation_space.number_matrix_nonzeros);
    }
 
    void MUMPSSolver::initialize_augmented_system(const Subproblem& subproblem) {
       const size_t dimension = subproblem.number_variables + subproblem.number_constraints;
 
       // evaluations
-      this->objective_gradient.resize(subproblem.number_variables);
-      this->constraints.resize(subproblem.number_constraints);
+      this->evaluation_space.objective_gradient.resize(subproblem.number_variables);
+      this->evaluation_space.constraints.resize(subproblem.number_constraints);
 
       // Jacobian
-      this->number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
-      this->jacobian_row_indices.resize(number_jacobian_nonzeros);
-      this->jacobian_column_indices.resize(number_jacobian_nonzeros);
-      subproblem.compute_constraint_jacobian_sparsity(this->jacobian_row_indices.data(), this->jacobian_column_indices.data(),
+      this->evaluation_space.number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
+      this->evaluation_space.jacobian_row_indices.resize(this->evaluation_space.number_jacobian_nonzeros);
+      this->evaluation_space.jacobian_column_indices.resize(this->evaluation_space.number_jacobian_nonzeros);
+      subproblem.compute_constraint_jacobian_sparsity(this->evaluation_space.jacobian_row_indices.data(), this->evaluation_space.jacobian_column_indices.data(),
          Indexing::C_indexing, MatrixOrder::COLUMN_MAJOR);
 
       // augmented system
-      this->number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-      this->number_matrix_nonzeros = subproblem.number_regularized_augmented_system_nonzeros();
-      this->matrix_row_indices.resize(this->number_matrix_nonzeros);
-      this->matrix_column_indices.resize(this->number_matrix_nonzeros);
+      this->evaluation_space.number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      this->evaluation_space.number_matrix_nonzeros = subproblem.number_regularized_augmented_system_nonzeros();
+      this->evaluation_space.matrix_row_indices.resize(this->evaluation_space.number_matrix_nonzeros);
+      this->evaluation_space.matrix_column_indices.resize(this->evaluation_space.number_matrix_nonzeros);
       // compute the COO sparse representation: use temporary vectors of size_t
-      Vector<size_t> tmp_row_indices(this->number_matrix_nonzeros);
-      Vector<size_t> tmp_column_indices(this->number_matrix_nonzeros);
+      Vector<size_t> tmp_row_indices(this->evaluation_space.number_matrix_nonzeros);
+      Vector<size_t> tmp_column_indices(this->evaluation_space.number_matrix_nonzeros);
       subproblem.compute_regularized_augmented_matrix_sparsity(tmp_row_indices.data(), tmp_column_indices.data(),
-         this->jacobian_row_indices.data(), this->jacobian_column_indices.data(), Indexing::Fortran_indexing);
+         this->evaluation_space.jacobian_row_indices.data(), this->evaluation_space.jacobian_column_indices.data(), Indexing::Fortran_indexing);
       // build vectors of int
-      for (size_t nonzero_index: Range(this->number_matrix_nonzeros)) {
-         this->matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
-         this->matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
+      for (size_t nonzero_index: Range(this->evaluation_space.number_matrix_nonzeros)) {
+         this->evaluation_space.matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
+         this->evaluation_space.matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
       }
-      this->matrix_values.resize(this->number_matrix_nonzeros);
-      this->rhs.resize(dimension);
-      this->solution.resize(dimension);
+      this->evaluation_space.matrix_values.resize(this->evaluation_space.number_matrix_nonzeros);
+      this->evaluation_space.rhs.resize(dimension);
+      this->evaluation_space.solution.resize(dimension);
 
       // workspace
       this->workspace.n = static_cast<int>(dimension);
-      this->workspace.nnz = static_cast<int>(this->number_matrix_nonzeros);
+      this->workspace.nnz = static_cast<int>(this->evaluation_space.number_matrix_nonzeros);
    }
 
    void MUMPSSolver::do_symbolic_analysis() {
       this->workspace.job = MUMPSSolver::JOB_ANALYSIS;
       // connect the local sparsity with the pointers in the workspace
-      this->workspace.irn = this->matrix_row_indices.data();
-      this->workspace.jcn = this->matrix_column_indices.data();
+      this->workspace.irn = this->evaluation_space.matrix_row_indices.data();
+      this->workspace.jcn = this->evaluation_space.matrix_column_indices.data();
       dmumps_c(&this->workspace);
       this->workspace.icntl[7] = 8; // ICNTL(8) = 8: recompute scaling before factorization
    }
@@ -140,27 +140,27 @@ namespace uno {
          const WarmstartInformation& warmstart_information) {
       // evaluate the functions at the current iterate
       if (warmstart_information.objective_changed) {
-         subproblem.evaluate_objective_gradient(this->objective_gradient.data());
+         subproblem.evaluate_objective_gradient(this->evaluation_space.objective_gradient.data());
       }
       if (warmstart_information.constraints_changed) {
-         subproblem.evaluate_constraints(this->constraints);
+         subproblem.evaluate_constraints(this->evaluation_space.constraints);
       }
 
       if (warmstart_information.objective_changed || warmstart_information.constraints_changed) {
          // assemble the augmented matrix
-         subproblem.assemble_augmented_matrix(statistics, this->matrix_values.data());
+         subproblem.assemble_augmented_matrix(statistics, this->evaluation_space.matrix_values.data());
          // regularize the augmented matrix (this calls the analysis and the factorization)
-         subproblem.regularize_augmented_matrix(statistics, this->matrix_values.data(),
+         subproblem.regularize_augmented_matrix(statistics, this->evaluation_space.matrix_values.data(),
             subproblem.dual_regularization_factor(), *this);
 
          // assemble the RHS
-         const COOMatrix jacobian{this->jacobian_row_indices.data(), this->jacobian_column_indices.data(),
-            this->matrix_values.data() + this->number_hessian_nonzeros};
-         subproblem.assemble_augmented_rhs(this->objective_gradient, this->constraints, jacobian, this->rhs);;
+         const COOMatrix jacobian{this->evaluation_space.jacobian_row_indices.data(), this->evaluation_space.jacobian_column_indices.data(),
+            this->evaluation_space.matrix_values.data() + this->evaluation_space.number_hessian_nonzeros};
+         subproblem.assemble_augmented_rhs(this->evaluation_space.objective_gradient, this->evaluation_space.constraints, jacobian, this->evaluation_space.rhs);;
       }
-      this->solve_indefinite_system(this->matrix_values, this->rhs, this->solution);
+      this->solve_indefinite_system(this->evaluation_space.matrix_values, this->evaluation_space.rhs, this->evaluation_space.solution);
       // assemble the full primal-dual direction
-      subproblem.assemble_primal_dual_direction(this->solution, direction);
+      subproblem.assemble_primal_dual_direction(this->evaluation_space.solution, direction);
       if (this->matrix_is_singular()) {
          direction.status = SubproblemStatus::INFEASIBLE;
       }
@@ -193,33 +193,7 @@ namespace uno {
       return this->workspace.n - this->number_zero_eigenvalues();
    }
 
-   void MUMPSSolver::evaluate_constraint_jacobian(const Subproblem& subproblem) {
-      subproblem.evaluate_constraint_jacobian(this->matrix_values.data() + this->number_hessian_nonzeros);
-   }
-
-   void MUMPSSolver::compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      result.fill(0.);
-      const size_t offset = this->number_hessian_nonzeros;
-      for (size_t nonzero_index: Range(this->number_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
-         const double derivative = this->matrix_values[offset + nonzero_index];
-         if (constraint_index < result.size()) {
-            result[constraint_index] += derivative * vector[variable_index];
-         }
-      }
-   }
-
-   void MUMPSSolver::compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const {
-      result.fill(0.);
-      const size_t offset = this->number_hessian_nonzeros;
-      for (size_t nonzero_index: Range(this->number_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
-         const double derivative = this->matrix_values[offset + nonzero_index];
-         if (variable_index < result.size()) {
-            result[variable_index] += derivative * vector[constraint_index];
-         }
-      }
+   EvaluationSpace& MUMPSSolver::get_evaluation_space() {
+      return this->evaluation_space;
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.hpp
@@ -4,9 +4,9 @@
 #ifndef UNO_MUMPSSOLVER_H
 #define UNO_MUMPSSOLVER_H
 
-#include <vector>
 #include "../DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "dmumps_c.h"
+#include "../COOEvaluationSpace.hpp"
 #include "linear_algebra/Vector.hpp"
 
 namespace uno {
@@ -31,30 +31,11 @@ namespace uno {
       [[nodiscard]] bool matrix_is_singular() const override;
       [[nodiscard]] size_t rank() const override;
 
-      void evaluate_constraint_jacobian(const Subproblem& subproblem) override;
-      void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
-      void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const override;
+      [[nodiscard]] EvaluationSpace& get_evaluation_space() override;
 
    protected:
       DMUMPS_STRUC_C workspace{};
-
-      // evaluations
-      Vector<double> objective_gradient; /*!< Sparse Jacobian of the objective */
-      std::vector<double> constraints; /*!< Constraint values (size \f$m)\f$ */
-
-      // Jacobian
-      size_t number_jacobian_nonzeros{};
-      std::vector<size_t> jacobian_row_indices{};
-      std::vector<size_t> jacobian_column_indices{};
-
-      // symmetric matrix (Hessian or augmented system)
-      size_t number_hessian_nonzeros{};
-      size_t number_matrix_nonzeros{};
-      std::vector<int> matrix_row_indices{};
-      std::vector<int> matrix_column_indices{};
-      Vector<double> matrix_values{};
-      Vector<double> rhs{};
-      Vector<double> solution{};
+      COOEvaluationSpace evaluation_space{};
 
       static const int JOB_INIT = -1;
       static const int JOB_END = -2;

--- a/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolver.hpp
@@ -9,6 +9,7 @@
 namespace uno {
    // forward declarations
    class Direction;
+   class EvaluationSpace;
    class Statistics;
    class Subproblem;
    template <typename ElementType>
@@ -29,9 +30,7 @@ namespace uno {
       virtual void solve_indefinite_system(Statistics& statistics, const Subproblem& subproblem, Direction& direction,
          const WarmstartInformation& warmstart_information) = 0;
 
-      virtual void evaluate_constraint_jacobian(const Subproblem& subproblem) = 0;
-      virtual void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;
-      virtual void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;
+      [[nodiscard]] virtual EvaluationSpace& get_evaluation_space() = 0;
    };
 } // namespace
 

--- a/uno/optimization/EvaluationSpace.hpp
+++ b/uno/optimization/EvaluationSpace.hpp
@@ -20,9 +20,6 @@ namespace uno {
       virtual ~EvaluationSpace() = default;
 
       virtual void evaluate_constraint_jacobian(const Subproblem& subproblem) = 0;
-
-      virtual void set_up_linear_system(Statistics& statistics, const Subproblem& subproblem, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         const WarmstartInformation& warmstart_information) = 0;
       virtual void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;
       virtual void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector,
          Vector<double>& result) const = 0;

--- a/uno/optimization/EvaluationSpace.hpp
+++ b/uno/optimization/EvaluationSpace.hpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_EVALUATIONSPACE_H
+#define UNO_EVALUATIONSPACE_H
+
+namespace uno {
+   // forward declaration
+   template <typename ElementType>
+   class DirectSymmetricIndefiniteLinearSolver;
+   class Statistics;
+   class Subproblem;
+   template <typename ElementType>
+   class Vector;
+   class WarmstartInformation;
+
+   class EvaluationSpace {
+   public:
+      EvaluationSpace() = default;
+      virtual ~EvaluationSpace() = default;
+
+      virtual void evaluate_constraint_jacobian(const Subproblem& subproblem) = 0;
+
+      virtual void set_up_linear_system(Statistics& statistics, const Subproblem& subproblem, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
+         const WarmstartInformation& warmstart_information) = 0;
+      virtual void compute_constraint_jacobian_vector_product(const Vector<double>& vector, Vector<double>& result) const = 0;
+      virtual void compute_constraint_jacobian_transposed_vector_product(const Vector<double>& vector,
+         Vector<double>& result) const = 0;
+      [[nodiscard]] virtual double compute_hessian_quadratic_product(const Vector<double>& vector) const = 0;
+   };
+} // namespace
+
+#endif // UNO_EVALUATIONSPACE_H


### PR DESCRIPTION
Introduce evaluation spaces for subproblem solvers:
- MA57, MA27 and MUMPS use `COOEvaluationSpace`
- BQPD uses `BQPDEvaluationSpace`
- HiGHS uses `HiGHSEvaluationSpace`

These objects are responsible for declaring the types of vectors and matrices used by the subproblem solvers, and provide functions for evaluating the Jacobian, and computing the Jacobian(^T)-vector products and the Hessian quadratic product.