### PR TITLE
Correctly set the dimensions in the `Result` object

### DIFF
--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -56,7 +56,11 @@ namespace uno {
          DISCRETE << "Reformulated model " << bound_relaxed_model.name << '\n' << bound_relaxed_model.number_variables << " variables, " <<
             bound_relaxed_model.number_constraints << " constraints (" << bound_relaxed_model.get_equality_constraints().size() <<
             " equality, " << bound_relaxed_model.get_inequality_constraints().size() << " inequality)\n";
-         return uno_solve(bound_relaxed_model, options, user_callbacks);
+         Result result = uno_solve(bound_relaxed_model, options, user_callbacks);
+         // fix the dimensions
+         result.number_variables = model.number_variables;
+         result.number_constraints = model.number_constraints;
+         return result;
       }
       else {
          return uno_solve(model, options, user_callbacks);

--- a/uno/optimization/Result.hpp
+++ b/uno/optimization/Result.hpp
@@ -12,8 +12,8 @@ namespace uno {
    public:
       Result() = delete;
 
-      const size_t number_variables;
-      const size_t number_constraints;
+      size_t number_variables;
+      size_t number_constraints;
       const OptimizationStatus optimization_status;
       const SolutionStatus solution_status;
       double solution_objective;


### PR DESCRIPTION
The dimensions in the `Result` object should be those of the original model, not those of the reformulated model.

@amontoison this should solve issue https://github.com/cvanaret/Uno/issues/556.