### PR TITLE
[CI] Upgrade macos-13 to macos-latest

### DIFF
--- a/.github/workflows/julia-tests-jll.yml
+++ b/.github/workflows/julia-tests-jll.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1']
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         arch: ['x64']
         allow_failure: [false]
         include:
@@ -36,7 +36,7 @@ jobs:
         with:
           compiler: 'gcc'
           version: '14'
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
+        if: matrix.os == 'macos-latest'
 
       - uses: julia-actions/setup-julia@v2
         with:


### PR DESCRIPTION
The macOS 13 runner image will be retired by December 4th, 2025. This deprecation includes the following labels:
- macos-13
- macos-13-large
- macos-13-xlarge