### PR TITLE
Improved Quasi-Newton initialization

### DIFF
--- a/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
@@ -50,8 +50,8 @@ namespace uno {
       // safeguard: if dot(sk, yk) is too small relative to sk and yk, skip the update
       const auto sk = this->S.column(this->current_index);
       const auto yk = this->Y.column(this->current_index);
-      const double norm_sk = dot(sk, sk);
-      const double norm_yk = dot(yk, yk);
+      const double norm_sk = norm_2(sk);
+      const double norm_yk = norm_2(yk);
       // tolerance is √(machine epsilon)
       if (dot(sk, yk) < std::sqrt(std::numeric_limits<double>::epsilon()) * norm_sk * norm_yk) {
          DEBUG << "dot(sk, yk) is too small, skipping the update\n";

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
@@ -198,7 +198,7 @@ namespace uno {
       this->current_index = (this->current_index + 1) % this->memory_size;
    }
 
-   // compute δ = yᵀy / sᵀy at the last entry
+   // compute δ = sᵀy / yᵀy at the last entry
    double LBFGSHessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
       const double sTy = this->D[this->current_index];

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
@@ -201,10 +201,10 @@ namespace uno {
    // compute δ = yᵀy / sᵀy at the last entry
    double LBFGSHessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
+      const double sTy = this->D[this->current_index];
       const auto y = this->Y.column(this->current_index);
       const double yTy = dot(y, y);
-      const double sTy = this->D[this->current_index]; // > 0 by the update rule
       // TODO safeguard
-      return std::min(this->delta_upper_bound, yTy/sTy);
+      return std::min(this->delta_upper_bound, sTy/yTy);
    }
 } // namespace

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -149,7 +149,7 @@ namespace uno {
       this->current_index = (this->current_index + 1) % this->memory_size;
    }
 
-   // compute δ = yᵀy / sᵀy at the last entry
+   // compute δ = sᵀy / yᵀy at the last entry
    double LSR1Hessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
       const auto s = this->S.column(this->current_index);

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -154,8 +154,8 @@ namespace uno {
       assert(0 < this->number_entries_in_memory);
       const auto s = this->S.column(this->current_index);
       const auto y = this->Y.column(this->current_index);
-      const double sTy = dot(s, y);
-      const double yTy = dot(y, y);
-      return sTy/yTy;
+      const double sᵀy = dot(s, y);
+      const double yᵀy = dot(y, y);
+      return sᵀy/yᵀy;
    }
 } // namespace

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -148,7 +148,7 @@ namespace uno {
       // increment the slot: if we exceed the size of the memory, we start over and replace the oldest point in memory
       this->current_index = (this->current_index + 1) % this->memory_size;
    }
-   
+
    double LSR1Hessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
       // TODO safeguard

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -38,8 +38,8 @@ namespace uno {
       // safeguard: if dot(sk, yk) is too small relative to sk and yk, skip the update
       const auto sk = this->S.column(this->current_index);
       const auto yk = this->Y.column(this->current_index);
-      const double norm_sk = dot(sk, sk);
-      const double norm_yk = dot(yk, yk);
+      const double norm_sk = norm_2(sk);
+      const double norm_yk = norm_2(yk);
       // tolerance is √(machine epsilon)
       if (dot(sk, yk) < std::sqrt(std::numeric_limits<double>::epsilon()) * norm_sk * norm_yk) {
          DEBUG << "dot(sk, yk) is too small, skipping the update\n";

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -148,15 +148,10 @@ namespace uno {
       // increment the slot: if we exceed the size of the memory, we start over and replace the oldest point in memory
       this->current_index = (this->current_index + 1) % this->memory_size;
    }
-
-   // compute δ = sᵀy / yᵀy at the last entry
+   
    double LSR1Hessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
-      const auto s = this->S.column(this->current_index);
-      const auto y = this->Y.column(this->current_index);
-      const double sᵀy = dot(s, y);
-      const double yᵀy = dot(y, y);
       // TODO safeguard
-      return sᵀy/yᵀy;
+      return 1.;
    }
 } // namespace

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -149,8 +149,13 @@ namespace uno {
       this->current_index = (this->current_index + 1) % this->memory_size;
    }
 
+   // compute δ = yᵀy / sᵀy at the last entry
    double LSR1Hessian::compute_delta() const {
-      // we cannot use the L-BFGS initialization because it kills U
-      return 1.;
+      assert(0 < this->number_entries_in_memory);
+      const auto s = this->S.column(this->current_index);
+      const auto y = this->Y.column(this->current_index);
+      const double sTy = dot(s, y);
+      const double yTy = dot(y, y);
+      return sTy/yTy;
    }
 } // namespace

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -156,6 +156,7 @@ namespace uno {
       const auto y = this->Y.column(this->current_index);
       const double sᵀy = dot(s, y);
       const double yᵀy = dot(y, y);
+      // TODO safeguard
       return sᵀy/yᵀy;
    }
 } // namespace

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -138,7 +138,6 @@ namespace uno {
       DEBUG << "Initial identity multiple: " << this->delta << "\n";
 
       /* form U = (Y - δ S) J⁻ᵀ */
-      const auto Yk = this->Y.submatrix(this->model.number_variables, this->number_entries_in_memory);
       auto Uk = this->U.submatrix(this->model.number_variables, this->number_entries_in_memory);
       for (size_t column_index: Range(this->number_entries_in_memory)) {
          this->U.column(column_index) = this->Y.column(column_index) - this->delta*this->S.column(column_index);

--- a/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
@@ -177,8 +177,8 @@ namespace uno {
    // compute δ = sᵀy / yᵀy at the last entry
    double InverseLBFGSHessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
-      const auto y = this->Y.column(this->current_index);
       const double sTy = this->R.entry(this->current_index, this->current_index);
+      const auto y = this->Y.column(this->current_index);
       const double yTy = dot(y, y);
       // TODO safeguard
       return sTy/yTy;

--- a/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
@@ -56,8 +56,8 @@ namespace uno {
       // safeguard: if dot(sk, yk) is too small relative to sk and yk, skip the update
       const auto sk = this->S.column(this->current_index);
       const auto yk = this->Y.column(this->current_index);
-      const double norm_sk = dot(sk, sk);
-      const double norm_yk = dot(yk, yk);
+      const double norm_sk = norm_2(sk);
+      const double norm_yk = norm_2(yk);
       // tolerance is √(machine epsilon)
       if (dot(sk, yk) < std::sqrt(std::numeric_limits<double>::epsilon()) * norm_sk * norm_yk) {
          DEBUG << "dot(sk, yk) is too small, skipping the update\n";

--- a/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
@@ -174,13 +174,13 @@ namespace uno {
       this->current_index = (this->current_index + 1) % this->memory_size;
    }
 
-   // compute δ = sᵀy / yᵀy at the last entry
+   // compute δ = yᵀy / sᵀy at the last entry
    double InverseLBFGSHessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
       const double sTy = this->R.entry(this->current_index, this->current_index);
       const auto y = this->Y.column(this->current_index);
       const double yTy = dot(y, y);
       // TODO safeguard
-      return sTy/yTy;
+      return yTy/sTy;
    }
 } // namespace


### PR DESCRIPTION
- fixed typos (`norm` instead of `dot`)
- initialized L-BFGS with $s^T y / y^T y$ instead of $y^T y / s^T y$