### PR TITLE
Add function in interfaces to get the solver's method

### DIFF
--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -834,6 +834,12 @@ Result* uno_get_result(void* solver) {
    return uno_solver->result;
 }
 
+const char* uno_get_solver_method(void* solver) {
+   assert(solver != nullptr);
+   Solver* uno_solver = static_cast<Solver*>(solver);
+   return uno_solver->solver->get_strategy_combination().c_str();
+}
+
 uno_int uno_get_optimization_status(void* solver) {
    const Result* result = uno_get_result(solver);
    return static_cast<uno_int>(result->optimization_status);

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -283,6 +283,9 @@ extern "C" {
    bool uno_get_solver_bool_option(void* solver, const char* option_name);
    const char* uno_get_solver_string_option(void* solver, const char* option_name);
 
+   // gets the method used by the solver as the result of the strategy combination
+   const char* uno_get_solver_method(void* solver);
+
    // gets the optimization status (once the model was solved)
    uno_int uno_get_optimization_status(void* solver);
 

--- a/interfaces/C/example/example_hs015.c
+++ b/interfaces/C/example/example_hs015.c
@@ -108,6 +108,7 @@ int main() {
 	uno_optimize(solver, model);
 
 	// get the solution
+	printf("Solved with: %s", uno_get_solver_method(solver));
 	const uno_int optimization_status = uno_get_optimization_status(solver);
 	assert(optimization_status == UNO_SUCCESS);
 	const uno_int iterate_status = uno_get_solution_status(solver);

--- a/interfaces/Fortran/uno.f90
+++ b/interfaces/Fortran/uno.f90
@@ -407,6 +407,18 @@ interface
 end interface
 
 !---------------------------------------------
+! uno_get_solver_method
+!---------------------------------------------
+interface
+   function uno_get_solver_method(solver) result(solver_method) &
+      bind(C, name="uno_get_solver_method")
+      import :: c_ptr
+      type(c_ptr), value :: solver
+      type(c_ptr) :: solver_method
+   end function uno_get_solver_method
+end interface
+
+!---------------------------------------------
 ! uno_get_solution_status
 !---------------------------------------------
 interface

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -199,6 +199,10 @@ function uno_get_solver_string_option(solver, option_name)
                                                option_name::Cstring)::Cstring
 end
 
+function uno_get_solver_method(solver)
+    @ccall libuno.uno_get_solver_method(solver::Ptr{Cvoid})::Cstring
+end
+
 function uno_get_optimization_status(solver)
     @ccall libuno.uno_get_optimization_status(solver::Ptr{Cvoid})::Int32
 end

--- a/interfaces/Python/example/example_hs015.py
+++ b/interfaces/Python/example/example_hs015.py
@@ -91,7 +91,8 @@ if __name__ == '__main__':
 	result = uno_solver.optimize(model)
 
 	# optimization summary
-	print("\nReading optimization summary from Python:")
+	print("\nSolved with: ", uno_solver.get_solver_method())
+	print("Reading optimization summary from Python:")
 	print("Number of iterations:", result.optimization_status)
 	print("Number of iterations:", result.solution_status)
 	print("Objective at solution:", result.solution_objective)

--- a/interfaces/Python/python_modules/UnoSolver.cpp
+++ b/interfaces/Python/python_modules/UnoSolver.cpp
@@ -36,6 +36,10 @@ namespace uno {
          Presets::set(solver.options, preset_name);
       }, py::arg("preset_name"))
 
+      .def("get_solver_method", [](const UnoSolverWrapper& solver) {
+         return solver.uno_solver.get_strategy_combination();
+      })
+
       .def("optimize", [](UnoSolverWrapper& solver, const PythonUserModel& user_model) {
          return solver.optimize(user_model);
       }, py::arg("model"), "Optimize an optimization model with the Uno solver");

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -142,6 +142,12 @@ namespace uno {
       std::cout << "- Presets: filtersqp, ipopt\n";
    }
 
+   const std::string& Uno::get_strategy_combination() const {
+      return this->strategy_combination;
+   }
+
+   // private member functions
+
    void Uno::initialize(Statistics& statistics, const Model& model, Iterate& current_iterate, const Options& options) {
       statistics.start_new_line();
       statistics.set("iter", 0);
@@ -233,10 +239,6 @@ namespace uno {
          result.upper_bound_dual_solution.scale(-1.);
       }
       result.solution_objective *= model.optimization_sense;
-   }
-
-   const std::string& Uno::get_strategy_combination() const {
-      return this->strategy_combination;
    }
 
    void Uno::print_optimization_summary(const Result& result, bool print_solution) const {

--- a/uno/Uno.hpp
+++ b/uno/Uno.hpp
@@ -33,8 +33,8 @@ namespace uno {
    private:
       std::unique_ptr<GlobalizationMechanism> globalization_mechanism{};
       Direction direction{};
+      std::string strategy_combination{};
 
-      void pick_ingredients(const Model& model, const Options& options);
       void initialize(Statistics& statistics, const Model& model, Iterate& current_iterate, const Options& options);
       [[nodiscard]] static Statistics create_statistics(const Model& model, const Options& options);
       [[nodiscard]] static bool termination_criteria(SolutionStatus solution_status, size_t iteration, size_t max_iterations,
@@ -44,7 +44,7 @@ namespace uno {
       [[nodiscard]] Result create_result(const Model& model, OptimizationStatus optimization_status, const Iterate& solution,
          size_t major_iterations, const Timer& timer) const;
       static void postprocess_multipliers_signs(const Model& model, Result& result);
-      [[nodiscard]] std::string get_strategy_combination() const;
+      [[nodiscard]] const std::string& get_strategy_combination() const;
       void print_optimization_summary(const Result& result, bool print_solution) const;
    };
 } // namespace

--- a/uno/Uno.hpp
+++ b/uno/Uno.hpp
@@ -29,6 +29,7 @@ namespace uno {
 
       static std::string current_version();
       static void print_available_strategies();
+      [[nodiscard]] const std::string& get_strategy_combination() const;
 
    private:
       std::unique_ptr<GlobalizationMechanism> globalization_mechanism{};
@@ -44,7 +45,6 @@ namespace uno {
       [[nodiscard]] Result create_result(const Model& model, OptimizationStatus optimization_status, const Iterate& solution,
          size_t major_iterations, const Timer& timer) const;
       static void postprocess_multipliers_signs(const Model& model, Result& result);
-      [[nodiscard]] const std::string& get_strategy_combination() const;
       void print_optimization_summary(const Result& result, bool print_solution) const;
    };
 } // namespace

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -41,7 +41,7 @@ namespace uno {
          double step_length, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) = 0;
       [[nodiscard]] virtual SolutionStatus check_termination(const Model& model, Iterate& iterate) = 0;
 
-      [[nodiscard]] virtual std::string get_name() const = 0;
+      [[nodiscard]] virtual std::string get_strategy_combination() const = 0;
       [[nodiscard]] virtual size_t get_number_subproblems_solved() const = 0;
 
    protected:

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -242,7 +242,7 @@ namespace uno {
       }
    }
 
-   std::string FeasibilityRestoration::get_name() const {
+   std::string FeasibilityRestoration::get_strategy_combination() const {
       return this->optimality_globalization_strategy->get_name() + " restoration " + this->optimality_inequality_handling_method->get_name() +
          " with " + this->optimality_hessian_model->name + " Hessian and " + this->optimality_inertia_correction_strategy->get_name() +
          " regularization";

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -37,7 +37,7 @@ namespace uno {
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
       [[nodiscard]] SolutionStatus check_termination(const Model& model, Iterate& iterate) override;
 
-      [[nodiscard]] std::string get_name() const override;
+      [[nodiscard]] std::string get_strategy_combination() const override;
       [[nodiscard]] size_t get_number_subproblems_solved() const override;
 
    private:

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -85,7 +85,7 @@ namespace uno {
       return ConstraintRelaxationStrategy::check_termination(this->problem, iterate);
    }
 
-   std::string NoRelaxation::get_name() const {
+   std::string NoRelaxation::get_strategy_combination() const {
       return this->globalization_strategy.get_name() + " " + this->inequality_handling_method->get_name() + " with " +
          this->hessian_model->name + " Hessian and " + this->inertia_correction_strategy->get_name() + " regularization";
    }

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -33,7 +33,7 @@ namespace uno {
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
       [[nodiscard]] SolutionStatus check_termination(const Model& model, Iterate& iterate) override;
 
-      [[nodiscard]] std::string get_name() const override;
+      [[nodiscard]] std::string get_strategy_combination() const override;
       [[nodiscard]] size_t get_number_subproblems_solved() const override;
 
    private:

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -15,7 +15,7 @@
 
 namespace uno {
    BacktrackingLineSearch::BacktrackingLineSearch(const Model& model, const Options& options):
-         GlobalizationMechanism(model, false, options),
+         GlobalizationMechanism("LS", model, false, options),
          backtracking_ratio(options.get_double("LS_backtracking_ratio")),
          minimum_step_length(options.get_double("LS_min_step_length")),
          scale_duals_with_step_length(options.get_bool("LS_scale_duals_with_step_length")) {
@@ -40,10 +40,6 @@ namespace uno {
       BacktrackingLineSearch::check_unboundedness(direction);
       this->backtrack_along_direction(statistics, model, current_iterate, trial_iterate, direction, warmstart_information,
          user_callbacks);
-   }
-
-   std::string BacktrackingLineSearch::get_name() const {
-      return "LS " + this->constraint_relaxation_strategy->get_name();
    }
 
    // protected member functions

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
@@ -17,8 +17,6 @@ namespace uno {
       void compute_next_iterate(Statistics& statistics, const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
          Direction& direction, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
 
-      [[nodiscard]] std::string get_name() const override;
-
    private:
       const double backtracking_ratio;
       const double minimum_step_length;

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
@@ -11,7 +11,9 @@
 #include "tools/Statistics.hpp"
 
 namespace uno {
-   GlobalizationMechanism::GlobalizationMechanism(const Model& model, bool use_trust_region, const Options& options):
+   GlobalizationMechanism::GlobalizationMechanism(std::string name, const Model& model, bool use_trust_region,
+         const Options& options):
+      name(std::move(name)),
       constraint_relaxation_strategy(ConstraintRelaxationStrategyFactory::create(model, use_trust_region, options)) {
    }
 
@@ -50,6 +52,10 @@ namespace uno {
    void GlobalizationMechanism::set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate) {
       statistics.set("stationarity", iterate.residuals.stationarity);
       statistics.set("complementarity", iterate.residuals.complementarity);
+   }
+
+   std::string GlobalizationMechanism::get_strategy_combination() const {
+      return this->name + " " + this->constraint_relaxation_strategy->get_strategy_combination();
    }
 
    size_t GlobalizationMechanism::get_number_subproblems_solved() const {

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
@@ -20,7 +20,7 @@ namespace uno {
 
    class GlobalizationMechanism {
    public:
-      GlobalizationMechanism(const Model& model, bool use_trust_region, const Options& options);
+      GlobalizationMechanism(std::string name, const Model& model, bool use_trust_region, const Options& options);
       virtual ~GlobalizationMechanism() = default;
 
       virtual void initialize(Statistics& statistics, const Model& model, Iterate& current_iterate,
@@ -31,10 +31,11 @@ namespace uno {
       static void set_primal_statistics(Statistics& statistics, const Model& model, const Iterate& iterate);
       static void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate);
 
-      [[nodiscard]] virtual std::string get_name() const = 0;
+      [[nodiscard]] std::string get_strategy_combination() const;
       [[nodiscard]] size_t get_number_subproblems_solved() const;
 
    protected:
+      const std::string name;
       const std::unique_ptr<ConstraintRelaxationStrategy> constraint_relaxation_strategy{};
 
       static void assemble_trial_iterate(const Model& model, Iterate& current_iterate, Iterate& trial_iterate,

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -17,7 +17,7 @@
 
 namespace uno {
    TrustRegionStrategy::TrustRegionStrategy(const Model& model, const Options& options) :
-         GlobalizationMechanism(model, true, options),
+         GlobalizationMechanism("TR", model, true, options),
          radius(options.get_double("TR_radius")),
          increase_factor(options.get_double("TR_increase_factor")),
          decrease_factor(options.get_double("TR_decrease_factor")),
@@ -105,10 +105,6 @@ namespace uno {
             throw std::runtime_error("Small radius");
          }
       }
-   }
-
-   std::string TrustRegionStrategy::get_name() const {
-      return "TR " + this->constraint_relaxation_strategy->get_name();
    }
 
    // protected member functions

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
@@ -17,8 +17,6 @@ namespace uno {
       void compute_next_iterate(Statistics& statistics, const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
          Direction& direction, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) override;
 
-      [[nodiscard]] std::string get_name() const override;
-
    private:
       double radius; /*!< Current trust region radius */
       const double increase_factor;


### PR DESCRIPTION
Added a function `uno_get_solver_method()` in C/Fortran/Python interfaces for the user to check which method is used by the solver, based on the strategy combination.
This is especially useful because some special cases in the ingredient instantiation exist (e.g., if unconstrained, Uno automatically picks merit function + no relaxation).

Fixes https://github.com/cvanaret/Uno/issues/421