### PR TITLE
Set the exact Hessian explicitly in the second run of the examples

### DIFF
--- a/interfaces/C/example/example_hs015.c
+++ b/interfaces/C/example/example_hs015.c
@@ -132,6 +132,8 @@ int main() {
       assert(uno_set_lagrangian_hessian(model, number_hessian_nonzeros, hessian_triangular_part, hessian_row_indices,
             hessian_column_indices, lagrangian_hessian));
       assert(uno_set_lagrangian_sign_convention(model, lagrangian_sign_convention));
+      // the Hessian model was overwritten. Set it again
+      uno_set_solver_string_option(solver, "hessian_model", "exact");
       uno_optimize(solver, model);
       // get the solution
       optimization_status = uno_get_optimization_status(solver);

--- a/interfaces/Fortran/example_uno.f90
+++ b/interfaces/Fortran/example_uno.f90
@@ -125,7 +125,7 @@ program example_uno
     success = uno_set_lagrangian_hessian(model, number_hessian_nonzeros, hessian_triangular_part, hessian_row_indices, &
                                          hessian_column_indices, lagrangian_hessian)
     success = uno_set_lagrangian_sign_convention(model, lagrangian_sign_convention)
-    ! The Hessian model was overwritten. Set it again
+    ! the Hessian model was overwritten. Set it again
     success = uno_set_solver_string_option(solver, "hessian_model", hessian_model)
     call uno_optimize(solver, model)
 

--- a/interfaces/Python/example/example_hs015.py
+++ b/interfaces/Python/example/example_hs015.py
@@ -82,6 +82,8 @@ if __name__ == '__main__':
 	model.set_lagrangian_hessian(number_hessian_nonzeros, hessian_triangular_part, hessian_row_indices,
 	  hessian_column_indices, lagrangian_hessian)
 	model.set_lagrangian_sign_convention(lagrangian_sign_convention)
+	# the Hessian model was overwritten. Set it again
+	uno_solver.set_option("hessian_model", "exact")
 	result = uno_solver.optimize(model)
 	print("Objective at solution:", result.solution_objective)
 	# optimization summary


### PR DESCRIPTION
Now that Uno may overwrite some options (including `hessian_model`), we need to set the exact Hessian explicitly in the second run of the examples.
For a more durable solution, see https://github.com/cvanaret/Uno/issues/612.

cc @david0oo