### PR TITLE
Use int* instead of size_t* to store sparsity

### DIFF
--- a/bindings/AMPL/AMPLModel.cpp
+++ b/bindings/AMPL/AMPLModel.cpp
@@ -115,7 +115,7 @@ namespace uno {
       gradient.scale(this->objective_sign);
    }
 
-   void AMPLModel::compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+   void AMPLModel::compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const {
       // by default, AMPLModel computes the Jacobian in a column-wise order (variable by variable).
       // if a row-wise evaluation is wished, modify the goff fields of the ASL "Cgrad" structures
@@ -131,29 +131,27 @@ namespace uno {
          }
       }
 
-      size_t current_index = 0;
       for (size_t constraint_index: Range(this->number_constraints)) {
          cgrad* constraint_gradient = this->asl->i.Cgrad_[constraint_index];
          while (constraint_gradient != nullptr) {
-            const size_t variable_index = static_cast<size_t>(constraint_gradient->varno);
+            const int variable_index = constraint_gradient->varno;
             // at the moment, the Jacobian is stored column-wise (that is, ordered by variables)
-            row_indices[constraint_gradient->goff] = constraint_index + solver_indexing;
+            row_indices[constraint_gradient->goff] = static_cast<int>(constraint_index) + solver_indexing;
             column_indices[constraint_gradient->goff] = variable_index + solver_indexing;
             constraint_gradient = constraint_gradient->next;
-            ++current_index;
          }
       }
    }
 
