### PR TITLE
Compile-time switch between int32_t and int64_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 if(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
    message(FATAL_ERROR "At least one of BUILD_SHARED_LIBS or BUILD_STATIC_LIBS must be ON.")
 endif()
+add_compile_definitions()
+option(USE_64BIT_INTEGERS "Use 64-bit integers" OFF)
+if(USE_64BIT_INTEGERS)
+   add_compile_definitions(USE_64BIT_INTEGERS)
+endif()
 
 # determine whether a Fortran compiler is required, based on the available optional dependencies
 find_library(HSL hsl)

--- a/uno/integer_type/integer_type.hpp
+++ b/uno/integer_type/integer_type.hpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_INTEGERTYPE_H
+#define UNO_INTEGERTYPE_H
+
+#include <cstdint>
+
+#ifdef USE_64BIT_INTEGERS
+using UnoInt = int64_t;
+#else
+using UnoInt = int32_t;
+#endif
+
+#endif // UNO_INTEGERTYPE_H


### PR DESCRIPTION
- [x] add a compile-time switch between `int32_t` and `int64_t`
- [ ] use the resulting `UnoInt` in the code (indices for sparsity patterns)

cc @amontoison 