### PR TITLE
Option BQPD_kmax_heuristic to choose heuristic for picking BQPD's kmax

### DIFF
--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.hpp
@@ -5,7 +5,6 @@
 #define UNO_BQPDSOLVER_H
 
 #include <array>
-#include <memory>
 #include <vector>
 #include "ingredients/subproblem_solvers/QPSolver.hpp"
 #include "BQPDEvaluationSpace.hpp"
@@ -56,6 +55,7 @@ namespace uno {
       std::vector<double> lower_bounds{}, upper_bounds{}; // lower and upper bounds of variables and constraints
 
       int kmax{0};
+      int (*pick_kmax)(size_t number_variables, size_t number_constraints);
       int mlp{1000};
       const size_t nprof{2000000};
       std::array<int, 100> info{};

--- a/uno/options/DefaultOptions.cpp
+++ b/uno/options/DefaultOptions.cpp
@@ -167,7 +167,7 @@ namespace uno {
       options.set_double("least_square_multiplier_max_norm", 1e3);
 
       /** BQPD options **/
-      options.set_integer("BQPD_kmax", 500);
+      options.set_string("BQPD_kmax_heuristic", "filtersqp");
    }
 
    // determine default subproblem solvers, based on the available external dependencies

--- a/uno/options/Options.hpp
+++ b/uno/options/Options.hpp
@@ -147,7 +147,7 @@ namespace uno {
          {"barrier_push_variable_to_interior_k2", OptionType::DOUBLE},
          {"barrier_damping_factor", OptionType::DOUBLE},
          {"least_square_multiplier_max_norm", OptionType::DOUBLE},
-         {"BQPD_kmax", OptionType::INTEGER},
+         {"BQPD_kmax_heuristic", OptionType::STRING},
          {"QP_solver", OptionType::STRING},
          {"LP_solver", OptionType::STRING},
          {"linear_solver", OptionType::STRING},


### PR DESCRIPTION
Added option `BQPD_kmax_heuristic=[filtersqp|minotaur]` to choose heuristic for picking BQPD's kmax (max size of nullspace). Default is `filtersqp` (filterSQP approach).

Fixes https://github.com/cvanaret/Uno/issues/424