### PR TITLE
Catch std::invalig_argument at startup if one of the options does not exist

### DIFF
--- a/interfaces/AMPL/uno_ampl.cpp
+++ b/interfaces/AMPL/uno_ampl.cpp
@@ -22,80 +22,70 @@ void* operator new(size_t size) {
 
 namespace uno {
    void run_uno_ampl(const std::string& model_name, Options& options) {
-      try {
-         const AMPLModel model(model_name);
-         Uno uno{};
-         Result result = uno.solve(model, options);
-         if (result.optimization_status == OptimizationStatus::SUCCESS) {
-            // check result.solution_status
-         }
-         else {
-            // ...
-         }
-         if (options.get_bool("AMPL_write_solution_to_file")) {
-            model.write_solution_to_file(result);
-         }
-         // std::cout << "memory_allocation_amount = " << memory_allocation_amount << '\n';
+      const AMPLModel model(model_name);
+      Uno uno{};
+      Result result = uno.solve(model, options);
+      if (result.optimization_status == OptimizationStatus::SUCCESS) {
+         // check result.solution_status
       }
-      catch (std::exception& exception) {
-         DISCRETE << exception.what() << '\n';
+      else {
+         // ...
       }
+      if (options.get_bool("AMPL_write_solution_to_file")) {
+         model.write_solution_to_file(result);
+      }
+      // std::cout << "memory_allocation_amount = " << memory_allocation_amount << '\n';
    }
 } // namespace
 
 int main(int argc, char* argv[]) {
    using namespace uno;
 
-   try {
-      if (argc == 1 || (argc == 2 && std::string(argv[1]) == "--v")) {
-         std::cout << "Uno " << Uno::current_version() << '\n';
-      } 
-      else if (argc == 2 && std::string(argv[1]) == "--dump-options") {
-         // Print all available options (type + default value) for automated tools
-         Options::dump_default_options();
-      }
-      else if (argc == 2 && std::string(argv[1]) == "--strategies") {
-         Uno::print_available_strategies();
+   if (argc == 1 || (argc == 2 && std::string(argv[1]) == "--v")) {
+      std::cout << "Uno " << Uno::current_version() << '\n';
+   }
+   else if (argc == 2 && std::string(argv[1]) == "--dump-options") {
+      // Print all available options (type + default value) for automated tools
+      Options::dump_default_options();
+   }
+   else if (argc == 2 && std::string(argv[1]) == "--strategies") {
+      Uno::print_available_strategies();
+   }
+   else {
+      // AMPL expects: ./uno_ampl model.nl [-AMPL] [option_name=option_value, ...]
+      // model name
+      const char* model_name = argv[1];
+
+      // gather the options
+      Options options;
+      DefaultOptions::load(options);
+      // the -AMPL flag indicates that the solution should be written to the AMPL solution file
+      size_t offset = 2;
+      if (argc > 2 && std::string(argv[2]) == "-AMPL") {
+         options.set_bool("AMPL_write_solution_to_file", true);
+         ++offset;
       }
       else {
-         // AMPL expects: ./uno_ampl model.nl [-AMPL] [option_name=option_value, ...]
-         // model name
-         const char* model_name = argv[1];
-
-         // gather the options
-         Options options;
-         DefaultOptions::load(options);
-         // the -AMPL flag indicates that the solution should be written to the AMPL solution file
-         size_t offset = 2;
-         if (argc > 2 && std::string(argv[2]) == "-AMPL") {
-            options.set_bool("AMPL_write_solution_to_file", true);
-            ++offset;
-         }
-         else {
-            options.set_bool("AMPL_write_solution_to_file", false);
-         }
-         // get the command line arguments (options start at index offset)
-         const Options command_line_options = Options::get_command_line_options(argc, argv, offset);
-         // possibly set options from an option file
-         const auto optional_option_file = command_line_options.get_string_optional("option_file");
-         if (optional_option_file.has_value()) {
-            Options file_options = Options::load_option_file(*optional_option_file);
-            options.overwrite_with(file_options);
-         }
-         // possibly set a preset
-         const auto optional_preset = command_line_options.get_string_optional("preset");
-         const Options preset_options = Presets::get_preset_options(optional_preset);
-         options.overwrite_with(preset_options);
-         // overwrite the options with the command line arguments
-         options.overwrite_with(command_line_options);
-
-         // solve the model
-         Logger::set_logger(options.get_string("logger"));
-         run_uno_ampl(model_name, options);
+         options.set_bool("AMPL_write_solution_to_file", false);
       }
-   }
-   catch (std::exception& exception) {
-      DISCRETE << exception.what() << '\n';
+      // get the command line arguments (options start at index offset)
+      const Options command_line_options = Options::get_command_line_options(argc, argv, offset);
+      // possibly set options from an option file
+      const auto optional_option_file = command_line_options.get_string_optional("option_file");
+      if (optional_option_file.has_value()) {
+         Options file_options = Options::load_option_file(*optional_option_file);
+         options.overwrite_with(file_options);
+      }
+      // possibly set a preset
+      const auto optional_preset = command_line_options.get_string_optional("preset");
+      const Options preset_options = Presets::get_preset_options(optional_preset);
+      options.overwrite_with(preset_options);
+      // overwrite the options with the command line arguments
+      options.overwrite_with(command_line_options);
+
+      // solve the model
+      Logger::set_logger(options.get_string("logger"));
+      run_uno_ampl(model_name, options);
    }
    return EXIT_SUCCESS;
 }

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -70,26 +70,25 @@ namespace uno {
    // protected solve function
    Result Uno::uno_solve(const Model& model, Options& options, UserCallbacks& user_callbacks) {
       const Timer timer{};
-      model.reset_number_evaluations();
-      // pick the ingredients based on the user-defined options
-      Uno::pick_ingredients(model, options);
-      Statistics statistics = Uno::create_statistics(model);
-      WarmstartInformation warmstart_information{};
-      warmstart_information.whole_problem_changed();
+      size_t major_iterations = 0;
 
       // initialize initial primal and dual points
       Iterate current_iterate(model.number_variables, model.number_constraints);
       model.initial_primal_point(current_iterate.primals);
       model.initial_dual_point(current_iterate.multipliers.constraints);
-
-      // evaluation cache
+      model.reset_number_evaluations();
+      OptimizationStatus optimization_status = OptimizationStatus::SUCCESS;
       EvaluationCache evaluation_cache{model};
 
-      size_t major_iterations = 0;
-      OptimizationStatus optimization_status = OptimizationStatus::SUCCESS;
+      Statistics statistics = Uno::create_statistics(model);
+      WarmstartInformation warmstart_information{};
+      warmstart_information.whole_problem_changed();
       const size_t max_iterations = options.get_unsigned_int("max_iterations"); // maximum number of iterations
       const double time_limit = options.get_double("time_limit"); // CPU time limit (can be inf)
-      try {
+
+      try { // catch errors at startup/initial iterate
+         // pick the ingredients based on the user-defined options
+         Uno::pick_ingredients(model, options);
          // use the initial primal-dual point to initialize the strategies and generate the initial iterate
          this->initialize(statistics, model, current_iterate, options, evaluation_cache);
          // allocate the trial iterate once and for all here
@@ -227,7 +226,8 @@ namespace uno {
 
    Result Uno::create_result(const Model& model, OptimizationStatus optimization_status, const Iterate& solution,
          const Evaluations& evaluations, size_t major_iterations, const Timer& timer) const {
-      const size_t number_subproblems_solved = this->globalization_mechanism->get_number_subproblems_solved();
+      const size_t number_subproblems_solved = (this->globalization_mechanism != nullptr) ?
+         this->globalization_mechanism->get_number_subproblems_solved() : 0;
       return {model.number_variables, model.number_constraints, optimization_status, solution.status,
          evaluations.objective, solution.progress.infeasibility, solution.residuals.stationarity,
          solution.residuals.complementarity, solution.primals, solution.multipliers.constraints,
@@ -254,7 +254,8 @@ namespace uno {
    }
 
    std::string Uno::get_strategy_combination() const {
-      return this->globalization_mechanism->get_name();
+      return (this->globalization_mechanism != nullptr) ? this->globalization_mechanism->get_name() :
+         "strategy combination not initialized";
    }
 
    void Uno::print_optimization_summary(const Result& result, bool print_solution) const {


### PR DESCRIPTION
- removed catch in `uno_ampl`
- added catch in `Uno.cpp` in case `Uno::pick_ingredients()` fails

Fixes https://github.com/cvanaret/Uno/issues/571