### PR TITLE
Fail in BQPD when no Hessian (operator or matrix) is available AND there is curvature in the subproblem

### DIFF
--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -61,7 +61,7 @@ namespace uno {
    }
 
    void BQPDSolver::initialize_memory(const Subproblem& subproblem) {
-      if (!subproblem.has_hessian_operator() && !subproblem.has_hessian_matrix()) {
+      if (subproblem.has_curvature() && !subproblem.has_hessian_operator() && !subproblem.has_hessian_matrix()) {
          throw std::runtime_error("The Hessian cannot be evaluated implicitly or explicitly");
       }
 


### PR DESCRIPTION
This addresses an issue encountered in https://github.com/cvanaret/Uno/pull/310: BQPD complains about no Hessian being available... even though we're solving LPs :)

fixes https://github.com/cvanaret/Uno/issues/312