### PR TITLE
[C] Set default preset upon creation of Options object

### DIFF
--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -667,6 +667,9 @@ void* uno_create_solver() {
    // default options
    Options* options = new Options;
    DefaultOptions::load(*options);
+   // add default preset
+   const Options preset_options = Presets::get_preset_options(std::nullopt);
+   options->overwrite_with(preset_options);
 
    // default user callbacks
    UserCallbacks* user_callbacks = new NoUserCallbacks;

--- a/interfaces/C/example/example_hs015.c
+++ b/interfaces/C/example/example_hs015.c
@@ -102,7 +102,7 @@ int main() {
 
 	// solver creation
 	void* solver = uno_create_solver();
-	uno_set_solver_preset(solver, "filtersqp");
+	//uno_set_solver_preset(solver, "filtersqp");
 	uno_set_solver_bool_option(solver, "print_solution", true);
 
 	// solve


### PR DESCRIPTION
When the `Options` object is created in the C interface, set the default preset so that all necessary options are set. It can obviously be overwritten by the user.