### PR TITLE
[unopy] Added `UnoSolver::set_logger_stream`

### DIFF
--- a/interfaces/Python/cpp_classes/PythonStreamBuffer.cpp
+++ b/interfaces/Python/cpp_classes/PythonStreamBuffer.cpp
@@ -1,0 +1,18 @@
+#include "PythonStreamBuffer.hpp"
+
+namespace uno {
+   PythonStreamBuffer::PythonStreamBuffer(pybind11::object output_function) : output_function(output_function) {
+   }
+
+   std::streamsize PythonStreamBuffer::xsputn(const char* s, std::streamsize n) {
+      output_function(std::string(s, n));
+      return n;
+   }
+
+   int PythonStreamBuffer::overflow(int c) {
+      if (c != EOF) {
+         output_function(std::string(1, static_cast<char>(c)));
+      }
+      return c;
+   }
+} // namespace

--- a/interfaces/Python/cpp_classes/PythonStreamBuffer.hpp
+++ b/interfaces/Python/cpp_classes/PythonStreamBuffer.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_PYTHONSTREAMBUFFER_H
+#define UNO_PYTHONSTREAMBUFFER_H
+
+#include <pybind11/pybind11.h>
+#include <streambuf>
+
+namespace uno {
+   class PythonStreamBuffer : public std::streambuf {
+   public:
+      explicit PythonStreamBuffer(pybind11::object output_function);
+
+   protected:
+      std::streamsize xsputn(const char* s, std::streamsize n) override;
+      int overflow(int c) override;
+
+   private:
+      pybind11::object output_function;
+   };
+} // namespace
+
+#endif // UNO_PYTHONSTREAMBUFFER_H

--- a/interfaces/Python/python_modules/UnoSolver.cpp
+++ b/interfaces/Python/python_modules/UnoSolver.cpp
@@ -2,11 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include <pybind11/pybind11.h>
+#include <iostream>
+#include <memory>
 #include <string>
 #include "../cpp_classes/PythonModel.hpp"
+#include "../cpp_classes/PythonStreamBuffer.hpp"
 #include "../cpp_classes/UnoSolverWrapper.hpp"
 #include "options/Options.hpp"
 #include "options/Presets.hpp"
+#include "tools/Logger.hpp"
 
 namespace py = pybind11;
 
@@ -76,6 +80,13 @@ namespace uno {
             throw py::key_error(option_name + " does not exist");
          }
       }, py::arg("option_name"), py::arg("option_value"))
+
+      // store the streambuf and ostream so they stay alive as long as needed
+       .def("set_logger_stream", [](UnoSolverWrapper& /*solver*/, py::object stream) {
+           static auto buffer = std::make_unique<PythonStreamBuffer>(stream.attr("write"));
+           static auto ostream = std::make_unique<std::ostream>(buffer.get());
+           Logger::set_stream(*ostream);
+       })
 
       .def("set_preset", [](UnoSolverWrapper& solver, const std::string& preset_name) {
          Presets::set(solver.options, preset_name);


### PR DESCRIPTION
Added `UnoSolver::set_logger_stream` function. Uses a custom object of type `PythonStreamBuffer`.

```python
uno_solver.set_logger_stream(sys.stdout)

# or

with open("log.txt", "w") as f:
    uno_solver.set_logger_stream(f)
    uno_solver.optimize(model)
    f.flush() # flush necessary at the moment
``` 

cc @robfalck

Closes https://github.com/cvanaret/Uno/issues/613