### PR TITLE
Run nlp_expr_005_010 (with scaling disabled, the initial point has a gradient)

### DIFF
--- a/.github/julia/runtests_uno_filterslp_bqpd.jl
+++ b/.github/julia/runtests_uno_filterslp_bqpd.jl
@@ -41,7 +41,7 @@ Optimizer_Uno_filterslp() = Optimizer(["logger=SILENT", "preset=filterslp", "LP_
             "001_010",  # Local solution
             "003_014",  # Local solution
             "008_010",  # Local solution
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
+            # no gradient at the initial point
             "005_010",
             # Okay to exclude forever: AmplNLWriter does not support
             # user-defined functions.

--- a/.github/julia/runtests_uno_filterslp_highs.jl
+++ b/.github/julia/runtests_uno_filterslp_highs.jl
@@ -41,7 +41,7 @@ Optimizer_Uno_filterslp() = Optimizer(["logger=SILENT", "preset=filterslp", "LP_
             "001_010",  # Local solution
             "003_014",  # Local solution
             "008_010",  # Local solution
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
+            # no gradient at the initial point
             "005_010",
             # Okay to exclude forever: AmplNLWriter does not support
             # user-defined functions.

--- a/.github/julia/runtests_uno_filtersqp_bqpd.jl
+++ b/.github/julia/runtests_uno_filtersqp_bqpd.jl
@@ -39,7 +39,7 @@ Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=filtersqp", "QP_
             "003_014",  # Local solution
             "004_010",  # Local solution
             "004_011",  # Local solution
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
+            # no gradient at the initial point
             "005_010",
             "007_010",
             "008_010",  # Local solution

--- a/.github/julia/runtests_uno_filtersqp_bqpd_identity.jl
+++ b/.github/julia/runtests_uno_filtersqp_bqpd_identity.jl
@@ -40,7 +40,7 @@ Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=filtersqp", "hes
             "003_014",  # Local solution
             "004_010",  # Local solution
             "004_011",  # Local solution
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
+            # no gradient at the initial point
             "005_010",
             "007_010",
             "008_010",  # Local solution

--- a/.github/julia/runtests_uno_filtersqp_bqpd_regularization_ls.jl
+++ b/.github/julia/runtests_uno_filtersqp_bqpd_regularization_ls.jl
@@ -39,7 +39,7 @@ Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=filtersqp", "QP_
             "003_014",  # Local solution
             "004_010",  # Local solution
             "004_011",  # Local solution
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
+            # no gradient at the initial point
             "005_010",
             "007_010",
             "008_010",  # Local solution

--- a/.github/julia/runtests_uno_filtersqp_bqpd_regularization_tr.jl
+++ b/.github/julia/runtests_uno_filtersqp_bqpd_regularization_tr.jl
@@ -39,7 +39,7 @@ Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=filtersqp", "QP_
             "003_014",  # Local solution
             "004_010",  # Local solution
             "004_011",  # Local solution
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
+            # no gradient at the initial point
             "005_010",
             "007_010",
             "008_010",  # Local solution

--- a/.github/julia/runtests_uno_ipopt_ma27.jl
+++ b/.github/julia/runtests_uno_ipopt_ma27.jl
@@ -38,8 +38,6 @@ Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solv
     MINLPTests.test_nlp_expr(
         Optimizer_Uno_ipopt;
         exclude = [
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
-            "005_010",
             # Okay to exclude forever: AmplNLWriter does not support
             # user-defined functions.
             "006_010",

--- a/.github/julia/runtests_uno_ipopt_ma57.jl
+++ b/.github/julia/runtests_uno_ipopt_ma57.jl
@@ -38,8 +38,6 @@ Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solv
     MINLPTests.test_nlp_expr(
         Optimizer_Uno_ipopt;
         exclude = [
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
-            "005_010",
             # Okay to exclude forever: AmplNLWriter does not support
             # user-defined functions.
             "006_010",

--- a/.github/julia/runtests_uno_ipopt_mumps.jl
+++ b/.github/julia/runtests_uno_ipopt_mumps.jl
@@ -38,8 +38,6 @@ Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solv
     MINLPTests.test_nlp_expr(
         Optimizer_Uno_ipopt;
         exclude = [
-            # Remove once https://github.com/cvanaret/Uno/issues/39 is fixed
-            "005_010",
             # Okay to exclude forever: AmplNLWriter does not support
             # user-defined functions.
             "006_010",


### PR DESCRIPTION
Since Uno's scaling was disabled, the gradients at the initial point are evaluated *after* the point is pushed away from the bounds.