### PR TITLE
[C] Fixed `uno_int` inconsistencies

### DIFF
--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -971,7 +971,7 @@ double uno_get_solver_double_option(void* solver, const char* option_name) {
    return uno_solver->options->get_double(option_name);
 }
 
-int uno_get_solver_integer_option(void* solver, const char* option_name) {
+uno_int uno_get_solver_integer_option(void* solver, const char* option_name) {
    if (solver == nullptr) {
       throw std::runtime_error("Please specify a valid solver.");
    }

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -364,10 +364,10 @@ public:
          return this->termination_callback(static_cast<uno_int>(primals.size()),
             static_cast<uno_int>(multipliers.constraints.size()), primals.data(), multipliers.lower_bounds.data(),
             multipliers.upper_bounds.data(), multipliers.constraints.data(), objective_multiplier, primal_feasibility_residual,
-            stationarity_residual, complementarity_residual, this->user_data);
+            stationarity_residual, complementarity_residual, this->user_data) == 0;
       }
       else {
-         return false; // never terminate
+         return false; // no user termination
       }
    }
 

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -134,7 +134,7 @@ extern "C" {
    // "number_constraints", an objective multiplier, the primal feasibility residual, the dual feasibility residual, and
    // the complementarity residual.
    // returns true for user termination.
-   typedef bool (*uno_termination_callback)(uno_int number_variables, uno_int number_constraints, const double* primals,
+   typedef uno_int (*uno_termination_callback)(uno_int number_variables, uno_int number_constraints, const double* primals,
       const double* lower_bound_multipliers, const double* upper_bound_multipliers, const double* constraint_multipliers,
       double objective_multiplier, double primal_feasibility_residual, double stationarity_residual,
       double complementarity_residual, void* user_data);

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -328,7 +328,7 @@ extern "C" {
    // gets the value of a given double option.
    // takes as inputs the name of the option.
    // the possible types are integer, double, bool and string.
-   int uno_get_solver_integer_option(void* solver, const char* option_name);
+   uno_int uno_get_solver_integer_option(void* solver, const char* option_name);
    double uno_get_solver_double_option(void* solver, const char* option_name);
    bool uno_get_solver_bool_option(void* solver, const char* option_name);
    const char* uno_get_solver_string_option(void* solver, const char* option_name);

--- a/interfaces/Fortran/uno_c.f90
+++ b/interfaces/Fortran/uno_c.f90
@@ -274,7 +274,7 @@ abstract interface
                                      primal_feasibility_residual, stationarity_residual, &
                                      complementarity_residual, user_data) &
       bind(C)
-      import :: uno_int, c_double, c_ptr, c_bool
+      import :: uno_int, c_double, c_ptr
       integer(uno_int), value :: number_variables
       integer(uno_int), value :: number_constraints
       real(c_double), intent(in) :: primals(*)

--- a/interfaces/Fortran/uno_c.f90
+++ b/interfaces/Fortran/uno_c.f90
@@ -286,7 +286,7 @@ abstract interface
       real(c_double), value :: stationarity_residual
       real(c_double), value :: complementarity_residual
       type(c_ptr), value :: user_data
-      logical(c_bool) :: uno_termination_callback
+      logical(uno_int) :: uno_termination_callback
    end function
 end interface
 

--- a/interfaces/Fortran/uno_fortran.f90
+++ b/interfaces/Fortran/uno_fortran.f90
@@ -322,7 +322,7 @@ end function uno_set_solver_preset
 function uno_get_solver_integer_option(solver, option_name) result(solver_integer_option)
    type(c_ptr), value :: solver
    character(len=*) :: option_name
-   integer(c_int) :: solver_integer_option
+   integer(uno_int) :: solver_integer_option
    character(c_char), allocatable :: option_name_c(:)
    integer :: i, n
 
@@ -330,10 +330,10 @@ function uno_get_solver_integer_option(solver, option_name) result(solver_intege
       function uno_get_solver_integer_option_c(solver, option_name) &
          result(solver_integer_option) &
          bind(C, name="uno_get_solver_integer_option")
-         import :: c_ptr, c_char, c_int
+         import :: c_ptr, c_char, uno_int
          type(c_ptr), value :: solver
          character(c_char) :: option_name(*)
-         integer(c_int) :: solver_integer_option
+         integer(uno_int) :: solver_integer_option
       end function uno_get_solver_integer_option_c
    end interface
 

--- a/interfaces/Julia/gen/prologue_fortran.f90
+++ b/interfaces/Julia/gen/prologue_fortran.f90
@@ -278,7 +278,7 @@ abstract interface
       real(c_double), value :: stationarity_residual
       real(c_double), value :: complementarity_residual
       type(c_ptr), value :: user_data
-      logical(c_bool) :: uno_termination_callback
+      logical(uno_int) :: uno_termination_callback
    end function
 end interface
 

--- a/interfaces/Julia/gen/prologue_fortran.f90
+++ b/interfaces/Julia/gen/prologue_fortran.f90
@@ -266,7 +266,7 @@ abstract interface
                                      primal_feasibility_residual, stationarity_residual, &
                                      complementarity_residual, user_data) &
       bind(C)
-      import :: uno_int, c_double, c_ptr, c_bool
+      import :: uno_int, c_double, c_ptr
       integer(uno_int), value :: number_variables
       integer(uno_int), value :: number_constraints
       real(c_double), intent(in) :: primals(*)

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -233,7 +233,7 @@ end
 
 function uno_get_solver_integer_option(solver, option_name)
     @ccall libuno.uno_get_solver_integer_option(solver::Ptr{Cvoid},
-                                                option_name::Cstring)::Cint
+                                                option_name::Cstring)::Int32
 end
 
 function uno_get_solver_double_option(solver, option_name)

--- a/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/Funnel.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/Funnel.hpp
@@ -4,6 +4,7 @@
 #ifndef UNO_FUNNEL_H
 #define UNO_FUNNEL_H
 
+#include "../interfaces/C/uno_int.h"
 #include "tools/Infinity.hpp"
 
 namespace uno {
@@ -27,7 +28,7 @@ namespace uno {
    protected:
       double width{INF<double>};
       const double margin;
-      const int update_strategy;
+      const uno_int update_strategy;
       const double kappa;
 
       [[nodiscard]] static double convex_combination(double a, double b, double coefficient);

--- a/uno/ingredients/hessian_models/quasi_newton/direct/DirectQuasiNewtonHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/DirectQuasiNewtonHessian.cpp
@@ -32,11 +32,11 @@ namespace uno {
    }
 
    // this can only be called by WoodburyEQPSolver
-   void DirectQuasiNewtonHessian::compute_sparsity(int* row_indices, int* column_indices, int solver_indexing) const {
+   void DirectQuasiNewtonHessian::compute_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int solver_indexing) const {
       // diagonal contribution
       for (size_t variable_index: Range(this->model.number_variables)) {
-         row_indices[variable_index] = static_cast<int>(variable_index) + solver_indexing;
-         column_indices[variable_index] = static_cast<int>(variable_index) + solver_indexing;
+         row_indices[variable_index] = static_cast<uno_int>(variable_index) + solver_indexing;
+         column_indices[variable_index] = static_cast<uno_int>(variable_index) + solver_indexing;
       }
    }
 

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDWorkspace.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDWorkspace.cpp
@@ -122,12 +122,12 @@ namespace uno {
       for (size_t jacobian_nonzero_index: Range(number_jacobian_nonzeros)) {
          const size_t permuted_nonzero_index = this->permutation_vector[jacobian_nonzero_index];
          // variable index
-         const int variable_index = this->jacobian_column_indices[permuted_nonzero_index];
+         const uno_int variable_index = this->jacobian_column_indices[permuted_nonzero_index];
          this->gradients_sparsity[1 + subproblem.number_variables + jacobian_nonzero_index] = variable_index +
             Indexing::Fortran_indexing;
 
          // constraint index
-         const int constraint_index = this->jacobian_row_indices[permuted_nonzero_index];
+         const uno_int constraint_index = this->jacobian_row_indices[permuted_nonzero_index];
          assert(current_constraint <= constraint_index);
          while (current_constraint < constraint_index) {
             ++current_constraint;

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSWorkspace.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSWorkspace.cpp
@@ -112,7 +112,7 @@ namespace uno {
          this->model.lp_.a_matrix_.index_[jacobian_nonzero_index] = constraint_index;
 
          // variable index is used to build the pointers to the column starts
-         const int variable_index = this->jacobian_column_indices[permuted_nonzero_index];
+         const uno_int variable_index = this->jacobian_column_indices[permuted_nonzero_index];
          assert(current_variable <= variable_index);
          while (current_variable < variable_index) {
             ++current_variable;
@@ -171,7 +171,7 @@ namespace uno {
          this->model.hessian_.index_[hessian_nonzero_index] = row_index;
 
          // column index
-         const int column_index = this->hessian_column_indices[permuted_nonzero_index];
+         const uno_int column_index = this->hessian_column_indices[permuted_nonzero_index];
          assert(current_column <= column_index);
          while (current_column < column_index) {
             ++current_column;


### PR DESCRIPTION
- Fixed inconsistencies between `int` and `uno_int`
- Have `uno_termination_callback` return an `uno_int` instead of a `bool`

cc @amontoison 