### PR TITLE
CI: test the ipopt preset with MUMPS and identity Hessian

### DIFF
--- a/.github/julia/runtests_uno_filtersqp_highs.jl
+++ b/.github/julia/runtests_uno_filtersqp_highs.jl
@@ -24,7 +24,7 @@ end
 
 # Note: the HiGHS QP solver tolerates only positive semi-definite Hessians.
 # We therefore run only on convex instances (for now)
-Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=filtersqp", "QP_solver=HiGHS", "max_iterations=10000", "unbounded_objective_threshold=-1e15"])
+Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=filtersqp", "QP_solver=HiGHS", "max_iterations=10000"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 @testset "MINLPTests" begin

--- a/.github/julia/runtests_uno_ipopt_ma57.jl
+++ b/.github/julia/runtests_uno_ipopt_ma57.jl
@@ -22,7 +22,7 @@ function Optimizer(options)
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solver=MA57", "unbounded_objective_threshold=-1e15", "print_solution=yes"])
+Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solver=MA57", "unbounded_objective_threshold=-1e15"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 @testset "MINLPTests" begin

--- a/.github/julia/runtests_uno_ipopt_mumps.jl
+++ b/.github/julia/runtests_uno_ipopt_mumps.jl
@@ -22,7 +22,7 @@ function Optimizer(options)
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solver=MUMPS", "unbounded_objective_threshold=-1e15", "print_solution=yes"])
+Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solver=MUMPS", "unbounded_objective_threshold=-1e15"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 @testset "MINLPTests" begin

--- a/.github/julia/runtests_uno_ipopt_mumps_identity.jl
+++ b/.github/julia/runtests_uno_ipopt_mumps_identity.jl
@@ -3,7 +3,7 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-# For help with this file, please contact `@amontoison` or `@odow` on GitHub.
+# For help with this file, please contact `@odow` on GitHub.
 
 using Test
 
@@ -22,7 +22,7 @@ function Optimizer(options)
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solver=MA27", "unbounded_objective_threshold=-1e15"])
+Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solver=MUMPS", "hessian_model=identity", "unbounded_objective_threshold=-1e15"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 @testset "MINLPTests" begin

--- a/.github/julia/runtests_uno_ipopt_mumps_identity.jl
+++ b/.github/julia/runtests_uno_ipopt_mumps_identity.jl
@@ -97,6 +97,14 @@ end
             r"^test_conic_linear_INFEASIBLE_2$",
             r"^test_linear_INFEASIBLE$",
             r"^test_linear_INFEASIBLE_2$",
+            r"^test_linear_DUAL_INFEASIBLE$",
+            r"^test_linear_DUAL_INFEASIBLE_2$",
+            r"^test_linear_add_constraints$",
+            r"^test_nonlinear_expression_hs109$",
+            r"^test_nonlinear_expression_quartic$",
+            r"^test_nonlinear_hs071_NLPBlockDual$",
+            r"^test_quadratic_nonhomogeneous$",
+            r"^test_solve_TerminationStatus_DUAL_INFEASIBLE$",
             r"^test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_",
             # ==================================================================
             # The following tests are okay to exclude forever.

--- a/.github/workflows/julia-tests-ubuntu.yml
+++ b/.github/workflows/julia-tests-ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        UNO_PRESET: [uno_filtersqp_bqpd, uno_filtersqp_highs, uno_filtersqp_bqpd_identity, uno_filtersqp_bqpd_regularization_tr, uno_filtersqp_bqpd_regularization_ls, uno_ipopt_mumps, uno_filterslp_bqpd, uno_filterslp_highs]
+        UNO_PRESET: [uno_filtersqp_bqpd, uno_filtersqp_highs, uno_filtersqp_bqpd_identity, uno_filtersqp_bqpd_regularization_tr, uno_filtersqp_bqpd_regularization_ls, uno_ipopt_mumps, uno_ipopt_mumps_identity, uno_filterslp_bqpd, uno_filterslp_highs]
     name: Julia tests of ${{matrix.UNO_PRESET}} - ${{ github.event_name }}
     
     steps:


### PR DESCRIPTION
We can now run an interior-point method with arbitrary Hessian model (exact, identity, zero).
The new CI script tests the `ipopt` preset with MUMPS and an identity Hessian.