### PR TITLE
Removed redundant callbacks notify_new_[primals|multipliers]

### DIFF
--- a/interfaces/C/README.md
+++ b/interfaces/C/README.md
@@ -113,7 +113,7 @@ uno_set_solver_preset(solver, "filtersqp");
 
 Setting the user callbacks to the Uno solver:
 ```c
-uno_set_solver_callbacks(solver, notify_acceptable_iterate_callback, notify_new_primals_callback, notify_new_multipliers_callback, user_termination_callback, user_data);
+uno_set_solver_callbacks(solver, notify_acceptable_iterate_callback, user_termination_callback, user_data);
 ```
 
 Setting the logger stream callback:

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -300,11 +300,8 @@ protected:
 class CUserCallbacks: public UserCallbacks {
 public:
    CUserCallbacks(NotifyAcceptableIterateUserCallback notify_acceptable_iterate_callback,
-      NotifyNewPrimalsUserCallback notify_new_primals_callback, NotifyNewMultipliersUserCallback notify_new_multipliers_callback,
       TerminationUserCallback user_termination_callback, void* user_data): UserCallbacks(),
          notify_acceptable_iterate_callback(notify_acceptable_iterate_callback),
-         notify_new_primals_callback(notify_new_primals_callback),
-         notify_new_multipliers_callback(notify_new_multipliers_callback),
          user_termination_callback(user_termination_callback),
          user_data(user_data) { };
 
@@ -315,20 +312,6 @@ public:
             static_cast<int32_t>(multipliers.constraints.size()), primals.data(), multipliers.lower_bounds.data(),
             multipliers.upper_bounds.data(), multipliers.constraints.data(), objective_multiplier, primal_feasibility_residual,
             stationarity_residual, complementarity_residual, this->user_data);
-      }
-   }
-
-   void notify_new_primals(const Vector<double>& primals) override {
-      if (this->notify_new_primals_callback != nullptr) {
-         this->notify_new_primals_callback(static_cast<int32_t>(primals.size()), primals.data(), this->user_data);
-      }
-   }
-
-   void notify_new_multipliers(const Multipliers& multipliers) override {
-      if (this->notify_new_multipliers_callback != nullptr) {
-         this->notify_new_multipliers_callback(static_cast<int32_t>(multipliers.lower_bounds.size()),
-            static_cast<int32_t>(multipliers.constraints.size()), multipliers.lower_bounds.data(), multipliers.upper_bounds.data(),
-            multipliers.constraints.data(), this->user_data);
       }
    }
 
@@ -347,8 +330,6 @@ public:
 
 private:
    NotifyAcceptableIterateUserCallback notify_acceptable_iterate_callback;
-   NotifyNewPrimalsUserCallback notify_new_primals_callback;
-   NotifyNewMultipliersUserCallback notify_new_multipliers_callback;
    TerminationUserCallback user_termination_callback;
    void* user_data;
 };
