### PR TITLE
Prep for v2.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,11 +1,11 @@
-cff-version: 2.0.3
+cff-version: 2.1.0
 message: "If you use this software, please cite it as below."
 authors:
 - family-names: "Vanaret"
   given-names: "Charlie"
   orcid: "https://orcid.org/0000-0002-1131-7631"
 title: "Uno"
-version: 2.0.3
+version: 2.1.0
 url: "https://github.com/cvanaret/Uno"
 preferred-citation:
   type: unpublished

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿# Copyright (c) 2018-2024 Charlie Vanaret
+﻿# Copyright (c) 2018-2025 Charlie Vanaret
 # Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 cmake_minimum_required(VERSION 3.7)
@@ -11,7 +11,7 @@ endif()
 ######################
 
 # define the project
-project(Uno VERSION 2.0.2
+project(Uno VERSION 2.1.0
         DESCRIPTION "Uno (Unifying Nonlinear Optimization)"
         LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)

--- a/bindings/C/Uno_C_API.h
+++ b/bindings/C/Uno_C_API.h
@@ -47,10 +47,10 @@ extern "C" {
    const int32_t UNO_INFEASIBLE_SMALL_STEP = 5;
    const int32_t UNO_UNBOUNDED = 6;
 
-   // current Uno version is 2.0.3
+   // current Uno version is 2.1.0
    const int32_t UNO_VERSION_MAJOR = 2;
-   const int32_t UNO_VERSION_MINOR = 0;
-   const int32_t UNO_VERSION_PATCH = 3;
+   const int32_t UNO_VERSION_MINOR = 1;
+   const int32_t UNO_VERSION_PATCH = 0;
 
    // get the current Uno version as v major.minor.patch
    void uno_get_version(int32_t* major, int32_t* minor, int32_t* patch);

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -128,7 +128,7 @@ namespace uno {
    }
 
    std::string Uno::current_version() {
-      return "2.0.3";
+      return "2.1.0";
    }
 
    void Uno::print_available_strategies() {


### PR DESCRIPTION
## Pre-release

 - [x] Change the version number in `Uno::current_version()` in `uno/Uno.cpp`
 - [x] Change the version number in `CITATION.cff` (twice)
 - [x] Change the version number in `CMakeLists.txt`
 - [x] Change the version number in `bindings/C/Uno_C_API.h`
 - [x] The commit messages in this PR do not contain `[ci skip]`