### PR TITLE
[unopy] Release v0.1.0

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -92,5 +92,5 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
+        #with:
+        #  repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "unopy"
-version = "0.1.3"
+version = "0.1.0"
 #requires-python = ">=3.8"
 description = "Uno, a highly customizable SQP & barrier solver for nonlinearly constrained optimization"
 readme = "interfaces/Python/README.md"


### PR DESCRIPTION
unopy v0.1.0 contains BQPD and HiGHS, is available as wheels for Linux and macOS, and as SDist.