### PR TITLE
Pass the bounds separately during model creation

### DIFF
--- a/interfaces/C/README.md
+++ b/interfaces/C/README.md
@@ -26,19 +26,19 @@ void* model = uno_create_unconstrained_model(problem_type, number_variables, bas
 The following optional elements can be added or set to the model separately:
 - lower bounds for the variables:
 ```c
-uno_set_variables_lower_bounds(variables_lower_bounds)
+uno_set_variables_lower_bounds(model, variables_lower_bounds)
 ```
 - upper bounds for the variables:
 ```c
-uno_set_variables_upper_bounds(variables_upper_bounds)
+uno_set_variables_upper_bounds(model, variables_upper_bounds)
 ```
 - a lower bound for a given variable:
 ```c
-uno_set_variable_lower_bound(variable_index, lower_bound)
+uno_set_variable_lower_bound(model, variable_index, lower_bound)
 ```
 - an upper bound for a given variable:
 ```c
-uno_set_variable_upper_bound(variable_index, upper_bound)
+uno_set_variable_upper_bound(model, variable_index, upper_bound)
 ```
 - the objective function (and its gradient). It is 0 otherwise;
 ```c
@@ -52,19 +52,19 @@ uno_set_constraints(model, number_constraints, constraint_functions,
 ```
 - lower bounds for the constraints:
 ```c
-uno_set_constraints_lower_bounds(constraints_lower_bounds)
+uno_set_constraints_lower_bounds(model, constraints_lower_bounds)
 ```
 - upper bounds for the constraints:
 ```c
-uno_set_constraints_upper_bounds(constraints_upper_bounds)
+uno_set_constraints_upper_bounds(model, constraints_upper_bounds)
 ```
 - a lower bound for a given constraint:
 ```c
-uno_set_constraint_lower_bound(constraint_index, lower_bound)
+uno_set_constraint_lower_bound(model, constraint_index, lower_bound)
 ```
 - an upper bound for a given constraint:
 ```c
-uno_set_constraint_upper_bound(constraint_index, upper_bound)
+uno_set_constraint_upper_bound(model, constraint_index, upper_bound)
 ```
 - the Lagrangian Hessian;
 ```c

--- a/interfaces/C/README.md
+++ b/interfaces/C/README.md
@@ -18,8 +18,28 @@ Building an optimization model is incremental and starts with the information ab
 void* model = uno_create_model(problem_type, number_variables,
    variables_lower_bounds, variables_upper_bounds, base_indexing);
 ```
+or (for an unconstrained model):
+```c
+void* model = uno_create_unconstrained_model(problem_type, number_variables, base_indexing);
+```
 
-The following optional elements can be added to the model separately:
+The following optional elements can be added or set to the model separately:
+- lower bounds for the variables:
+```c
+uno_set_variables_lower_bounds(variables_lower_bounds)
+```
+- upper bounds for the variables:
+```c
+uno_set_variables_upper_bounds(variables_upper_bounds)
+```
+- a lower bound for a given variable:
+```c
+uno_set_variable_lower_bound(variable_index, lower_bound)
+```
+- an upper bound for a given variable:
+```c
+uno_set_variable_upper_bound(variable_index, upper_bound)
+```
 - the objective function (and its gradient). It is 0 otherwise;
 ```c
 uno_set_objective(model, optimization_sense, objective_function, objective_gradient);
@@ -29,6 +49,22 @@ uno_set_objective(model, optimization_sense, objective_function, objective_gradi
 uno_set_constraints(model, number_constraints, constraint_functions,
    constraints_lower_bounds, constraints_upper_bounds, number_jacobian_nonzeros,
    jacobian_row_indices, jacobian_column_indices, jacobian);
+```
+- lower bounds for the constraints:
+```c
+uno_set_constraints_lower_bounds(constraints_lower_bounds)
+```
+- upper bounds for the constraints:
+```c
+uno_set_constraints_upper_bounds(constraints_upper_bounds)
+```
+- a lower bound for a given constraint:
+```c
+uno_set_constraint_lower_bound(constraint_index, lower_bound)
+```
+- an upper bound for a given constraint:
+```c
+uno_set_constraint_upper_bound(constraint_index, upper_bound)
 ```
 - the Lagrangian Hessian;
 ```c

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -503,8 +503,7 @@ bool uno_set_variables_lower_bounds(void* model, const double* variables_lower_b
    CUserModel* user_model = static_cast<CUserModel*>(model);
    // copy the bounds internally
    if (variables_lower_bounds != nullptr) {
-      const size_t unsigned_number_variables = static_cast<size_t>(user_model->number_variables);
-      for (size_t variable_index: Range(unsigned_number_variables)) {
+      for (size_t variable_index: Range(static_cast<size_t>(user_model->number_variables))) {
          user_model->variables_lower_bounds[variable_index] = variables_lower_bounds[variable_index];
       }
    }
@@ -519,8 +518,7 @@ bool uno_set_variables_upper_bounds(void* model, const double* variables_upper_b
    CUserModel* user_model = static_cast<CUserModel*>(model);
    // copy the bounds internally
    if (variables_upper_bounds != nullptr) {
-      const size_t unsigned_number_variables = static_cast<size_t>(user_model->number_variables);
-      for (size_t variable_index: Range(unsigned_number_variables)) {
+      for (size_t variable_index: Range(static_cast<size_t>(user_model->number_variables))) {
          user_model->variables_upper_bounds[variable_index] = variables_upper_bounds[variable_index];
       }
    }
@@ -591,12 +589,8 @@ bool uno_set_constraints(void* model, uno_int number_constraints, uno_constraint
    const size_t unsigned_number_constraints = static_cast<size_t>(number_constraints);
    user_model->constraints_lower_bounds.resize(unsigned_number_constraints);
    user_model->constraints_upper_bounds.resize(unsigned_number_constraints);
-   for (size_t constraint_index: Range(unsigned_number_constraints)) {
-      user_model->constraints_lower_bounds[constraint_index] = (constraints_lower_bounds != nullptr) ?
-         constraints_lower_bounds[constraint_index] : -INF<double>;
-      user_model->constraints_upper_bounds[constraint_index] = (constraints_upper_bounds != nullptr) ?
-         constraints_upper_bounds[constraint_index] : INF<double>;
-   }
+   uno_set_constraints_lower_bounds(model, constraints_lower_bounds);
+   uno_set_constraints_upper_bounds(model, constraints_upper_bounds);
    user_model->number_jacobian_nonzeros = number_jacobian_nonzeros;
    // copy the Jacobian sparsity to allow the calling code to dispose of its vectors
    user_model->jacobian_row_indices.resize(static_cast<size_t>(number_jacobian_nonzeros));
@@ -611,6 +605,64 @@ bool uno_set_constraints(void* model, uno_int number_constraints, uno_constraint
    for (size_t constraint_index: Range(unsigned_number_constraints)) {
       user_model->initial_dual_iterate[constraint_index] = 0.;
    }
+   return true;
+}
+
+bool uno_set_constraints_lower_bounds(void* model, const double* constraints_lower_bounds) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   // copy the bounds internally
+   if (constraints_lower_bounds != nullptr) {
+      for (size_t constraint_index: Range(static_cast<size_t>(user_model->number_constraints))) {
+         user_model->constraints_lower_bounds[constraint_index] = constraints_lower_bounds[constraint_index];
+      }
+   }
+   return true;
+}
+
+bool uno_set_constraints_upper_bounds(void* model, const double* constraints_upper_bounds) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   // copy the bounds internally
+   if (constraints_upper_bounds != nullptr) {
+      for (size_t constraint_index: Range(static_cast<size_t>(user_model->number_constraints))) {
+         user_model->constraints_upper_bounds[constraint_index] = constraints_upper_bounds[constraint_index];
+      }
+   }
+   return true;
+}
+
+bool uno_set_constraint_lower_bound(void* model, uno_int constraint_index, double lower_bound) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   if (constraint_index < 0 || constraint_index >= user_model->number_constraints) {
+      WARNING << "Please specify a valid index."  << std::endl;
+      return false;
+   }
+   user_model->constraints_lower_bounds[static_cast<size_t>(constraint_index)] = lower_bound;
+   return true;
+}
+
+bool uno_set_constraint_upper_bound(void* model, uno_int constraint_index, double upper_bound) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   if (constraint_index < 0 || constraint_index >= user_model->number_constraints) {
+      WARNING << "Please specify a valid index."  << std::endl;
+      return false;
+   }
+   user_model->constraints_upper_bounds[static_cast<size_t>(constraint_index)] = upper_bound;
    return true;
 }
 

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -463,7 +463,8 @@ void uno_get_version(uno_int* major, uno_int* minor, uno_int* patch) {
 void* uno_create_model(const char* problem_type, uno_int number_variables, const double* variables_lower_bounds,
       const double* variables_upper_bounds, uno_int base_indexing) {
    void* model = uno_create_unconstrained_model(problem_type, number_variables, base_indexing);
-   uno_set_variables_bounds(model, variables_lower_bounds, variables_upper_bounds);
+   uno_set_variables_lower_bounds(model, variables_lower_bounds);
+   uno_set_variables_upper_bounds(model, variables_upper_bounds);
    return model;
 }
 
@@ -494,16 +495,36 @@ void* uno_create_unconstrained_model(const char* problem_type, uno_int number_va
    return user_model;
 }
 
-bool uno_set_variables_bounds(void* model, const double* variables_lower_bounds, const double* variables_upper_bounds) {
+bool uno_set_variables_lower_bounds(void* model, const double* variables_lower_bounds) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
    CUserModel* user_model = static_cast<CUserModel*>(model);
    // copy the bounds internally
-   const size_t unsigned_number_variables = static_cast<size_t>(user_model->number_variables);
-   for (size_t variable_index: Range(unsigned_number_variables)) {
-      user_model->variables_lower_bounds[variable_index] = (variables_lower_bounds != nullptr) ?
-         variables_lower_bounds[variable_index] : -INF<double>;
-      user_model->variables_upper_bounds[variable_index] = (variables_upper_bounds != nullptr) ?
-         variables_upper_bounds[variable_index] : INF<double>;
+   if (variables_lower_bounds != nullptr) {
+      const size_t unsigned_number_variables = static_cast<size_t>(user_model->number_variables);
+      for (size_t variable_index: Range(unsigned_number_variables)) {
+         user_model->variables_lower_bounds[variable_index] = variables_lower_bounds[variable_index];
+      }
    }
+   return true;
+}
+
+bool uno_set_variables_upper_bounds(void* model, const double* variables_upper_bounds) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   // copy the bounds internally
+   if (variables_upper_bounds != nullptr) {
+      const size_t unsigned_number_variables = static_cast<size_t>(user_model->number_variables);
+      for (size_t variable_index: Range(unsigned_number_variables)) {
+         user_model->variables_upper_bounds[variable_index] = variables_upper_bounds[variable_index];
+      }
+   }
+
    return true;
 }
 

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -507,6 +507,34 @@ bool uno_set_variables_bounds(void* model, const double* variables_lower_bounds,
    return true;
 }
 
+bool uno_set_variable_lower_bound(void* model, uno_int variable_index, double lower_bound) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   if (variable_index < 0 || variable_index >= user_model->number_variables) {
+      WARNING << "Please specify a valid index."  << std::endl;
+      return false;
+   }
+   user_model->variables_lower_bounds[static_cast<size_t>(variable_index)] = lower_bound;
+   return true;
+}
+
+bool uno_set_variable_upper_bound(void* model, uno_int variable_index, double upper_bound) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   if (variable_index < 0 || variable_index >= user_model->number_variables) {
+      WARNING << "Please specify a valid index."  << std::endl;
+      return false;
+   }
+   user_model->variables_upper_bounds[static_cast<size_t>(variable_index)] = upper_bound;
+   return true;
+}
+
 bool uno_set_objective(void* model, uno_int optimization_sense, uno_objective_callback objective_function,
       uno_objective_gradient_callback objective_gradient) {
    if (optimization_sense != UNO_MINIMIZE && optimization_sense != UNO_MAXIMIZE) {

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -462,6 +462,12 @@ void uno_get_version(uno_int* major, uno_int* minor, uno_int* patch) {
 
 void* uno_create_model(const char* problem_type, uno_int number_variables, const double* variables_lower_bounds,
       const double* variables_upper_bounds, uno_int base_indexing) {
+   void* model = uno_create_unconstrained_model(problem_type, number_variables, base_indexing);
+   uno_set_variables_bounds(model, variables_lower_bounds, variables_upper_bounds);
+   return model;
+}
+
+void* uno_create_unconstrained_model(const char* problem_type, uno_int number_variables, uno_int base_indexing) {
    if (number_variables <= 0) {
       WARNING << "Please specify a positive number of variables."  << std::endl;
       return nullptr;
@@ -476,22 +482,29 @@ void* uno_create_model(const char* problem_type, uno_int number_variables, const
       return nullptr;
    }
    CUserModel* user_model = new CUserModel(problem_type, number_variables, base_indexing);
-   // copy the bounds internally
+   // set (-inf, +inf) bounds
    const size_t unsigned_number_variables = static_cast<size_t>(number_variables);
-   user_model->variables_lower_bounds.resize(unsigned_number_variables);
-   user_model->variables_upper_bounds.resize(unsigned_number_variables);
-   for (size_t variable_index: Range(unsigned_number_variables)) {
-      user_model->variables_lower_bounds[variable_index] = (variables_lower_bounds != nullptr) ?
-         variables_lower_bounds[variable_index] : -INF<double>;
-      user_model->variables_upper_bounds[variable_index] = (variables_upper_bounds != nullptr) ?
-         variables_upper_bounds[variable_index] : INF<double>;
-   }
+   user_model->variables_lower_bounds.resize(unsigned_number_variables, -INF<double>);
+   user_model->variables_upper_bounds.resize(unsigned_number_variables, INF<double>);
    // create the initial primal point
    user_model->initial_primal_iterate.resize(unsigned_number_variables);
    for (size_t variable_index: Range(unsigned_number_variables)) {
       user_model->initial_primal_iterate[variable_index] = 0.;
    }
    return user_model;
+}
+
+bool uno_set_variables_bounds(void* model, const double* variables_lower_bounds, const double* variables_upper_bounds) {
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   // copy the bounds internally
+   const size_t unsigned_number_variables = static_cast<size_t>(user_model->number_variables);
+   for (size_t variable_index: Range(unsigned_number_variables)) {
+      user_model->variables_lower_bounds[variable_index] = (variables_lower_bounds != nullptr) ?
+         variables_lower_bounds[variable_index] : -INF<double>;
+      user_model->variables_upper_bounds[variable_index] = (variables_upper_bounds != nullptr) ?
+         variables_upper_bounds[variable_index] : INF<double>;
+   }
+   return true;
 }
 
 bool uno_set_objective(void* model, uno_int optimization_sense, uno_objective_callback objective_function,

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -160,10 +160,16 @@ extern "C" {
    void* uno_create_unconstrained_model(const char* problem_type, uno_int number_variables, uno_int base_indexing);
 
    // [optional]
-   // sets the variables bounds of a given model.
-   // takes as inputs two arrays of lower and upper bounds of size "number_variables".
+   // sets the variables lower bounds of a given model.
+   // takes as inputs an array of lower bounds of size "number_variables".
    // returns true if it succeeded, false otherwise.
-   bool uno_set_variables_bounds(void* model, const double* variables_lower_bounds, const double* variables_upper_bounds);
+   bool uno_set_variables_lower_bounds(void* model, const double* variables_lower_bounds);
+
+   // [optional]
+   // sets the variables upper bounds of a given model.
+   // takes as inputs an array of upper bounds of size "number_variables".
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_variables_upper_bounds(void* model, const double* variables_upper_bounds);
 
    // [optional]
    // sets the lower bound of a given variable.

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -153,6 +153,18 @@ extern "C" {
    void* uno_create_model(const char* problem_type, uno_int number_variables, const double* variables_lower_bounds,
       const double* variables_upper_bounds, uno_int base_indexing);
 
+   // creates an unconstrained optimization model that can be solved by Uno.
+   // initially, the model contains "number_variables" variables, no bounds, no objective function, and no constraints.
+   // takes as inputs the type of problem (UNO_PROBLEM_LINEAR, UNO_PROBLEM_QUADRATIC, or UNO_PROBLEM_NONLINEAR), the
+   // number of variables, and the vector indexing (0 for C-style indexing, 1 for Fortran-style indexing).
+   void* uno_create_unconstrained_model(const char* problem_type, uno_int number_variables, uno_int base_indexing);
+
+   // [optional]
+   // sets the variables bounds of a given model.
+   // takes as inputs two arrays of lower and upper bounds of size "number_variables".
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_variables_bounds(void* model, const double* variables_lower_bounds, const double* variables_upper_bounds);
+
    // [optional]
    // sets the objective and objective gradient of a given model.
    // takes as inputs the optimization sense (UNO_MINIMIZE or UNO_MAXIMIZE), a function pointer of the objective

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -200,6 +200,28 @@ extern "C" {
       const uno_int* jacobian_row_indices, const uno_int* jacobian_column_indices, uno_constraints_jacobian_callback jacobian);
 
    // [optional]
+   // sets the constraints lower bounds of a given model.
+   // takes as inputs an array of lower bounds of size "number_constraints".
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_constraints_lower_bounds(void* model, const double* constraints_lower_bounds);
+
+   // [optional]
+   // sets the constraints upper bounds of a given model.
+   // takes as inputs an array of upper bounds of size "number_constraints".
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_constraints_upper_bounds(void* model, const double* constraints_upper_bounds);
+
+   // [optional]
+   // sets the lower bound of a given constraint.
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_constraint_lower_bound(void* model, uno_int constraint_index, double lower_bound);
+
+   // [optional]
+   // sets the upper bound of a given constraint.
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_constraint_upper_bound(void* model, uno_int constraint_index, double upper_bound);
+
+   // [optional]
    // sets the Jacobian operator (computes Jacobian-vector products) of a given model.
    // returns true if it succeeded, false otherwise.
    bool uno_set_jacobian_operator(void* model, uno_constraints_jacobian_operator_callback jacobian_operator);

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -166,6 +166,16 @@ extern "C" {
    bool uno_set_variables_bounds(void* model, const double* variables_lower_bounds, const double* variables_upper_bounds);
 
    // [optional]
+   // sets the lower bound of a given variable.
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_variable_lower_bound(void* model, uno_int variable_index, double lower_bound);
+
+   // [optional]
+   // sets the upper bound of a given variable.
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_variable_upper_bound(void* model, uno_int variable_index, double upper_bound);
+
+   // [optional]
    // sets the objective and objective gradient of a given model.
    // takes as inputs the optimization sense (UNO_MINIMIZE or UNO_MAXIMIZE), a function pointer of the objective
    // function and a function pointer of its gradient function.

--- a/interfaces/Fortran/README.md
+++ b/interfaces/Fortran/README.md
@@ -74,6 +74,30 @@ model = uno_create_unconstrained_model(problem_type, number_variables, &
 ```
 
 The following optional elements can be added or set to the model separately:
+* lower bounds for the variables:
+```fortran
+logical(c_bool) :: success
+success = uno_set_variables_lower_bounds(variables_lower_bounds)
+```
+
+* upper bounds for the variables:
+```fortran
+logical(c_bool) :: success
+success = uno_set_variables_upper_bounds(variables_upper_bounds)
+```
+
+* a lower bound for a given variable:
+```fortran
+logical(c_bool) :: success
+success = uno_set_variable_lower_bound(variable_index, lower_bound)
+```
+
+* an upper bound for a given variable:
+```fortran
+logical(c_bool) :: success
+success = uno_set_variable_upper_bound(variable_index, upper_bound)
+```
+
 * the objective function and its gradient:
 
 ```fortran
@@ -90,6 +114,30 @@ success = uno_set_constraints(model, number_constraints, constraint_functions, &
                               constraints_lower_bounds, constraints_upper_bounds, &
                               number_jacobian_nonzeros, jacobian_row_indices, &
                               jacobian_column_indices, jacobian)
+```
+
+* lower bounds for the constraints:
+```fortran
+logical(c_bool) :: success
+success = uno_set_constraints_lower_bounds(constraints_lower_bounds)
+```
+
+* upper bounds for the constraints:
+```fortran
+logical(c_bool) :: success
+success = uno_set_constraints_upper_bounds(constraints_upper_bounds)
+```
+
+* a lower bound for a given constraint:
+```fortran
+logical(c_bool) :: success
+success = uno_set_constraint_lower_bound(constraint_index, lower_bound)
+```
+
+* an upper bound for a given constraint:
+```fortran
+logical(c_bool) :: success
+success = uno_set_constraint_upper_bound(constraint_index, upper_bound)
 ```
 
 * the Lagrangian Hessian:

--- a/interfaces/Fortran/README.md
+++ b/interfaces/Fortran/README.md
@@ -77,25 +77,25 @@ The following optional elements can be added or set to the model separately:
 * lower bounds for the variables:
 ```fortran
 logical(c_bool) :: success
-success = uno_set_variables_lower_bounds(variables_lower_bounds)
+success = uno_set_variables_lower_bounds(model, variables_lower_bounds)
 ```
 
 * upper bounds for the variables:
 ```fortran
 logical(c_bool) :: success
-success = uno_set_variables_upper_bounds(variables_upper_bounds)
+success = uno_set_variables_upper_bounds(model, variables_upper_bounds)
 ```
 
 * a lower bound for a given variable:
 ```fortran
 logical(c_bool) :: success
-success = uno_set_variable_lower_bound(variable_index, lower_bound)
+success = uno_set_variable_lower_bound(model, variable_index, lower_bound)
 ```
 
 * an upper bound for a given variable:
 ```fortran
 logical(c_bool) :: success
-success = uno_set_variable_upper_bound(variable_index, upper_bound)
+success = uno_set_variable_upper_bound(model, variable_index, upper_bound)
 ```
 
 * the objective function and its gradient:
@@ -119,25 +119,25 @@ success = uno_set_constraints(model, number_constraints, constraint_functions, &
 * lower bounds for the constraints:
 ```fortran
 logical(c_bool) :: success
-success = uno_set_constraints_lower_bounds(constraints_lower_bounds)
+success = uno_set_constraints_lower_bounds(model, constraints_lower_bounds)
 ```
 
 * upper bounds for the constraints:
 ```fortran
 logical(c_bool) :: success
-success = uno_set_constraints_upper_bounds(constraints_upper_bounds)
+success = uno_set_constraints_upper_bounds(model, constraints_upper_bounds)
 ```
 
 * a lower bound for a given constraint:
 ```fortran
 logical(c_bool) :: success
-success = uno_set_constraint_lower_bound(constraint_index, lower_bound)
+success = uno_set_constraint_lower_bound(model, constraint_index, lower_bound)
 ```
 
 * an upper bound for a given constraint:
 ```fortran
 logical(c_bool) :: success
-success = uno_set_constraint_upper_bound(constraint_index, upper_bound)
+success = uno_set_constraint_upper_bound(model, constraint_index, upper_bound)
 ```
 
 * the Lagrangian Hessian:

--- a/interfaces/Fortran/README.md
+++ b/interfaces/Fortran/README.md
@@ -67,9 +67,13 @@ model = uno_create_model(problem_type, number_variables, &
                          variables_lower_bounds, variables_upper_bounds, &
                          base_indexing)
 ```
+or (for an unconstrained model):
+```fortran
+model = uno_create_unconstrained_model(problem_type, number_variables, &
+                                       base_indexing)
+```
 
-The following optional elements can be added to the model separately:
-
+The following optional elements can be added or set to the model separately:
 * the objective function and its gradient:
 
 ```fortran

--- a/interfaces/Fortran/uno_c.f90
+++ b/interfaces/Fortran/uno_c.f90
@@ -449,6 +449,47 @@ interface
 end interface
 
 !---------------------------------------------
+! uno_set_variables_bounds
+!---------------------------------------------
+interface
+   function uno_set_variables_bounds(model, variables_lower_bounds, variables_upper_bounds) result(success) &
+      bind(C, name="uno_set_variables_bounds")
+      import :: c_ptr, c_double, c_bool
+      type(c_ptr), value :: model
+      real(c_double) :: variables_lower_bounds(*), variables_upper_bounds(*)
+      logical(c_bool) :: success
+   end function uno_set_variables_bounds
+end interface
+
+!---------------------------------------------
+! uno_set_variable_lower_bound
+!---------------------------------------------
+interface
+   function uno_set_variable_lower_bound(model, variable_index, lower_bound) result(success) &
+      bind(C, name="uno_set_variable_lower_bound")
+      import :: c_ptr, uno_int, c_double, c_bool
+      type(c_ptr), value :: model
+      integer(uno_int), value :: variable_index
+      real(c_double) :: lower_bound
+      logical(c_bool) :: success
+   end function uno_set_variable_lower_bound
+end interface
+
+!---------------------------------------------
+! uno_set_variable_upper_bound
+!---------------------------------------------
+interface
+   function uno_set_variable_upper_bound(model, variable_index, upper_bound) result(success) &
+      bind(C, name="uno_set_variable_upper_bound")
+      import :: c_ptr, uno_int, c_double, c_bool
+      type(c_ptr), value :: model
+      integer(uno_int), value :: variable_index
+      real(c_double) :: upper_bound
+      logical(c_bool) :: success
+   end function uno_set_variable_upper_bound
+end interface
+
+!---------------------------------------------
 ! uno_set_initial_primal_iterate_component
 !---------------------------------------------
 interface

--- a/interfaces/Fortran/uno_c.f90
+++ b/interfaces/Fortran/uno_c.f90
@@ -318,6 +318,64 @@ interface
 end interface
 
 !---------------------------------------------
+! uno_set_variables_lower_bounds
+!---------------------------------------------
+interface
+   function uno_set_variables_lower_bounds(model, variables_lower_bounds) &
+      result(success) &
+      bind(C, name="uno_set_variables_lower_bounds")
+      import :: c_ptr, c_double, c_bool
+      type(c_ptr), value :: model
+      real(c_double) :: variables_lower_bounds(*)
+      logical(c_bool) :: success
+   end function uno_set_variables_lower_bounds
+end interface
+
+!---------------------------------------------
+! uno_set_variables_upper_bounds
+!---------------------------------------------
+interface
+   function uno_set_variables_upper_bounds(model, variables_upper_bounds) &
+      result(success) &
+      bind(C, name="uno_set_variables_upper_bounds")
+      import :: c_ptr, c_double, c_bool
+      type(c_ptr), value :: model
+      real(c_double) :: variables_upper_bounds(*)
+      logical(c_bool) :: success
+   end function uno_set_variables_upper_bounds
+end interface
+
+!---------------------------------------------
+! uno_set_variable_lower_bound
+!---------------------------------------------
+interface
+   function uno_set_variable_lower_bound(model, variable_index, lower_bound) &
+      result(success) &
+      bind(C, name="uno_set_variable_lower_bound")
+      import :: c_ptr, uno_int, c_double, c_bool
+      type(c_ptr), value :: model
+      integer(uno_int), value :: variable_index
+      real(c_double), value :: lower_bound
+      logical(c_bool) :: success
+   end function uno_set_variable_lower_bound
+end interface
+
+!---------------------------------------------
+! uno_set_variable_upper_bound
+!---------------------------------------------
+interface
+   function uno_set_variable_upper_bound(model, variable_index, upper_bound) &
+      result(success) &
+      bind(C, name="uno_set_variable_upper_bound")
+      import :: c_ptr, uno_int, c_double, c_bool
+      type(c_ptr), value :: model
+      integer(uno_int), value :: variable_index
+      real(c_double), value :: upper_bound
+      logical(c_bool) :: success
+   end function uno_set_variable_upper_bound
+end interface
+
+!---------------------------------------------
 ! uno_set_objective
 !---------------------------------------------
 interface
@@ -356,6 +414,64 @@ interface
       type(c_funptr), value :: jacobian
       logical(c_bool) :: success
    end function uno_set_constraints
+end interface
+
+!---------------------------------------------
+! uno_set_constraints_lower_bounds
+!---------------------------------------------
+interface
+   function uno_set_constraints_lower_bounds(model, constraints_lower_bounds) &
+      result(success) &
+      bind(C, name="uno_set_constraints_lower_bounds")
+      import :: c_ptr, c_double, c_bool
+      type(c_ptr), value :: model
+      real(c_double) :: constraints_lower_bounds(*)
+      logical(c_bool) :: success
+   end function uno_set_constraints_lower_bounds
+end interface
+
+!---------------------------------------------
+! uno_set_constraints_upper_bounds
+!---------------------------------------------
+interface
+   function uno_set_constraints_upper_bounds(model, constraints_upper_bounds) &
+      result(success) &
+      bind(C, name="uno_set_constraints_upper_bounds")
+      import :: c_ptr, c_double, c_bool
+      type(c_ptr), value :: model
+      real(c_double) :: constraints_upper_bounds(*)
+      logical(c_bool) :: success
+   end function uno_set_constraints_upper_bounds
+end interface
+
+!---------------------------------------------
+! uno_set_constraint_lower_bound
+!---------------------------------------------
+interface
+   function uno_set_constraint_lower_bound(model, constraint_index, lower_bound) &
+      result(success) &
+      bind(C, name="uno_set_constraint_lower_bound")
+      import :: c_ptr, uno_int, c_double, c_bool
+      type(c_ptr), value :: model
+      integer(uno_int), value :: constraint_index
+      real(c_double), value :: lower_bound
+      logical(c_bool) :: success
+   end function uno_set_constraint_lower_bound
+end interface
+
+!---------------------------------------------
+! uno_set_constraint_upper_bound
+!---------------------------------------------
+interface
+   function uno_set_constraint_upper_bound(model, constraint_index, upper_bound) &
+      result(success) &
+      bind(C, name="uno_set_constraint_upper_bound")
+      import :: c_ptr, uno_int, c_double, c_bool
+      type(c_ptr), value :: model
+      integer(uno_int), value :: constraint_index
+      real(c_double), value :: upper_bound
+      logical(c_bool) :: success
+   end function uno_set_constraint_upper_bound
 end interface
 
 !---------------------------------------------
@@ -446,47 +562,6 @@ interface
       type(c_ptr), value :: user_data
       logical(c_bool) :: success
    end function uno_set_user_data
-end interface
-
-!---------------------------------------------
-! uno_set_variables_bounds
-!---------------------------------------------
-interface
-   function uno_set_variables_bounds(model, variables_lower_bounds, variables_upper_bounds) result(success) &
-      bind(C, name="uno_set_variables_bounds")
-      import :: c_ptr, c_double, c_bool
-      type(c_ptr), value :: model
-      real(c_double) :: variables_lower_bounds(*), variables_upper_bounds(*)
-      logical(c_bool) :: success
-   end function uno_set_variables_bounds
-end interface
-
-!---------------------------------------------
-! uno_set_variable_lower_bound
-!---------------------------------------------
-interface
-   function uno_set_variable_lower_bound(model, variable_index, lower_bound) result(success) &
-      bind(C, name="uno_set_variable_lower_bound")
-      import :: c_ptr, uno_int, c_double, c_bool
-      type(c_ptr), value :: model
-      integer(uno_int), value :: variable_index
-      real(c_double) :: lower_bound
-      logical(c_bool) :: success
-   end function uno_set_variable_lower_bound
-end interface
-
-!---------------------------------------------
-! uno_set_variable_upper_bound
-!---------------------------------------------
-interface
-   function uno_set_variable_upper_bound(model, variable_index, upper_bound) result(success) &
-      bind(C, name="uno_set_variable_upper_bound")
-      import :: c_ptr, uno_int, c_double, c_bool
-      type(c_ptr), value :: model
-      integer(uno_int), value :: variable_index
-      real(c_double) :: upper_bound
-      logical(c_bool) :: success
-   end function uno_set_variable_upper_bound
 end interface
 
 !---------------------------------------------

--- a/interfaces/Fortran/uno_fortran.f90
+++ b/interfaces/Fortran/uno_fortran.f90
@@ -48,6 +48,36 @@ function uno_create_model(problem_type, number_variables, variables_lower_bounds
 end function uno_create_model
 
 !---------------------------------------------
+! uno_create_unconstrained_model
+!---------------------------------------------
+function uno_create_model(problem_type, number_variables, base_indexing) result(model)
+   character(len=*) :: problem_type
+   integer(uno_int), value :: number_variables, base_indexing
+   type(c_ptr) :: model
+   character(c_char), allocatable :: problem_type_c(:)
+   integer :: i, n
+
+   interface
+      function uno_create_unconstrained_model_c(problem_type, number_variables, base_indexing) result(model) &
+         bind(C, name="uno_create_unconstrained_model")
+         import :: c_char, uno_int, c_ptr
+         character(c_char) :: problem_type(*)
+         integer(uno_int), value :: number_variables, base_indexing
+         type(c_ptr) :: model
+      end function uno_create_unconstrained_model_c
+   end interface
+
+   n = len_trim(problem_type)
+   allocate(problem_type_c(n+1))
+   do i = 1, n
+      problem_type_c(i) = problem_type(i:i)
+   end do
+   problem_type_c(n+1) = c_null_char
+   model = uno_create_unconstrained_model_c(problem_type_c, number_variables, base_indexing)
+   deallocate(problem_type_c)
+end function uno_create_unconstrained_model
+
+!---------------------------------------------
 ! uno_set_solver_integer_option
 !---------------------------------------------
 function uno_set_solver_integer_option(solver, option_name, option_value) result(success)

--- a/interfaces/Fortran/uno_fortran.f90
+++ b/interfaces/Fortran/uno_fortran.f90
@@ -50,7 +50,7 @@ end function uno_create_model
 !---------------------------------------------
 ! uno_create_unconstrained_model
 !---------------------------------------------
-function uno_create_model(problem_type, number_variables, base_indexing) result(model)
+function uno_create_unconstrained_model(problem_type, number_variables, base_indexing) result(model)
    character(len=*) :: problem_type
    integer(uno_int), value :: number_variables, base_indexing
    type(c_ptr) :: model

--- a/interfaces/Fortran/uno_fortran.f90
+++ b/interfaces/Fortran/uno_fortran.f90
@@ -50,19 +50,24 @@ end function uno_create_model
 !---------------------------------------------
 ! uno_create_unconstrained_model
 !---------------------------------------------
-function uno_create_unconstrained_model(problem_type, number_variables, base_indexing) result(model)
+function uno_create_unconstrained_model(problem_type, number_variables, base_indexing) &
+   result(model)
    character(len=*) :: problem_type
-   integer(uno_int), value :: number_variables, base_indexing
+   integer(uno_int), value :: number_variables
+   integer(uno_int), value :: base_indexing
    type(c_ptr) :: model
    character(c_char), allocatable :: problem_type_c(:)
    integer :: i, n
 
    interface
-      function uno_create_unconstrained_model_c(problem_type, number_variables, base_indexing) result(model) &
+      function uno_create_unconstrained_model_c(problem_type, number_variables, &
+                                                base_indexing) &
+         result(model) &
          bind(C, name="uno_create_unconstrained_model")
          import :: c_char, uno_int, c_ptr
          character(c_char) :: problem_type(*)
-         integer(uno_int), value :: number_variables, base_indexing
+         integer(uno_int), value :: number_variables
+         integer(uno_int), value :: base_indexing
          type(c_ptr) :: model
       end function uno_create_unconstrained_model_c
    end interface
@@ -73,7 +78,8 @@ function uno_create_unconstrained_model(problem_type, number_variables, base_ind
       problem_type_c(i) = problem_type(i:i)
    end do
    problem_type_c(n+1) = c_null_char
-   model = uno_create_unconstrained_model_c(problem_type_c, number_variables, base_indexing)
+   model = uno_create_unconstrained_model_c(problem_type_c, number_variables, &
+                                            base_indexing)
    deallocate(problem_type_c)
 end function uno_create_unconstrained_model
 

--- a/interfaces/Julia/src/C_wrapper.jl
+++ b/interfaces/Julia/src/C_wrapper.jl
@@ -260,30 +260,21 @@ function uno_model(
   )
 end
 
-function uno_set_variables_bounds(model::Model, variables_lower_bounds::Vector{Float64}, variables_upper_bounds::Vector{Float64})
-  @assert model.nvar == length(variables_lower_bounds) == length(variables_upper_bounds)
+function uno_set_variables_lower_bounds(model::Model, variables_lower_bounds::Vector{Float64})
+  @assert model.nvar == length(variables_lower_bounds)
   GC.@preserve model begin
-    flag = uno_set_variables_bounds(model.c_model, variables_lower_bounds, variables_upper_bounds)
+    flag = uno_set_variables_lower_bounds(model.c_model, variables_lower_bounds)
   end
-  flag || error("Failed to set variables bounds via uno_set_variables_bounds.")
+  flag || error("Failed to set variables lower bounds via uno_set_variables_lower_bounds.")
   return
 end
 
-function uno_set_variable_lower_bound(model::Model, variable_index::Int, lower_bound::Float64)
-  @assert 1 <= variable_index <= model.nvar
+function uno_set_variables_upper_bounds(model::Model, variables_upper_bounds::Vector{Float64})
+  @assert model.nvar == length(variables_upper_bounds)
   GC.@preserve model begin
-    flag = uno_set_variable_lower_bound(model.c_model, variable_index, lower_bound)
+    flag = uno_set_variables_upper_bounds(model.c_model, variables_upper_bounds)
   end
-  flag || error("Failed to set lower bound via uno_set_variable_lower_bound.")
-  return
-end
-
-function uno_set_variable_upper_bound(model::Model, variable_index::Int, upper_bound::Float64)
-  @assert 1 <= variable_index <= model.nvar
-  GC.@preserve model begin
-    flag = uno_set_variable_upper_bound(model.c_model, variable_index, upper_bound)
-  end
-  flag || error("Failed to set upper bound via uno_set_variable_upper_bound.")
+  flag || error("Failed to set variables upper bounds via uno_set_variables_upper_bounds.")
   return
 end
 

--- a/interfaces/Julia/src/C_wrapper.jl
+++ b/interfaces/Julia/src/C_wrapper.jl
@@ -278,6 +278,24 @@ function uno_set_variables_upper_bounds(model::Model, variables_upper_bounds::Ve
   return
 end
 
+function uno_set_constraints_lower_bounds(model::Model, constraints_lower_bounds::Vector{Float64})
+  @assert model.ncon == length(constraints_lower_bounds)
+  GC.@preserve model begin
+    flag = uno_set_constraints_lower_bounds(model.c_model, constraints_lower_bounds)
+  end
+  flag || error("Failed to set constraints lower bounds via uno_set_constraints_lower_bounds.")
+  return
+end
+
+function uno_set_constraints_upper_bounds(model::Model, constraints_upper_bounds::Vector{Float64})
+  @assert model.ncon == length(constraints_upper_bounds)
+  GC.@preserve model begin
+    flag = uno_set_constraints_upper_bounds(model.c_model, constraints_upper_bounds)
+  end
+  flag || error("Failed to set constraints upper bounds via uno_set_constraints_upper_bounds.")
+  return
+end
+
 function uno_set_initial_primal_iterate(model::Model, initial_primal_iterate::Vector{Float64})
   @assert model.nvar == length(initial_primal_iterate)
   GC.@preserve model begin

--- a/interfaces/Julia/src/C_wrapper.jl
+++ b/interfaces/Julia/src/C_wrapper.jl
@@ -260,6 +260,15 @@ function uno_model(
   )
 end
 
+function uno_set_variables_bounds(model::Model, variables_lower_bounds::Vector{Float64}, variables_upper_bounds::Vector{Float64})
+  @assert model.nvar == length(variables_lower_bounds) == length(variables_upper_bounds)
+  GC.@preserve model begin
+    flag = uno_set_variables_bounds(model.c_model, variables_lower_bounds, variables_upper_bounds)
+  end
+  flag || error("Failed to set variables bounds via uno_set_variables_bounds.")
+  return
+end
+
 function uno_set_initial_primal_iterate(model::Model, initial_primal_iterate::Vector{Float64})
   @assert model.nvar == length(initial_primal_iterate)
   GC.@preserve model begin

--- a/interfaces/Julia/src/C_wrapper.jl
+++ b/interfaces/Julia/src/C_wrapper.jl
@@ -269,6 +269,24 @@ function uno_set_variables_bounds(model::Model, variables_lower_bounds::Vector{F
   return
 end
 
+function uno_set_variable_lower_bound(model::Model, variable_index::Int, lower_bound::Float64)
+  @assert 1 <= variable_index <= model.nvar
+  GC.@preserve model begin
+    flag = uno_set_variable_lower_bound(model.c_model, variable_index, lower_bound)
+  end
+  flag || error("Failed to set lower bound via uno_set_variable_lower_bound.")
+  return
+end
+
+function uno_set_variable_upper_bound(model::Model, variable_index::Int, upper_bound::Float64)
+  @assert 1 <= variable_index <= model.nvar
+  GC.@preserve model begin
+    flag = uno_set_variable_upper_bound(model.c_model, variable_index, upper_bound)
+  end
+  flag || error("Failed to set upper bound via uno_set_variable_upper_bound.")
+  return
+end
+
 function uno_set_initial_primal_iterate(model::Model, initial_primal_iterate::Vector{Float64})
   @assert model.nvar == length(initial_primal_iterate)
   GC.@preserve model begin

--- a/interfaces/Julia/src/UnoSolver.jl
+++ b/interfaces/Julia/src/UnoSolver.jl
@@ -18,8 +18,9 @@ export uno, uno_model, uno_solver, uno_optimize, uno_version
 export uno_set_solver_integer_option, uno_set_solver_double_option
 export uno_set_solver_bool_option, uno_set_solver_string_option
 export uno_set_solver_preset, uno_statistics
-export uno_set_variables_bounds, uno_set_variable_lower_bound, uno_set_variable_upper_bound
 export uno_set_initial_primal_iterate, uno_set_initial_dual_iterate
+export uno_set_variables_lower_bounds, uno_set_variables_upper_bounds
+export uno_set_constraints_lower_bounds, uno_set_constraints_upper_bounds
 
 export UnoExecutionStats
 

--- a/interfaces/Julia/src/UnoSolver.jl
+++ b/interfaces/Julia/src/UnoSolver.jl
@@ -18,6 +18,7 @@ export uno, uno_model, uno_solver, uno_optimize, uno_version
 export uno_set_solver_integer_option, uno_set_solver_double_option
 export uno_set_solver_bool_option, uno_set_solver_string_option
 export uno_set_solver_preset, uno_statistics
+export uno_set_variables_bounds, uno_set_initial_primal_iterate, uno_set_initial_dual_iterate
 
 export UnoExecutionStats
 

--- a/interfaces/Julia/src/UnoSolver.jl
+++ b/interfaces/Julia/src/UnoSolver.jl
@@ -18,7 +18,8 @@ export uno, uno_model, uno_solver, uno_optimize, uno_version
 export uno_set_solver_integer_option, uno_set_solver_double_option
 export uno_set_solver_bool_option, uno_set_solver_string_option
 export uno_set_solver_preset, uno_statistics
-export uno_set_variables_bounds, uno_set_initial_primal_iterate, uno_set_initial_dual_iterate
+export uno_set_variables_bounds, uno_set_variable_lower_bound, uno_set_variable_upper_bound
+export uno_set_initial_primal_iterate, uno_set_initial_dual_iterate
 
 export UnoExecutionStats
 

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -57,10 +57,14 @@ function uno_create_unconstrained_model(problem_type, number_variables, base_ind
                                                  base_indexing::Int32)::Ptr{Cvoid}
 end
 
-function uno_set_variables_bounds(model, variables_lower_bounds, variables_upper_bounds)
-    @ccall libuno.uno_set_variables_bounds(model::Ptr{Cvoid},
-                                           variables_lower_bounds::Ptr{Cdouble},
-                                           variables_upper_bounds::Ptr{Cdouble})::Bool
+function uno_set_variables_lower_bounds(model, variables_lower_bounds)
+    @ccall libuno.uno_set_variables_lower_bounds(model::Ptr{Cvoid},
+                                                 variables_lower_bounds::Ptr{Cdouble})::Bool
+end
+
+function uno_set_variables_upper_bounds(model, variables_upper_bounds)
+    @ccall libuno.uno_set_variables_upper_bounds(model::Ptr{Cvoid},
+                                                 variables_upper_bounds::Ptr{Cdouble})::Bool
 end
 
 function uno_set_variable_lower_bound(model, variable_index, lower_bound)

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -51,6 +51,18 @@ function uno_create_model(problem_type, number_variables, variables_lower_bounds
                                    base_indexing::Int32)::Ptr{Cvoid}
 end
 
+function uno_create_unconstrained_model(problem_type, number_variables, base_indexing)
+    @ccall libuno.uno_create_unconstrained_model(problem_type::Cstring,
+                                                 number_variables::Int32,
+                                                 base_indexing::Int32)::Ptr{Cvoid}
+end
+
+function uno_set_variables_bounds(model, variables_lower_bounds, variables_upper_bounds)
+    @ccall libuno.uno_set_variables_bounds(model::Ptr{Cvoid},
+                                           variables_lower_bounds::Ptr{Cdouble},
+                                           variables_upper_bounds::Ptr{Cdouble})::Bool
+end
+
 function uno_set_objective(model, optimization_sense, objective_function,
                            objective_gradient)
     @ccall libuno.uno_set_objective(model::Ptr{Cvoid}, optimization_sense::Int32,

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -63,6 +63,16 @@ function uno_set_variables_bounds(model, variables_lower_bounds, variables_upper
                                            variables_upper_bounds::Ptr{Cdouble})::Bool
 end
 
+function uno_set_variable_lower_bound(model, variable_index, lower_bound)
+    @ccall libuno.uno_set_variable_lower_bound(model::Ptr{Cvoid}, variable_index::Int32,
+                                               lower_bound::Cdouble)::Bool
+end
+
+function uno_set_variable_upper_bound(model, variable_index, upper_bound)
+    @ccall libuno.uno_set_variable_upper_bound(model::Ptr{Cvoid}, variable_index::Int32,
+                                               upper_bound::Cdouble)::Bool
+end
+
 function uno_set_objective(model, optimization_sense, objective_function,
                            objective_gradient)
     @ccall libuno.uno_set_objective(model::Ptr{Cvoid}, optimization_sense::Int32,

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -98,6 +98,26 @@ function uno_set_constraints(model, number_constraints, constraint_functions,
                                       jacobian::Ptr{Cvoid})::Bool
 end
 
+function uno_set_constraints_lower_bounds(model, constraints_lower_bounds)
+    @ccall libuno.uno_set_constraints_lower_bounds(model::Ptr{Cvoid},
+                                                   constraints_lower_bounds::Ptr{Cdouble})::Bool
+end
+
+function uno_set_constraints_upper_bounds(model, constraints_upper_bounds)
+    @ccall libuno.uno_set_constraints_upper_bounds(model::Ptr{Cvoid},
+                                                   constraints_upper_bounds::Ptr{Cdouble})::Bool
+end
+
+function uno_set_constraint_lower_bound(model, constraint_index, lower_bound)
+    @ccall libuno.uno_set_constraint_lower_bound(model::Ptr{Cvoid}, constraint_index::Int32,
+                                                 lower_bound::Cdouble)::Bool
+end
+
+function uno_set_constraint_upper_bound(model, constraint_index, upper_bound)
+    @ccall libuno.uno_set_constraint_upper_bound(model::Ptr{Cvoid}, constraint_index::Int32,
+                                                 upper_bound::Cdouble)::Bool
+end
+
 function uno_set_jacobian_operator(model, jacobian_operator)
     @ccall libuno.uno_set_jacobian_operator(model::Ptr{Cvoid},
                                             jacobian_operator::Ptr{Cvoid})::Bool

--- a/interfaces/Julia/test/C_wrapper.jl
+++ b/interfaces/Julia/test/C_wrapper.jl
@@ -214,8 +214,22 @@ end
       c_lagrangian_hessian_operator_hs71,
     )
 
-    UnoSolver.uno_set_initial_primal_iterate(model, x0)
-    UnoSolver.uno_set_initial_dual_iterate(model, y0)
+    uno_set_initial_primal_iterate(model, x0)
+    uno_set_initial_dual_iterate(model, y0)
+
+    # code coverage
+    uno_set_variables_lower_bounds(model, lvar)
+    uno_set_variables_upper_bounds(model, uvar)
+    for i = 1:nvar
+      UnoSolver.uno_set_variable_lower_bound(model, i-1, lvar[i])
+      UnoSolver.uno_set_variable_upper_bound(model, i-1, uvar[i])
+    end
+    uno_set_constraints_lower_bounds(model, lcon)
+    uno_set_constraints_upper_bounds(model, ucon)
+    for i = 1:ncon
+      UnoSolver.uno_set_constraint_lower_bound(model, i-1, lcon[i])
+      UnoSolver.uno_set_constraint_upper_bound(model, i-1, ucon[i])
+    end
 
     solver = uno_solver()
     uno_set_solver_preset(solver, "filtersqp")
@@ -281,8 +295,8 @@ end
       nothing,
     )
 
-    UnoSolver.uno_set_initial_primal_iterate(model, x0)
-    UnoSolver.uno_set_initial_dual_iterate(model, y0)
+    uno_set_initial_primal_iterate(model, x0)
+    uno_set_initial_dual_iterate(model, y0)
 
     solver = uno_solver()
     uno_set_solver_preset(solver, "filtersqp")
@@ -461,7 +475,15 @@ end
       1,
     )
 
-    UnoSolver.uno_set_initial_primal_iterate(model, x0)
+    uno_set_initial_primal_iterate(model, x0)
+
+    # code coverage
+    uno_set_variables_lower_bounds(model, lvar)
+    uno_set_variables_upper_bounds(model, uvar)
+    for i = 1:nvar
+      UnoSolver.uno_set_variable_lower_bound(model, i-1, lvar[i])
+      UnoSolver.uno_set_variable_upper_bound(model, i-1, uvar[i])
+    end
 
     solver = uno_solver()
     uno_set_solver_preset(solver, "filtersqp")
@@ -515,7 +537,7 @@ end
       1,
     )
 
-    UnoSolver.uno_set_initial_primal_iterate(model, x0)
+    uno_set_initial_primal_iterate(model, x0)
 
     solver = uno_solver()
     uno_set_solver_preset(solver, "filtersqp")

--- a/interfaces/Python/README.md
+++ b/interfaces/Python/README.md
@@ -24,8 +24,28 @@ Building an optimization model is incremental and starts with the information ab
 model = unopy.Model(problem_type, number_variables,
    variables_lower_bounds, variables_upper_bounds, base_indexing)
 ```
+or (for an unconstrained model):
+```python
+model = unopy.Model(problem_type, number_variables, base_indexing)
+```
 
-The following optional elements can be added to the model separately:
+The following optional elements can be added or set to the model separately:
+- lower bounds for the variables:
+```python
+model.set_variables_lower_bounds(variables_lower_bounds)
+```
+- upper bounds for the variables:
+```python
+model.set_variables_upper_bounds(variables_upper_bounds)
+```
+- a lower bound for a given variable:
+```python
+model.set_variable_lower_bound(variable_index, lower_bound)
+```
+- an upper bound for a given variable:
+```python
+model.set_variable_upper_bound(variable_index, upper_bound)
+```
 - the objective function (and its gradient). It is 0 otherwise;
 ```python
 model.set_objective(optimization_sense, objective_function, objective_gradient)
@@ -35,6 +55,22 @@ model.set_objective(optimization_sense, objective_function, objective_gradient)
 model.set_constraints(number_constraints, constraint_functions,
    constraints_lower_bounds, constraints_upper_bounds, number_jacobian_nonzeros,
    jacobian_row_indices, jacobian_column_indices, jacobian)
+```
+- lower bounds for the constraints:
+```python
+model.set_constraints_lower_bounds(constraints_lower_bounds)
+```
+- upper bounds for the constraints:
+```python
+model.set_constraints_upper_bounds(constraints_upper_bounds)
+```
+- a lower bound for a given constraint:
+```python
+model.set_constraint_lower_bound(constraint_index, lower_bound)
+```
+- an upper bound for a given constraint:
+```python
+model.set_constraint_upper_bound(constraint_index, upper_bound)
 ```
 - the Lagrangian Hessian;
 ```python

--- a/interfaces/Python/example/example_hs015.py
+++ b/interfaces/Python/example/example_hs015.py
@@ -62,7 +62,9 @@ if __name__ == '__main__':
 	# initial point
 	x0 = [-2., 1.]
 
-	model = unopy.Model(problem_type, number_variables, variables_lower_bounds, variables_upper_bounds, base_indexing)
+	model = unopy.Model(problem_type, number_variables, base_indexing)
+	model.set_variables_lower_bounds(variables_lower_bounds)
+	model.set_variables_upper_bounds(variables_upper_bounds)
 	model.set_objective(optimization_sense, objective, objective_gradient)
 	model.set_constraints(number_constraints, constraints, constraints_lower_bounds, constraints_upper_bounds,
 	  number_jacobian_nonzeros, jacobian_row_indices, jacobian_column_indices, jacobian)

--- a/interfaces/Python/python_modules/Model.cpp
+++ b/interfaces/Python/python_modules/Model.cpp
@@ -5,13 +5,14 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 #include "../unopy.hpp"
+#include "tools/Infinity.hpp"
 
 namespace py = pybind11;
 
 namespace uno {
    void define_Model(py::module& module) {
       py::class_<PythonUserModel>(module, "Model")
-      // constructor
+      // constructor with bounds
       // https://stackoverflow.com/a/62310838/16037994
       .def(py::init<>([](const std::string& problem_type, uno_int number_variables, std::vector<double> variables_lower_bounds,
             std::vector<double> variables_upper_bounds, uno_int base_indexing) {
@@ -22,7 +23,39 @@ namespace uno {
          return model;
       }), "Constructor")
 
+      // constructor without bounds
+      .def(py::init<>([](const std::string& problem_type, uno_int number_variables, uno_int base_indexing) {
+         PythonUserModel model(problem_type.data(), number_variables, base_indexing);
+         const size_t unsigned_number_variables = static_cast<size_t>(number_variables);
+         model.variables_lower_bounds.resize(unsigned_number_variables, -INF<double>);
+         model.variables_upper_bounds.resize(unsigned_number_variables, INF<double>);
+         model.initial_primal_iterate.resize(unsigned_number_variables, 0.);
+         return model;
+      }), "Constructor")
+
       // methods
+      .def("set_variables_lower_bounds", [](PythonUserModel& user_model, std::vector<double> variables_lower_bounds) {
+         user_model.variables_lower_bounds = std::move(variables_lower_bounds);
+      })
+
+      .def("set_variables_upper_bounds", [](PythonUserModel& user_model, std::vector<double> variables_upper_bounds) {
+         user_model.variables_upper_bounds = std::move(variables_upper_bounds);
+      })
+
+      .def("set_variable_lower_bound", [](PythonUserModel& user_model, uno_int variable_index, double lower_bound) {
+         if (variable_index < 0 || variable_index >= user_model.number_variables) {
+            throw std::invalid_argument("Please specify a valid index.");
+         }
+         user_model.variables_lower_bounds[static_cast<size_t>(variable_index)] = lower_bound;
+      })
+
+      .def("set_variable_upper_bound", [](PythonUserModel& user_model, uno_int variable_index, double upper_bound) {
+         if (variable_index < 0 || variable_index >= user_model.number_variables) {
+            throw std::invalid_argument("Please specify a valid index.");
+         }
+         user_model.variables_upper_bounds[static_cast<size_t>(variable_index)] = upper_bound;
+      })
+
       .def("set_objective", [](PythonUserModel& user_model, uno_int optimization_sense, Objective objective_function,
             ObjectiveGradient objective_gradient) {
          if (optimization_sense != UNO_MINIMIZE && optimization_sense != UNO_MAXIMIZE) {
@@ -60,6 +93,28 @@ namespace uno {
          user_model.jacobian_column_indices = std::move(jacobian_column_indices);
          user_model.jacobian = std::move(jacobian);
          user_model.initial_dual_iterate.resize(static_cast<size_t>(number_constraints), 0.);
+      })
+
+      .def("set_constraints_lower_bounds", [](PythonUserModel& user_model, std::vector<double> constraints_lower_bounds) {
+         user_model.constraints_lower_bounds = std::move(constraints_lower_bounds);
+      })
+
+      .def("set_constraints_upper_bounds", [](PythonUserModel& user_model, std::vector<double> constraints_upper_bounds) {
+         user_model.constraints_upper_bounds = std::move(constraints_upper_bounds);
+      })
+
+      .def("set_constraint_lower_bound", [](PythonUserModel& user_model, uno_int constraint_index, double lower_bound) {
+         if (constraint_index < 0 || constraint_index >= user_model.number_constraints) {
+            throw std::invalid_argument("Please specify a valid index.");
+         }
+         user_model.constraints_lower_bounds[static_cast<size_t>(constraint_index)] = lower_bound;
+      })
+
+      .def("set_constraint_upper_bound", [](PythonUserModel& user_model, uno_int constraint_index, double upper_bound) {
+         if (constraint_index < 0 || constraint_index >= user_model.number_variables) {
+            throw std::invalid_argument("Please specify a valid index.");
+         }
+         user_model.constraints_upper_bounds[static_cast<size_t>(constraint_index)] = upper_bound;
       })
 
       .def("set_lagrangian_hessian", [](PythonUserModel& user_model, uno_int number_hessian_nonzeros, char hessian_triangular_part,


### PR DESCRIPTION
- Added `uno_create_unconstrained_model()`, `uno_set_variables_lower_bounds()`, `uno_set_variables_upper_bounds()`, `uno_set_variable_lower_bound()` and `uno_set_variable_upper_bound()` to:
  - [x] C API
  - [x] Julia interface
  - [x] Python interface
  - [x] Fortran interface

- Have `uno_create_model()` call both `uno_create_unconstrained_model()`, `uno_set_variables_lower_bounds()` and `uno_set_variables_upper_bounds()` in C API

- Other routines added: `uno_set_constraints_lower_bounds()`, `uno_set_constraints_upper_bounds()`, `uno_set_constraint_lower_bound()` and `uno_set_constraint_upper_bound()` to:
  - [x] C API
  - [x] Julia interface
  - [x] Python interface
  - [x] Fortran interface

cc @amontoison @david0oo

Closes https://github.com/cvanaret/Uno/issues/671