-   void AMPLModel::compute_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const {
+   void AMPLModel::compute_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const {
       const fint* asl_column_start = this->asl->i.sputinfo_->hcolstarts;
       const fint* asl_row_index = this->asl->i.sputinfo_->hrownos;
       size_t current_index = 0;
       for (size_t column_index: Range(this->number_variables)) {
          for (size_t nonzero_index: Range(static_cast<size_t>(asl_column_start[column_index]), static_cast<size_t>(asl_column_start[column_index + 1]))) {
-            const size_t row_index = static_cast<size_t>(asl_row_index[nonzero_index]);
+            const int row_index = asl_row_index[nonzero_index];
             row_indices[current_index] = row_index + solver_indexing;
-            column_indices[current_index] = column_index + solver_indexing;
+            column_indices[current_index] = static_cast<int>(column_index) + solver_indexing;
             ++current_index;
          }
       }

--- a/bindings/AMPL/AMPLModel.hpp
+++ b/bindings/AMPL/AMPLModel.hpp
@@ -33,9 +33,9 @@ namespace uno {
       void evaluate_objective_gradient(const Vector<double>& x, Vector<double>& gradient) const override;
 
       // structures of Jacobian and Hessian
-      void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const override;
-      void compute_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const override;
+      void compute_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const override;
 
       // numerical evaluations of Jacobian and Hessian
       void evaluate_constraint_jacobian(const Vector<double>& x, double* jacobian_values) const override;

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.cpp
@@ -103,40 +103,40 @@ namespace uno {
       return number_nonzeros;
    }
 
-   void l1RelaxedProblem::compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+   void l1RelaxedProblem::compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const {
       this->model.compute_constraint_jacobian_sparsity(row_indices, column_indices, solver_indexing, matrix_order);
 
       // add the contribution of the elastic variables
-      size_t elastic_index = this->model.number_variables;
+      int elastic_index = static_cast<int>(this->model.number_variables);
       size_t current_index = this->model.number_jacobian_nonzeros();
       for (size_t inequality_index: this->model.get_inequality_constraints()) {
-         row_indices[current_index] = inequality_index + solver_indexing;
+         row_indices[current_index] = static_cast<int>(inequality_index) + solver_indexing;
          column_indices[current_index] = elastic_index + solver_indexing;
          ++elastic_index;
          ++current_index;
       }
       for (size_t equality_index: this->model.get_equality_constraints()) {
-         row_indices[current_index] = equality_index + solver_indexing;
+         row_indices[current_index] = static_cast<int>(equality_index) + solver_indexing;
          column_indices[current_index] = elastic_index + solver_indexing;
          ++current_index;
-         row_indices[current_index] = equality_index + solver_indexing;
+         row_indices[current_index] = static_cast<int>(equality_index) + solver_indexing;
          column_indices[current_index] = elastic_index + 1 + solver_indexing;
          elastic_index += 2;
          ++current_index;
       }
    }
 
-   void l1RelaxedProblem::compute_hessian_sparsity(const HessianModel& hessian_model, size_t* row_indices,
-         size_t* column_indices, size_t solver_indexing) const {
+   void l1RelaxedProblem::compute_hessian_sparsity(const HessianModel& hessian_model, int* row_indices,
+         int* column_indices, int solver_indexing) const {
       hessian_model.compute_sparsity(this->model, row_indices, column_indices, solver_indexing);
 
       // diagonal proximal contribution
       if (this->proximal_center != nullptr && this->proximal_coefficient != 0.) {
          size_t current_index = hessian_model.number_nonzeros(this->model);
          for (size_t variable_index: Range(this->model.number_variables)) {
-            row_indices[current_index] = variable_index + solver_indexing;
-            column_indices[current_index] = variable_index + solver_indexing;
+            row_indices[current_index] = static_cast<int>(variable_index) + solver_indexing;
+            column_indices[current_index] = static_cast<int>(variable_index) + solver_indexing;
             ++current_index;
          }
       }

--- a/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/l1RelaxedProblem.hpp
@@ -26,10 +26,10 @@ namespace uno {
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;
       [[nodiscard]] bool has_curvature(const HessianModel& hessian_model) const override;
       [[nodiscard]] size_t number_hessian_nonzeros(const HessianModel& hessian_model) const override;
-      void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const override;
-      void compute_hessian_sparsity(const HessianModel& hessian_model, size_t* row_indices,
-         size_t* column_indices, size_t solver_indexing) const override;
+      void compute_hessian_sparsity(const HessianModel& hessian_model, int* row_indices,
+         int* column_indices, int solver_indexing) const override;
 
       // numerical evaluations of Jacobian and Hessian
       void evaluate_constraint_jacobian(Iterate& iterate, double* jacobian_values) const override;

--- a/uno/ingredients/hessian_models/ExactHessian.cpp
+++ b/uno/ingredients/hessian_models/ExactHessian.cpp
@@ -24,7 +24,7 @@ namespace uno {
       return model.number_hessian_nonzeros();
    }
 
-   void ExactHessian::compute_sparsity(const Model& model, size_t* row_indices, size_t* column_indices, size_t solver_indexing) const {
+   void ExactHessian::compute_sparsity(const Model& model, int* row_indices, int* column_indices, int solver_indexing) const {
       // Hessian sparsity of the model
       model.compute_hessian_sparsity(row_indices, column_indices, solver_indexing);
    }

--- a/uno/ingredients/hessian_models/ExactHessian.hpp
+++ b/uno/ingredients/hessian_models/ExactHessian.hpp
@@ -13,7 +13,7 @@ namespace uno {
       [[nodiscard]] bool has_explicit_representation() const override;
       [[nodiscard]] bool has_curvature(const Model& model) const override;
       [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
-      void compute_sparsity(const Model& model, size_t* row_indices, size_t* column_indices, size_t solver_indexing) const override;
+      void compute_sparsity(const Model& model, int* row_indices, int* column_indices, int solver_indexing) const override;
       [[nodiscard]] bool is_positive_definite() const override;
 
       void initialize(const Model& model) override;

--- a/uno/ingredients/hessian_models/HessianModel.hpp
+++ b/uno/ingredients/hessian_models/HessianModel.hpp
@@ -25,7 +25,7 @@ namespace uno {
       [[nodiscard]] virtual bool has_explicit_representation() const = 0;
       [[nodiscard]] virtual bool has_curvature(const Model& model) const = 0;
       [[nodiscard]] virtual size_t number_nonzeros(const Model& model) const = 0;
-      virtual void compute_sparsity(const Model& model, size_t* row_indices, size_t* column_indices, size_t solver_indexing) const = 0;
+      virtual void compute_sparsity(const Model& model, int* row_indices, int* column_indices, int solver_indexing) const = 0;
       [[nodiscard]] virtual bool is_positive_definite() const = 0;
 
       virtual void initialize(const Model& model) = 0;

--- a/uno/ingredients/hessian_models/IdentityHessian.cpp
+++ b/uno/ingredients/hessian_models/IdentityHessian.cpp
@@ -23,11 +23,11 @@ namespace uno {
       return model.number_variables;
    }
 
-   void IdentityHessian::compute_sparsity(const Model& model, size_t* row_indices, size_t* column_indices, size_t solver_indexing) const {
+   void IdentityHessian::compute_sparsity(const Model& model, int* row_indices, int* column_indices, int solver_indexing) const {
       // diagonal structure
       for (size_t variable_index: Range(model.number_variables)) {
-         row_indices[variable_index] = variable_index + solver_indexing;
-         column_indices[variable_index] = variable_index + solver_indexing;
+         row_indices[variable_index] = static_cast<int>(variable_index) + solver_indexing;
+         column_indices[variable_index] = static_cast<int>(variable_index) + solver_indexing;
       }
    }
 

--- a/uno/ingredients/hessian_models/IdentityHessian.hpp
+++ b/uno/ingredients/hessian_models/IdentityHessian.hpp
@@ -15,7 +15,7 @@ namespace uno {
       [[nodiscard]] bool has_explicit_representation() const override;
       [[nodiscard]] bool has_curvature(const Model& model) const override;
       [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
-      void compute_sparsity(const Model& model, size_t* row_indices, size_t* column_indices, size_t solver_indexing) const override;
+      void compute_sparsity(const Model& model, int* row_indices, int* column_indices, int solver_indexing) const override;
       [[nodiscard]] bool is_positive_definite() const override;
 
       void initialize(const Model& model) override;

--- a/uno/ingredients/hessian_models/ZeroHessian.cpp
+++ b/uno/ingredients/hessian_models/ZeroHessian.cpp
@@ -22,8 +22,8 @@ namespace uno {
       return 0;
    }
 
-   void ZeroHessian::compute_sparsity(const Model& /*model*/, size_t* /*row_indices*/, size_t* /*column_indices*/,
-         size_t /*solver_indexing*/) const {
+   void ZeroHessian::compute_sparsity(const Model& /*model*/, int* /*row_indices*/, int* /*column_indices*/,
+         int /*solver_indexing*/) const {
       // empty structure
    }
 

--- a/uno/ingredients/hessian_models/ZeroHessian.hpp
+++ b/uno/ingredients/hessian_models/ZeroHessian.hpp
@@ -15,7 +15,7 @@ namespace uno {
       [[nodiscard]] bool has_explicit_representation() const override;
       [[nodiscard]] bool has_curvature(const Model& model) const override;
       [[nodiscard]] size_t number_nonzeros(const Model& model) const override;
-      void compute_sparsity(const Model& model, size_t* row_indices, size_t* column_indices, size_t solver_indexing) const override;
+      void compute_sparsity(const Model& model, int* row_indices, int* column_indices, int solver_indexing) const override;
       [[nodiscard]] bool is_positive_definite() const override;
 
       void initialize(const Model& model) override;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.cpp
@@ -49,13 +49,13 @@ namespace uno {
       }
    }
 
-   void PrimalDualInteriorPointProblem::compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices,
-         size_t solver_indexing, MatrixOrder matrix_order) const {
+   void PrimalDualInteriorPointProblem::compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices,
+         int solver_indexing, MatrixOrder matrix_order) const {
       this->first_reformulation.compute_constraint_jacobian_sparsity(row_indices, column_indices, solver_indexing, matrix_order);
    }
 
-   void PrimalDualInteriorPointProblem::compute_hessian_sparsity(const HessianModel& hessian_model, size_t* row_indices,
-         size_t* column_indices, size_t solver_indexing) const {
+   void PrimalDualInteriorPointProblem::compute_hessian_sparsity(const HessianModel& hessian_model, int* row_indices,
+         int* column_indices, int solver_indexing) const {
       // original Lagrangian Hessian
       this->first_reformulation.compute_hessian_sparsity(hessian_model, row_indices, column_indices, solver_indexing);
 
@@ -65,8 +65,8 @@ namespace uno {
          const bool finite_lower_bound = is_finite(this->first_reformulation.variable_lower_bound(variable_index));
          const bool finite_upper_bound = is_finite(this->first_reformulation.variable_upper_bound(variable_index));
          if (finite_lower_bound || finite_upper_bound) {
-            row_indices[current_index] = variable_index + solver_indexing;
-            column_indices[current_index] = variable_index + solver_indexing;
+            row_indices[current_index] = static_cast<int>(variable_index) + solver_indexing;
+            column_indices[current_index] = static_cast<int>(variable_index) + solver_indexing;
             ++current_index;
          }
       }

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/PrimalDualInteriorPointProblem.hpp
@@ -24,10 +24,10 @@ namespace uno {
 
       // sparsity patterns of Jacobian and Hessian
 
-      void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const override;
-      void compute_hessian_sparsity(const HessianModel& hessian_model, size_t* row_indices,
-         size_t* column_indices, size_t solver_indexing) const override;
+      void compute_hessian_sparsity(const HessianModel& hessian_model, int* row_indices,
+         int* column_indices, int solver_indexing) const override;
 
       // numerical evaluations of Jacobian and Hessian
       [[nodiscard]] size_t number_jacobian_nonzeros() const override;

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -33,11 +33,11 @@ namespace uno {
          RegularizationStrategy<double>& regularization_strategy, double trust_region_radius);
 
       // sparsity patterns
-      void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const;
-      void compute_regularized_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const;
-      void compute_regularized_augmented_matrix_sparsity(size_t* row_indices, size_t* column_indices, const size_t* jacobian_row_indices,
-         const size_t* jacobian_column_indices, size_t solver_indexing) const;
+      void compute_regularized_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const;
+      void compute_regularized_augmented_matrix_sparsity(int* row_indices, int* column_indices, const int* jacobian_row_indices,
+         const int* jacobian_column_indices, int solver_indexing) const;
 
       // regularized Hessian
       void evaluate_lagrangian_hessian(Statistics& statistics, double* hessian_values) const;

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -100,7 +100,8 @@ namespace uno {
       // Jacobian
       for (size_t nonzero_index: Range(this->number_jacobian_nonzeros())) {
          const auto [constraint_index, variable_index, derivative] = constraint_jacobian[nonzero_index];
-         rhs[variable_index] += this->current_iterate.multipliers.constraints[constraint_index] * derivative;
+         rhs[static_cast<size_t>(variable_index)] +=
+            this->current_iterate.multipliers.constraints[static_cast<size_t>(constraint_index)] * derivative;
       }
       // constraints
       for (size_t constraint_index: Range(this->number_constraints)) {

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp
@@ -45,8 +45,8 @@ namespace uno {
       result.fill(0.);
       const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
       for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const size_t constraint_index = static_cast<size_t>(this->jacobian_row_indices[nonzero_index]);
+         const size_t variable_index = static_cast<size_t>(this->jacobian_column_indices[nonzero_index]);
          const double derivative = this->jacobian_values[nonzero_index];
 
          // a safeguard to make sure we take only the correct part of the Jacobian
@@ -60,8 +60,8 @@ namespace uno {
       result.fill(0.);
       const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
       for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const size_t constraint_index = static_cast<size_t>(this->jacobian_row_indices[nonzero_index]);
+         const size_t variable_index = static_cast<size_t>(this->jacobian_column_indices[nonzero_index]);
          const double derivative = this->jacobian_values[nonzero_index];
          assert(constraint_index < vector.size());
          assert(variable_index < result.size());

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp
@@ -74,8 +74,8 @@ namespace uno {
       double quadratic_product = 0.;
       const size_t number_hessian_nonzeros = this->hessian_values.size();
       for (size_t nonzero_index: Range(number_hessian_nonzeros)) {
-         const size_t row_index = this->hessian_row_indices[nonzero_index];
-         const size_t column_index = this->hessian_column_indices[nonzero_index];
+         const size_t row_index = static_cast<size_t>(this->hessian_row_indices[nonzero_index]);
+         const size_t column_index = static_cast<size_t>(this->hessian_column_indices[nonzero_index]);
          const double entry = this->hessian_values[nonzero_index];
          assert(row_index < vector.size());
          assert(column_index < vector.size());
@@ -139,26 +139,27 @@ namespace uno {
       );
 
       // copy the COO format into BQPD's CSR format
-      size_t current_constraint = 0;
+      int current_constraint = 0;
       for (size_t jacobian_nonzero_index: Range(number_jacobian_nonzeros)) {
          const size_t permutated_nonzero_index = this->permutation_vector[jacobian_nonzero_index];
          // variable index
-         const size_t variable_index = this->jacobian_column_indices[permutated_nonzero_index];
-         this->gradient_sparsity[1 + subproblem.number_variables + jacobian_nonzero_index] =
-            static_cast<int>(variable_index + Indexing::Fortran_indexing);
+         const int variable_index = this->jacobian_column_indices[permutated_nonzero_index];
+         this->gradient_sparsity[1 + subproblem.number_variables + jacobian_nonzero_index] = variable_index +
+            Indexing::Fortran_indexing;
 
          // constraint index
-         const size_t constraint_index = this->jacobian_row_indices[permutated_nonzero_index];
+         const int constraint_index = this->jacobian_row_indices[permutated_nonzero_index];
          assert(current_constraint <= constraint_index);
          while (current_constraint < constraint_index) {
             ++current_constraint;
-            this->gradient_sparsity[1 + subproblem.number_variables + number_jacobian_nonzeros + 1 + current_constraint] =
-               static_cast<int>(subproblem.number_variables + jacobian_nonzero_index + Indexing::Fortran_indexing);
+            this->gradient_sparsity[1 + subproblem.number_variables + number_jacobian_nonzeros + 1 +
+               static_cast<size_t>(current_constraint)] = static_cast<int>(subproblem.number_variables +
+                  jacobian_nonzero_index) + Indexing::Fortran_indexing;
          }
       }
       // since there cannot be empty rows, we don't need to loop over empty rows like we do for the HiGHS Hessian
       this->gradient_sparsity[1 + subproblem.number_variables + number_jacobian_nonzeros + 1 + subproblem.number_constraints] =
-         static_cast<int>(subproblem.number_variables + number_jacobian_nonzeros + Indexing::Fortran_indexing);
+         static_cast<int>(subproblem.number_variables + number_jacobian_nonzeros) + Indexing::Fortran_indexing;
 
       // the Jacobian will be evaluated in this vector, and copied with permutation into this->gradients
       this->jacobian_values.resize(number_jacobian_nonzeros);

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.hpp
@@ -33,13 +33,13 @@ namespace uno {
       Vector<double> gradients{};
       Vector<int> gradient_sparsity{};
       // COO constraint Jacobian
-      Vector<size_t> jacobian_row_indices{};
-      Vector<size_t> jacobian_column_indices{};
+      Vector<int> jacobian_row_indices{};
+      Vector<int> jacobian_column_indices{};
       Vector<double> jacobian_values{};
       Vector<size_t> permutation_vector{};
       // COO Hessian
-      Vector<size_t> hessian_row_indices{};
-      Vector<size_t> hessian_column_indices{};
+      Vector<int> hessian_row_indices{};
+      Vector<int> hessian_column_indices{};
       Vector<double> hessian_values{};
       bool evaluate_hessian{false};
 

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -330,8 +330,8 @@ void hessian_vector_product(int* dimension, const double vector[], const double 
    bool* evaluate_hessian = uno::retrieve_pointer<bool>(0, lws);
    uno::Statistics* statistics = uno::retrieve_pointer<uno::Statistics>(1, lws);
    uno::Subproblem* subproblem = uno::retrieve_pointer<uno::Subproblem>(2, lws);
-   uno::Vector<size_t>* hessian_row_indices = uno::retrieve_pointer<uno::Vector<size_t>>(3, lws);
-   uno::Vector<size_t>* hessian_column_indices = uno::retrieve_pointer<uno::Vector<size_t>>(4, lws);
+   uno::Vector<int>* hessian_row_indices = uno::retrieve_pointer<uno::Vector<int>>(3, lws);
+   uno::Vector<int>* hessian_column_indices = uno::retrieve_pointer<uno::Vector<int>>(4, lws);
    uno::Vector<double>* hessian_values = uno::retrieve_pointer<uno::Vector<double>>(5, lws);
    assert(evaluate_hessian != nullptr);
    assert(statistics != nullptr);
@@ -354,8 +354,8 @@ void hessian_vector_product(int* dimension, const double vector[], const double 
       }
       // Hessian-vector product
       for (size_t nonzero_index: uno::Range(subproblem->number_regularized_hessian_nonzeros())) {
-         const size_t row_index = (*hessian_row_indices)[nonzero_index];
-         const size_t column_index = (*hessian_column_indices)[nonzero_index];
+         const size_t row_index = static_cast<size_t>((*hessian_row_indices)[nonzero_index]);
+         const size_t column_index = static_cast<size_t>((*hessian_column_indices)[nonzero_index]);
          const double entry = (*hessian_values)[nonzero_index];
          result[row_index] += entry * vector[column_index];
          if (row_index != column_index) {

--- a/uno/ingredients/subproblem_solvers/COOEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/COOEvaluationSpace.cpp
@@ -17,15 +17,9 @@ namespace uno {
       this->number_matrix_nonzeros = subproblem.number_regularized_hessian_nonzeros();
       this->matrix_row_indices.resize(this->number_matrix_nonzeros);
       this->matrix_column_indices.resize(this->number_matrix_nonzeros);
-      // compute the COO sparse representation: use temporary vectors of size_t
-      Vector<size_t> tmp_row_indices(this->number_matrix_nonzeros);
-      Vector<size_t> tmp_column_indices(this->number_matrix_nonzeros);
-      subproblem.compute_regularized_hessian_sparsity(tmp_row_indices.data(), tmp_column_indices.data(), Indexing::Fortran_indexing);
-      // build vectors of int
-      for (size_t nonzero_index: Range(this->number_matrix_nonzeros)) {
-         this->matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
-         this->matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
-      }
+      // compute the COO sparse representation
+      subproblem.compute_regularized_hessian_sparsity(this->matrix_row_indices.data(), this->matrix_column_indices.data(),
+         Indexing::Fortran_indexing);
       this->matrix_values.resize(this->number_matrix_nonzeros);
       this->rhs.resize(dimension);
       this->solution.resize(dimension);
@@ -50,16 +44,9 @@ const size_t dimension = subproblem.number_variables + subproblem.number_constra
       this->number_matrix_nonzeros = subproblem.number_regularized_augmented_system_nonzeros();
       this->matrix_row_indices.resize(this->number_matrix_nonzeros);
       this->matrix_column_indices.resize(this->number_matrix_nonzeros);
-      // compute the COO sparse representation: use temporary vectors of size_t
-      Vector<size_t> tmp_row_indices(this->number_matrix_nonzeros);
-      Vector<size_t> tmp_column_indices(this->number_matrix_nonzeros);
-      subproblem.compute_regularized_augmented_matrix_sparsity(tmp_row_indices.data(), tmp_column_indices.data(),
+      // compute the COO sparse representation
+      subproblem.compute_regularized_augmented_matrix_sparsity(this->matrix_row_indices.data(), this->matrix_column_indices.data(),
          this->jacobian_row_indices.data(), this->jacobian_column_indices.data(), Indexing::Fortran_indexing);
-      // build vectors of int
-      for (size_t nonzero_index: Range(this->number_matrix_nonzeros)) {
-         this->matrix_row_indices[nonzero_index] = static_cast<int>(tmp_row_indices[nonzero_index]);
-         this->matrix_column_indices[nonzero_index] = static_cast<int>(tmp_column_indices[nonzero_index]);
-      }
       this->matrix_values.resize(this->number_matrix_nonzeros);
       this->rhs.resize(dimension);
       this->solution.resize(dimension);
@@ -73,8 +60,8 @@ const size_t dimension = subproblem.number_variables + subproblem.number_constra
       result.fill(0.);
       const size_t offset = this->number_hessian_nonzeros;
       for (size_t nonzero_index: Range(this->number_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const size_t constraint_index = static_cast<size_t>(this->jacobian_row_indices[nonzero_index]);
+         const size_t variable_index = static_cast<size_t>(this->jacobian_column_indices[nonzero_index]);
          const double derivative = this->matrix_values[offset + nonzero_index];
 
          if (constraint_index < result.size() && variable_index < vector.size()) {
@@ -87,8 +74,8 @@ const size_t dimension = subproblem.number_variables + subproblem.number_constra
       result.fill(0.);
       const size_t offset = this->number_hessian_nonzeros;
       for (size_t nonzero_index: Range(this->number_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const size_t constraint_index = static_cast<size_t>(this->jacobian_row_indices[nonzero_index]);
+         const size_t variable_index = static_cast<size_t>(this->jacobian_column_indices[nonzero_index]);
          const double derivative = this->matrix_values[offset + nonzero_index];
 
          if (variable_index < result.size() && constraint_index < vector.size()) {

--- a/uno/ingredients/subproblem_solvers/COOEvaluationSpace.hpp
+++ b/uno/ingredients/subproblem_solvers/COOEvaluationSpace.hpp
@@ -32,8 +32,8 @@ namespace uno {
 
       // Jacobian
       size_t number_jacobian_nonzeros{};
-      std::vector<size_t> jacobian_row_indices{};
-      std::vector<size_t> jacobian_column_indices{};
+      std::vector<int> jacobian_row_indices{};
+      std::vector<int> jacobian_column_indices{};
 
       // symmetric matrix (Hessian or augmented system)
       size_t number_hessian_nonzeros{};

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.cpp
@@ -39,18 +39,18 @@ namespace uno {
       this->model.lp_.a_matrix_.index_.resize(number_jacobian_nonzeros); // constraint indices
       this->model.lp_.a_matrix_.start_.resize(subproblem.number_variables + 1);
       this->model.lp_.a_matrix_.value_.resize(number_jacobian_nonzeros);
-      size_t current_variable = 0;
+      int current_variable = 0;
       for (size_t jacobian_nonzero_index: Range(number_jacobian_nonzeros)) {
          // constraint index is used as is
-         const size_t constraint_index = this->jacobian_row_indices[jacobian_nonzero_index];
-         this->model.lp_.a_matrix_.index_[jacobian_nonzero_index] = static_cast<HighsInt>(constraint_index);
+         const HighsInt constraint_index = static_cast<HighsInt>(this->jacobian_row_indices[jacobian_nonzero_index]);
+         this->model.lp_.a_matrix_.index_[jacobian_nonzero_index] = constraint_index;
 
          // variable index is used to build the pointers to the column starts
-         const size_t variable_index = this->jacobian_column_indices[jacobian_nonzero_index];
+         const int variable_index = this->jacobian_column_indices[jacobian_nonzero_index];
          assert(current_variable <= variable_index);
          while (current_variable < variable_index) {
             ++current_variable;
-            this->model.lp_.a_matrix_.start_[current_variable] = static_cast<HighsInt>(jacobian_nonzero_index);
+            this->model.lp_.a_matrix_.start_[static_cast<size_t>(current_variable)] = static_cast<HighsInt>(jacobian_nonzero_index);
          }
       }
       this->model.lp_.a_matrix_.start_[subproblem.number_variables] = static_cast<HighsInt>(number_jacobian_nonzeros);
@@ -67,8 +67,8 @@ namespace uno {
       result.fill(0.);
       const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
       for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const size_t constraint_index = static_cast<size_t>(this->jacobian_row_indices[nonzero_index]);
+         const size_t variable_index = static_cast<size_t>(this->jacobian_column_indices[nonzero_index]);
          const double derivative = this->model.lp_.a_matrix_.value_[nonzero_index];
 
          // a safeguard to make sure we take only the correct part of the Jacobian
@@ -96,8 +96,8 @@ namespace uno {
       double quadratic_product = 0.;
       const size_t number_hessian_nonzeros = this->hessian_values.size();
       for (size_t nonzero_index: Range(number_hessian_nonzeros)) {
-         const size_t row_index = this->hessian_row_indices[nonzero_index];
-         const size_t column_index = this->hessian_column_indices[nonzero_index];
+         const size_t row_index = static_cast<size_t>(this->hessian_row_indices[nonzero_index]);
+         const size_t column_index = static_cast<size_t>(this->hessian_column_indices[nonzero_index]);
          const double entry = this->hessian_values[nonzero_index];
          assert(row_index < vector.size());
          assert(column_index < vector.size());
@@ -168,25 +168,25 @@ namespace uno {
 
       // copy the COO format into HiGHS' CSC format
       this->model.hessian_.start_[0] = 0;
-      size_t current_column = 0;
+      int current_column = 0;
       for (size_t hessian_nonzero_index: Range(number_regularized_hessian_nonzeros)) {
          const size_t permutated_nonzero_index = this->permutation_vector[hessian_nonzero_index];
          // row index
-         const size_t row_index = this->hessian_row_indices[permutated_nonzero_index];
-         this->model.hessian_.index_[hessian_nonzero_index] = static_cast<HighsInt>(row_index);
+         const HighsInt row_index = static_cast<HighsInt>(this->hessian_row_indices[permutated_nonzero_index]);
+         this->model.hessian_.index_[hessian_nonzero_index] = row_index;
 
          // column index
-         const size_t column_index = this->hessian_column_indices[permutated_nonzero_index];
+         const int column_index = this->hessian_column_indices[permutated_nonzero_index];
          assert(current_column <= column_index);
          while (current_column < column_index) {
             ++current_column;
-            this->model.hessian_.start_[current_column] = static_cast<HighsInt>(hessian_nonzero_index);
+            this->model.hessian_.start_[static_cast<size_t>(current_column)] = static_cast<HighsInt>(hessian_nonzero_index);
          }
       }
       // fill the remaining empty columns
-      while (current_column < subproblem.number_variables) {
+      while (current_column < static_cast<int>(subproblem.number_variables)) {
          ++current_column;
-         this->model.hessian_.start_[current_column] = static_cast<HighsInt>(number_regularized_hessian_nonzeros);
+         this->model.hessian_.start_[static_cast<size_t>(current_column)] = static_cast<HighsInt>(number_regularized_hessian_nonzeros);
       }
 
       // the Hessian will be evaluated in this vector, and copied with permutation into this->model.hessian_.value_

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.cpp
@@ -82,8 +82,8 @@ namespace uno {
       result.fill(0.);
       const size_t number_constraint_jacobian_nonzeros = this->jacobian_row_indices.size();
       for (size_t nonzero_index: Range(number_constraint_jacobian_nonzeros)) {
-         const size_t constraint_index = this->jacobian_row_indices[nonzero_index];
-         const size_t variable_index = this->jacobian_column_indices[nonzero_index];
+         const size_t constraint_index = static_cast<size_t>(this->jacobian_row_indices[nonzero_index]);
+         const size_t variable_index = static_cast<size_t>(this->jacobian_column_indices[nonzero_index]);
          const double derivative = this->model.lp_.a_matrix_.value_[nonzero_index];
          assert(constraint_index < vector.size());
          assert(variable_index < result.size());

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSEvaluationSpace.hpp
@@ -35,11 +35,11 @@ namespace uno {
       std::vector<double> constraints{};
       Vector<double> linear_objective{};
       // constraint Jacobian in COO format
-      Vector<size_t> jacobian_row_indices{};
-      Vector<size_t> jacobian_column_indices{};
+      Vector<int> jacobian_row_indices{};
+      Vector<int> jacobian_column_indices{};
       // Lagrangian Hessian in COO format
-      Vector<size_t> hessian_row_indices{};
-      Vector<size_t> hessian_column_indices{};
+      Vector<int> hessian_row_indices{};
+      Vector<int> hessian_column_indices{};
       Vector<double> hessian_values{};
       Vector<size_t> permutation_vector{};
 

--- a/uno/linear_algebra/Indexing.hpp
+++ b/uno/linear_algebra/Indexing.hpp
@@ -6,8 +6,8 @@
 
 namespace uno {
    struct Indexing {
-      static constexpr size_t C_indexing = 0;
-      static constexpr size_t Fortran_indexing = 1;
+      static constexpr int C_indexing = 0;
+      static constexpr int Fortran_indexing = 1;
    };
 } // namespace
 

--- a/uno/model/BoundRelaxedModel.hpp
+++ b/uno/model/BoundRelaxedModel.hpp
@@ -27,12 +27,12 @@ namespace uno {
       }
 
       // sparsity patterns of Jacobian and Hessian
-      void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
             MatrixOrder matrix_order) const override {
          this->model->compute_constraint_jacobian_sparsity(row_indices, column_indices, solver_indexing, matrix_order);
       }
 
-      void compute_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const override {
+      void compute_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const override {
          this->model->compute_hessian_sparsity(row_indices, column_indices, solver_indexing);
       }
 

--- a/uno/model/FixedBoundsConstraintsModel.cpp
+++ b/uno/model/FixedBoundsConstraintsModel.cpp
@@ -47,23 +47,23 @@ namespace uno {
       this->model->evaluate_objective_gradient(x, gradient);
    }
 
-   void FixedBoundsConstraintsModel::compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices,
-         size_t solver_indexing, MatrixOrder matrix_order) const {
+   void FixedBoundsConstraintsModel::compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices,
+         int solver_indexing, MatrixOrder matrix_order) const {
       // original constraints
       this->model->compute_constraint_jacobian_sparsity(row_indices, column_indices, solver_indexing, matrix_order);
 
       // fixed variables (as linear constraints)
-      size_t constraint_index = this->model->number_constraints;
+      int constraint_index = static_cast<int>(this->model->number_constraints);
       size_t current_index = this->model->number_jacobian_nonzeros();
       for (size_t fixed_variable_index: this->model->get_fixed_variables()) {
          row_indices[current_index] = constraint_index + solver_indexing;
-         column_indices[current_index] = fixed_variable_index + solver_indexing;
+         column_indices[current_index] = static_cast<int>(fixed_variable_index) + solver_indexing;
          ++constraint_index;
          ++current_index;
       }
    }
 
-   void FixedBoundsConstraintsModel::compute_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const {
+   void FixedBoundsConstraintsModel::compute_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const {
       this->model->compute_hessian_sparsity(row_indices, column_indices, solver_indexing);
    }
 

--- a/uno/model/FixedBoundsConstraintsModel.hpp
+++ b/uno/model/FixedBoundsConstraintsModel.hpp
@@ -30,9 +30,9 @@ namespace uno {
       void evaluate_objective_gradient(const Vector<double>& x, Vector<double>& gradient) const override;
 
       // sparsity patterns of Jacobian and Hessian
-      void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const override;
-      void compute_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const override;
+      void compute_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const override;
 
       // numerical evaluations of Jacobian and Hessian
       void evaluate_constraint_jacobian(const Vector<double>& x, double* jacobian_values) const override;

--- a/uno/model/HomogeneousEqualityConstrainedModel.cpp
+++ b/uno/model/HomogeneousEqualityConstrainedModel.cpp
@@ -73,20 +73,20 @@ namespace uno {
       this->model->evaluate_objective_gradient(x, gradient);
    }
 
-   void HomogeneousEqualityConstrainedModel::compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices,
-         size_t solver_indexing, MatrixOrder matrix_order) const {
+   void HomogeneousEqualityConstrainedModel::compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices,
+         int solver_indexing, MatrixOrder matrix_order) const {
       this->model->compute_constraint_jacobian_sparsity(row_indices, column_indices, solver_indexing, matrix_order);
 
       // add the slack contributions
       size_t nonzero_index = this->model->number_jacobian_nonzeros();
       for (const auto [constraint_index, slack_index]: this->get_slacks()) {
-         row_indices[nonzero_index] = constraint_index + solver_indexing;
-         column_indices[nonzero_index] = slack_index + solver_indexing;
+         row_indices[nonzero_index] = static_cast<int>(constraint_index) + solver_indexing;
+         column_indices[nonzero_index] = static_cast<int>(slack_index) + solver_indexing;
          ++nonzero_index;
       }
    }
 
-   void HomogeneousEqualityConstrainedModel::compute_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const {
+   void HomogeneousEqualityConstrainedModel::compute_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const {
       this->model->compute_hessian_sparsity(row_indices, column_indices, solver_indexing);
    }
 

--- a/uno/model/HomogeneousEqualityConstrainedModel.hpp
+++ b/uno/model/HomogeneousEqualityConstrainedModel.hpp
@@ -27,9 +27,9 @@ namespace uno {
       void evaluate_objective_gradient(const Vector<double>& x, Vector<double>& gradient) const override;
 
       // sparsity patterns of Jacobian and Hessian
-      void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const override;
-      void compute_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const override;
+      void compute_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const override;
 
       // numerical evaluations of Jacobian and Hessian
       void evaluate_constraint_jacobian(const Vector<double>& x, double* jacobian_values) const override;

--- a/uno/model/Model.hpp
+++ b/uno/model/Model.hpp
@@ -43,9 +43,9 @@ namespace uno {
       virtual void evaluate_objective_gradient(const Vector<double>& x, Vector<double>& gradient) const = 0;
 
       // sparsity patterns of Jacobian and Hessian
-      virtual void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      virtual void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_format) const = 0;
-      virtual void compute_hessian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing) const = 0;
+      virtual void compute_hessian_sparsity(int* row_indices, int* column_indices, int solver_indexing) const = 0;
 
       // numerical evaluations of Jacobian and Hessian
       virtual void evaluate_constraint_jacobian(const Vector<double>& x, double* jacobian_values) const = 0;

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -49,13 +49,13 @@ namespace uno {
       return hessian_model.number_nonzeros(this->model);
    }
 
-   void OptimizationProblem::compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+   void OptimizationProblem::compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const {
       this->model.compute_constraint_jacobian_sparsity(row_indices, column_indices, solver_indexing, matrix_order);
    }
 
-   void OptimizationProblem::compute_hessian_sparsity(const HessianModel& hessian_model, size_t* row_indices,
-         size_t* column_indices, size_t solver_indexing) const {
+   void OptimizationProblem::compute_hessian_sparsity(const HessianModel& hessian_model, int* row_indices,
+         int* column_indices, int solver_indexing) const {
       hessian_model.compute_sparsity(this->model, row_indices, column_indices, solver_indexing);
    }
 

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -46,10 +46,10 @@ namespace uno {
       [[nodiscard]] virtual size_t number_jacobian_nonzeros() const;
       [[nodiscard]] virtual bool has_curvature(const HessianModel& hessian_model) const;
       [[nodiscard]] virtual size_t number_hessian_nonzeros(const HessianModel& hessian_model) const;
-      virtual void compute_constraint_jacobian_sparsity(size_t* row_indices, size_t* column_indices, size_t solver_indexing,
+      virtual void compute_constraint_jacobian_sparsity(int* row_indices, int* column_indices, int solver_indexing,
          MatrixOrder matrix_order) const;
-      virtual void compute_hessian_sparsity(const HessianModel& hessian_model, size_t* row_indices,
-         size_t* column_indices, size_t solver_indexing) const;
+      virtual void compute_hessian_sparsity(const HessianModel& hessian_model, int* row_indices,
+         int* column_indices, int solver_indexing) const;
 
       // numerical evaluations of Jacobian and Hessian
       virtual void evaluate_constraint_jacobian(Iterate& iterate, double* jacobian_values) const;


### PR DESCRIPTION
Pretty much all subproblem solvers use int*.