### PR TITLE
Bug fix: deal with Hessian explicitly in BQPD when regularizing

### DIFF
--- a/uno/ingredients/regularization_strategies/PrimalDualRegularization.hpp
+++ b/uno/ingredients/regularization_strategies/PrimalDualRegularization.hpp
@@ -118,6 +118,8 @@ namespace uno {
          const double* augmented_matrix_values, ElementType dual_regularization_parameter,
          const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
          double* primal_regularization_values, double* dual_regularization_values) {
+      assert(augmented_matrix_values != nullptr);
+
       this->primal_regularization = ElementType(0);
       this->dual_regularization = ElementType(0);
       for (size_t index: Range(subproblem.get_primal_regularization_variables().size())) {

--- a/uno/ingredients/regularization_strategies/PrimalRegularization.hpp
+++ b/uno/ingredients/regularization_strategies/PrimalRegularization.hpp
@@ -4,6 +4,7 @@
 #ifndef UNO_PRIMALREGULARIZATION_H
 #define UNO_PRIMALREGULARIZATION_H
 
+#include <cassert>
 #include <memory>
 #include <string>
 #include "RegularizationStrategy.hpp"

--- a/uno/ingredients/regularization_strategies/PrimalRegularization.hpp
+++ b/uno/ingredients/regularization_strategies/PrimalRegularization.hpp
@@ -84,6 +84,8 @@ namespace uno {
    void PrimalRegularization<ElementType>::regularize_hessian(Statistics& statistics, const Subproblem& subproblem,
          const double* hessian_values, const Inertia& expected_inertia,
          DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* primal_regularization_values) {
+      assert(hessian_values != nullptr);
+
       DEBUG << "Current Hessian:\n" << hessian_values << '\n';
       const double smallest_diagonal_entry = 0.; // TODO hessian_values.smallest_diagonal_entry(expected_inertia.positive);
       DEBUG << "The minimal diagonal entry of the matrix is " << smallest_diagonal_entry << '\n';

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -140,6 +140,10 @@ namespace uno {
       }
    }
 
+   bool Subproblem::is_hessian_positive_definite() const {
+      return this->hessian_model.is_positive_definite();
+   }
+
    bool Subproblem::has_implicit_hessian_representation() const {
       return this->hessian_model.has_implicit_representation(this->problem.model);
    }

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -61,6 +61,7 @@ namespace uno {
       void set_constraints_bounds(Array& constraints_lower_bounds, Array& constraints_upper_bounds,
          std::vector<double>& constraints) const;
 
+      [[nodiscard]] bool is_hessian_positive_definite() const;
       [[nodiscard]] bool has_implicit_hessian_representation() const;
       [[nodiscard]] bool has_explicit_hessian_representation() const;
       [[nodiscard]] bool has_curvature() const;

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDEvaluationSpace.cpp
@@ -20,8 +20,11 @@ namespace uno {
       // save sparsity patterns of objective gradient and constraint Jacobian into BQPD workspace
       this->compute_gradients_sparsity(subproblem);
 
-      // if the Hessian model only has an explicit representation, allocate an explicit Hessian matrix
-      if (subproblem.has_curvature() && !subproblem.has_implicit_hessian_representation() && subproblem.has_explicit_hessian_representation()) {
+      // allocate an explicit Hessian matrix if:
+      // - the Hessian is not positive definite and must be regularized, or
+      // - the Hessian model only has an explicit representation
+      if ((!subproblem.is_hessian_positive_definite() && subproblem.performs_primal_regularization()) ||
+            !subproblem.has_implicit_hessian_representation()) {
          const size_t number_regularized_hessian_nonzeros = subproblem.number_regularized_hessian_nonzeros();
          this->hessian_row_indices.resize(number_regularized_hessian_nonzeros);
          this->hessian_column_indices.resize(number_regularized_hessian_nonzeros);


### PR DESCRIPTION
When the Hessian isn't positive definite and must be regularized, allocate and evaluate a sparse matrix in BQPD.