### PR TITLE
[UnoSolver.jl] Fix _manually_evaluated_primal_status with VectorNonlinearOracle

### DIFF
--- a/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl
+++ b/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl
@@ -1537,15 +1537,13 @@ function _manually_evaluated_primal_status(model::Optimizer)
 
     x_L, x_U = model.variables.lower, model.variables.upper
     g_L, g_U = copy(model.qp_data.g_L), copy(model.qp_data.g_U)
-    # Assuming constraints are guaranteed to be in the order:
-    # [qp_cons, nlp_cons, oracle]
-    for bound in model.nlp_data.constraint_bounds
-        push!(g_L, bound.lower)
-        push!(g_U, bound.upper)
-    end
     for (_, cache) in model.vector_nonlinear_oracle_constraints
         append!(g_L, cache.set.l)
         append!(g_U, cache.set.u)
+    end
+    for bound in model.nlp_data.constraint_bounds
+        push!(g_L, bound.lower)
+        push!(g_U, bound.upper)
     end
     m, n = length(g_L), length(x)
     # 1e-8 is the default primal tolerance


### PR DESCRIPTION
Following https://github.com/jump-dev/Ipopt.jl/pull/538

cc @amontoison