### PR TITLE
Throw exception in unopy's `UnoSolver.set_option` if type or key is wrong

### DIFF
--- a/interfaces/Python/python_modules/UnoSolver.cpp
+++ b/interfaces/Python/python_modules/UnoSolver.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include "../cpp_classes/PythonModel.hpp"
 #include "../cpp_classes/UnoSolverWrapper.hpp"
+#include "options/Options.hpp"
 #include "options/Presets.hpp"
 
 namespace py = pybind11;
@@ -16,20 +17,64 @@ namespace uno {
       .def(py::init<>(), "Constructor")
 
       // methods
+      .def("set_option", [](UnoSolverWrapper& solver, const std::string& option_name, bool option_value) {
+         const auto type = Options::option_types.find(option_name);
+         if (type != Options::option_types.end()) { // key found
+            if (type->second == OptionType::BOOL) { // correct type
+               solver.options.set_bool(option_name, option_value);
+            }
+            else { // incorrect type
+               throw py::type_error(option_name + " is not of type bool");
+            }
+         }
+         else { // key not found
+            throw py::key_error(option_name + " does not exist");
+         }
+      }, py::arg("option_name"), py::arg("option_value"))
+
       .def("set_option", [](UnoSolverWrapper& solver, const std::string& option_name, uno_int option_value) {
-         solver.options.set_integer(option_name, option_value);
+         const auto type = Options::option_types.find(option_name);
+         if (type != Options::option_types.end()) { // key found
+            if (type->second == OptionType::INTEGER) { // correct type
+               solver.options.set_integer(option_name, option_value);
+            }
+            else { // incorrect type
+               throw py::type_error(option_name + " is not of type int");
+            }
+         }
+         else { // key not found
+            throw py::key_error(option_name + " does not exist");
+         }
       }, py::arg("option_name"), py::arg("option_value"))
 
       .def("set_option", [](UnoSolverWrapper& solver, const std::string& option_name, double option_value) {
-         solver.options.set_double(option_name, option_value);
-      }, py::arg("option_name"), py::arg("option_value"))
-
-      .def("set_option", [](UnoSolverWrapper& solver, const std::string& option_name, bool option_value) {
-         solver.options.set_bool(option_name, option_value);
+         const auto type = Options::option_types.find(option_name);
+         if (type != Options::option_types.end()) { // key found
+            if (type->second == OptionType::DOUBLE) { // correct type
+               solver.options.set_double(option_name, option_value);
+            }
+            else { // incorrect type
+               throw py::type_error(option_name + " is not of type double");
+            }
+         }
+         else { // key not found
+            throw py::key_error(option_name + " does not exist");
+         }
       }, py::arg("option_name"), py::arg("option_value"))
 
       .def("set_option", [](UnoSolverWrapper& solver, const std::string& option_name, const std::string& option_value) {
-         solver.options.set_string(option_name, option_value);
+         const auto type = Options::option_types.find(option_name);
+         if (type != Options::option_types.end()) { // key found
+            if (type->second == OptionType::STRING) { // correct type
+               solver.options.set_string(option_name, option_value);
+            }
+            else { // incorrect type
+               throw py::type_error(option_name + " is not of type string");
+            }
+         }
+         else { // key not found
+            throw py::key_error(option_name + " does not exist");
+         }
       }, py::arg("option_name"), py::arg("option_value"))
 
       .def("set_preset", [](UnoSolverWrapper& solver, const std::string& preset_name) {

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Charlie Vanaret
+// Copyright (c) 2025-2026 Charlie Vanaret
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include "InequalityHandlingMethod.hpp"
@@ -9,7 +9,6 @@
 #include "optimization/Iterate.hpp"
 #include "optimization/OptimizationProblem.hpp"
 #include "options/Options.hpp"
-#include "tools/Infinity.hpp"
 #include "tools/Logger.hpp"
 #include "tools/Statistics.hpp"
 #include "tools/UserCallbacks.hpp"

--- a/uno/options/Options.hpp
+++ b/uno/options/Options.hpp
@@ -41,6 +41,8 @@ namespace uno {
       void overwrite_with(const Options& overwriting_options);
       void print_non_default() const;
 
+      static const std::unordered_map<std::string, OptionType> option_types;
+
    private:
       std::map<std::string, uno_int> integer_options{};
       std::map<std::string, double> double_options{};
@@ -49,8 +51,6 @@ namespace uno {
 
       mutable std::map<std::string, bool> used{};
       mutable std::map<std::string, bool> overwritten_options{};
-
-      static const std::unordered_map<std::string, OptionType> option_types;
    };
 } // namespace
 


### PR DESCRIPTION
In unopy's `UnoSolver.set_option` functions:
- throw `TypeError` if the type of an option doesn't match
- throw `KeyError` if the option is not known

cc @robfalck

Closes https://github.com/cvanaret/Uno/issues/604