@@ -744,12 +725,10 @@ void uno_set_solver_preset(void* solver, const char* preset_name) {
 }
 
 void uno_set_solver_callbacks(void* solver, NotifyAcceptableIterateUserCallback notify_acceptable_iterate_callback,
-      NotifyNewPrimalsUserCallback notify_new_primals_callback, NotifyNewMultipliersUserCallback notify_new_multipliers_callback,
       TerminationUserCallback user_termination_callback, void* user_data) {
    Solver* uno_solver = static_cast<Solver*>(solver);
    delete uno_solver->user_callbacks; // delete the previous callbacks
-   uno_solver->user_callbacks = new CUserCallbacks(notify_acceptable_iterate_callback, notify_new_primals_callback,
-      notify_new_multipliers_callback, user_termination_callback, user_data);
+   uno_solver->user_callbacks = new CUserCallbacks(notify_acceptable_iterate_callback, user_termination_callback, user_data);
 }
 
 void uno_optimize(void* solver, void* model) {

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -131,15 +131,6 @@ extern "C" {
       double objective_multiplier, double primal_feasibility_residual, double stationarity_residual,
       double complementarity_residual, void* user_data);
 
-   // - takes as inputs the number of variables, and a vector "primals" of size "number_variables".
-   typedef void (*NotifyNewPrimalsUserCallback)(int32_t number_variables, const double* primals, void* user_data);
-   
-   // - takes as inputs the number of variables, the number of constraints, the lower and upper bound multipliers of
-   // size "number_variables", and a vector "constraint_multipliers" of size "number_constraints".
-   typedef void (*NotifyNewMultipliersUserCallback)(int32_t number_variables, int32_t number_constraints,
-      const double* lower_bound_multipliers, const double* upper_bound_multipliers, const double* constraints_multipliers,
-      void* user_data);
-
    // - takes as inputs the number of variables, the number of constraints, a vector "primals" of size "number_variables",
    // the lower and upper bound multipliers of size "number_variables", a vector "constraint_multipliers" of size
    // "number_constraints", an objective multiplier, the primal feasibility residual, the dual feasibility residual, and
@@ -264,7 +255,6 @@ extern "C" {
    // [optional]
    // sets the user callbacks for solver.
    void uno_set_solver_callbacks(void* solver, NotifyAcceptableIterateUserCallback notify_acceptable_iterate_callback,
-      NotifyNewPrimalsUserCallback notify_new_primals_callback, NotifyNewMultipliersUserCallback notify_new_multipliers_callback, 
       TerminationUserCallback user_termination_callback, void* user_data);
 
    // [optional]

--- a/interfaces/Julia/gen/wrapper.jl
+++ b/interfaces/Julia/gen/wrapper.jl
@@ -16,8 +16,7 @@ function main()
   callbacks = ["ObjectiveGradient", "Objective", "Constraints",
                "JacobianOperator", "JacobianTransposedOperator", "HessianOperator",
                "JacobianSparsity", "Jacobian", "HessianSparsity", "Hessian",
-               "NotifyAcceptableIterateUserCallback", "NotifyNewPrimalsUserCallback",
-               "NotifyNewMultipliersUserCallback", "TerminationUserCallback",
+               "NotifyAcceptableIterateUserCallback", "TerminationUserCallback",
                "LoggerStreamUserCallback"]
   options["general"]["output_ignorelist"] = callbacks
 

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -162,13 +162,9 @@ function uno_set_solver_preset(solver, preset_name)
 end
 
 function uno_set_solver_callbacks(solver, notify_acceptable_iterate_callback,
-                                  notify_new_primals_callback,
-                                  notify_new_multipliers_callback,
                                   user_termination_callback, user_data)
     @ccall libuno.uno_set_solver_callbacks(solver::Ptr{Cvoid},
                                            notify_acceptable_iterate_callback::Ptr{Cvoid},
-                                           notify_new_primals_callback::Ptr{Cvoid},
-                                           notify_new_multipliers_callback::Ptr{Cvoid},
                                            user_termination_callback::Ptr{Cvoid},
                                            user_data::Ptr{Cvoid})::Cvoid
 end

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -98,8 +98,6 @@ namespace uno {
                   *this->globalization_strategy, model, current_iterate, trial_iterate, this->direction, warmstart_information,
                   user_callbacks);
                GlobalizationMechanism::set_dual_residuals_statistics(statistics, trial_iterate);
-               user_callbacks.notify_new_primals(trial_iterate.primals);
-               user_callbacks.notify_new_multipliers(trial_iterate.multipliers);
                const bool user_termination = user_callbacks.user_termination(trial_iterate.primals, trial_iterate.multipliers,
                   trial_iterate.objective_multiplier, trial_iterate.progress.infeasibility, trial_iterate.residuals.stationarity,
                   trial_iterate.residuals.complementarity);

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -123,7 +123,8 @@ namespace uno {
             predicted_reductions, objective_multiplier);
       }
       if (accept_iterate) {
-         user_callbacks.notify_acceptable_iterate(trial_iterate.primals, trial_iterate.multipliers, objective_multiplier, trial_iterate.progress.infeasibility, trial_iterate.residuals.stationarity, trial_iterate.residuals.complementarity);  
+         user_callbacks.notify_acceptable_iterate(trial_iterate.primals, trial_iterate.multipliers, objective_multiplier,
+            trial_iterate.progress.infeasibility, trial_iterate.residuals.stationarity, trial_iterate.residuals.complementarity);
       }
       return accept_iterate;
    }

--- a/uno/tools/UserCallbacks.hpp
+++ b/uno/tools/UserCallbacks.hpp
@@ -17,8 +17,6 @@ namespace uno {
 
       virtual void notify_acceptable_iterate(const Vector<double>& primals, const Multipliers& multipliers, double objective_multiplier,
          double primal_feasibility_residual, double stationarity_residual, double complementarity_residual) = 0;
-      virtual void notify_new_primals(const Vector<double>& primals) = 0;
-      virtual void notify_new_multipliers(const Multipliers& multipliers) = 0;
       virtual bool user_termination(const Vector<double>& primals, const Multipliers& multipliers, double objective_multiplier,
          double primal_feasibility_residual, double stationarity_residual, double complementarity_residual) = 0; // returns true for user termination
    };
@@ -29,8 +27,6 @@ namespace uno {
 
       void notify_acceptable_iterate(const Vector<double>& /*primals*/, const Multipliers& /*multipliers*/, double /*objective_multiplier*/,
          double /*primal_feasibility_residual*/, double /*stationarity_residual*/, double /*complementarity_residual*/) override { }
-      void notify_new_primals(const Vector<double>& /*primals*/) override { }
-      void notify_new_multipliers(const Multipliers& /*multipliers*/) override { }
       bool user_termination(const Vector<double>& /*primals*/, const Multipliers& /*multipliers*/, double /*objective_multiplier*/,
             double /*primal_feasibility_residual*/, double /*stationarity_residual*/, double /*complementarity_residual*/) override {
          return false;


### PR DESCRIPTION
The primal and dual iterates passed to `notify_new_[primals|duals]` were the same as the ones passed to `notify_acceptable_iterate`.