### PR TITLE
[APIs] Handle base indexing internally for `uno_[get|set]_*` functions with index parameter

### DIFF
--- a/interfaces/AMPL/AMPLModel.cpp
+++ b/interfaces/AMPL/AMPLModel.cpp
@@ -42,7 +42,7 @@ namespace uno {
 
    AMPLModel::AMPLModel(const std::string& file_name, ASL* asl) :
          Model(file_name, static_cast<size_t>(asl->i.n_var_), static_cast<size_t>(asl->i.n_con_),
-            (asl->i.objtype_[0] == 1) ? -1. : 1. /* optimization sense */, AMPLModel::lagrangian_sign_convention),
+            (asl->i.objtype_[0] == 1) ? -1. : 1. /* optimization sense */, AMPLModel::lagrangian_sign_convention, 0),
          asl(asl),
          // compute sparsity pattern and number of nonzeros of Lagrangian Hessian
          number_asl_hessian_nonzeros(this->compute_lagrangian_hessian_sparsity()),

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -106,7 +106,7 @@ public:
    }
 
    // sparsity patterns of Jacobian and Hessian
-   void compute_jacobian_sparsity(uno_int * row_indices, uno_int * column_indices, uno_int row_offset, uno_int column_offset,
+   void compute_jacobian_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int row_offset, uno_int column_offset,
          uno_int solver_indexing, MatrixOrder /*matrix_order*/) const override {
       // copy the indices of the user sparsity patterns to the Uno vectors
       for (size_t nonzero_index: Range(static_cast<size_t>(this->user_model.number_jacobian_nonzeros))) {
@@ -125,7 +125,7 @@ public:
       }
    }
 
-   void compute_hessian_sparsity(uno_int *row_indices, uno_int *column_indices, uno_int solver_indexing) const override {
+   void compute_hessian_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int solver_indexing) const override {
       // copy the indices of the user sparsity patterns to the Uno vectors
       const size_t number_hessian_nonzeros = this->number_hessian_nonzeros();
       for (size_t nonzero_index: Range(number_hessian_nonzeros)) {
@@ -533,6 +533,8 @@ bool uno_set_variable_lower_bound(void* model, uno_int variable_index, double lo
       return false;
    }
    CUserModel* user_model = static_cast<CUserModel*>(model);
+   // shift the index with the base indexing
+   variable_index -= user_model->base_indexing;
    if (variable_index < 0 || variable_index >= user_model->number_variables) {
       WARNING << "Please specify a valid index."  << std::endl;
       return false;
@@ -547,6 +549,8 @@ bool uno_set_variable_upper_bound(void* model, uno_int variable_index, double up
       return false;
    }
    CUserModel* user_model = static_cast<CUserModel*>(model);
+   // shift the index with the base indexing
+   variable_index -= user_model->base_indexing;
    if (variable_index < 0 || variable_index >= user_model->number_variables) {
       WARNING << "Please specify a valid index."  << std::endl;
       return false;
@@ -645,6 +649,8 @@ bool uno_set_constraint_lower_bound(void* model, uno_int constraint_index, doubl
       return false;
    }
    CUserModel* user_model = static_cast<CUserModel*>(model);
+   // shift the index with the base indexing
+   constraint_index -= user_model->base_indexing;
    if (constraint_index < 0 || constraint_index >= user_model->number_constraints) {
       WARNING << "Please specify a valid index."  << std::endl;
       return false;
@@ -659,6 +665,8 @@ bool uno_set_constraint_upper_bound(void* model, uno_int constraint_index, doubl
       return false;
    }
    CUserModel* user_model = static_cast<CUserModel*>(model);
+   // shift the index with the base indexing
+   constraint_index -= user_model->base_indexing;
    if (constraint_index < 0 || constraint_index >= user_model->number_constraints) {
       WARNING << "Please specify a valid index."  << std::endl;
       return false;

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -761,9 +761,10 @@ bool uno_set_initial_primal_iterate_component(void* model, uno_int index, double
       return false;
    }
    CUserModel* user_model = static_cast<CUserModel*>(model);
+   // shift the index with the base indexing
+   index -= user_model->base_indexing;
    if (0 <= index && index < user_model->number_variables) {
-      const size_t unsigned_index = static_cast<size_t>(index);
-      user_model->initial_primal_iterate[unsigned_index] = initial_primal_component;
+      user_model->initial_primal_iterate[static_cast<size_t>(index)] = initial_primal_component;
       return true;
    }
    return false;
@@ -775,9 +776,10 @@ bool uno_set_initial_dual_iterate_component(void* model, uno_int index, double i
       return false;
    }
    CUserModel* user_model = static_cast<CUserModel*>(model);
+   // shift the index with the base indexing
+   index -= user_model->base_indexing;
    if (0 <= index && index < user_model->number_constraints) {
-      const size_t unsigned_index = static_cast<size_t>(index);
-      user_model->initial_dual_iterate[unsigned_index] = initial_dual_component;
+      user_model->initial_dual_iterate[static_cast<size_t>(index)] = initial_dual_component;
       return true;
    }
    return false;
@@ -1025,6 +1027,8 @@ double uno_get_solution_objective(void* solver) {
 
 double uno_get_primal_solution_component(void* solver, uno_int index) {
    const Result* result = uno_get_result(solver);
+   // shift the index with the base indexing
+   index -= result->base_indexing;
    const size_t unsigned_index = static_cast<size_t>(index);
    if (index < 0 || result->number_variables <= unsigned_index) {
       throw std::runtime_error("The index is not valid.");
@@ -1034,6 +1038,8 @@ double uno_get_primal_solution_component(void* solver, uno_int index) {
 
 double uno_get_constraint_dual_solution_component(void* solver, uno_int index) {
    const Result* result = uno_get_result(solver);
+   // shift the index with the base indexing
+   index -= result->base_indexing;
    const size_t unsigned_index = static_cast<size_t>(index);
    if (index < 0 || result->number_constraints <= unsigned_index) {
       throw std::runtime_error("The index is not valid.");
@@ -1043,6 +1049,8 @@ double uno_get_constraint_dual_solution_component(void* solver, uno_int index) {
 
 double uno_get_lower_bound_dual_solution_component(void* solver, uno_int index) {
    const Result* result = uno_get_result(solver);
+   // shift the index with the base indexing
+   index -= result->base_indexing;
    const size_t unsigned_index = static_cast<size_t>(index);
    if (index < 0 || result->number_variables <= unsigned_index) {
       throw std::runtime_error("The index is not valid.");
@@ -1052,6 +1060,8 @@ double uno_get_lower_bound_dual_solution_component(void* solver, uno_int index) 
 
 double uno_get_upper_bound_dual_solution_component(void* solver, uno_int index) {
    const Result* result = uno_get_result(solver);
+   // shift the index with the base indexing
+   index -= result->base_indexing;
    const size_t unsigned_index = static_cast<size_t>(index);
    if (index < 0 || result->number_variables <= unsigned_index) {
       throw std::runtime_error("The index is not valid.");

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -33,7 +33,8 @@ class UnoModel: public Model {
 public:
    explicit UnoModel(const CUserModel& user_model):
          Model("C model", static_cast<size_t>(user_model.number_variables), static_cast<size_t>(user_model.number_constraints),
-            static_cast<double>(user_model.optimization_sense), static_cast<double>(user_model.lagrangian_sign_convention)),
+            static_cast<double>(user_model.optimization_sense), static_cast<double>(user_model.lagrangian_sign_convention),
+            user_model.base_indexing),
          user_model(user_model),
          nonlinear_constraints(this->number_constraints),
          equality_constraints_collection(this->equality_constraints),

--- a/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl
+++ b/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl
@@ -1420,35 +1420,35 @@ function MOI.optimize!(model::Optimizer)
             model.variable_primal_start[i],
             clamp(0.0, model.variables.lower[i], model.variables.upper[i]),
         )
-        UnoSolver.uno_set_initial_primal_iterate_component(inner, i-1, x0_i)
+        UnoSolver.uno_set_initial_primal_iterate_component(inner, i, x0_i)
     end
 
     for (i, start) in enumerate(model.qp_data.mult_g)
         y0_i = _dual_start(model, start, -1)
-        UnoSolver.uno_set_initial_dual_iterate_component(inner, i-1, y0_i)
+        UnoSolver.uno_set_initial_dual_iterate_component(inner, i, y0_i)
     end
     offset = length(model.qp_data.mult_g)
     if model.nlp_dual_start === nothing
         for i in offset+1:inner.ncon
-            UnoSolver.uno_set_initial_dual_iterate_component(inner, i-1, 0.0)
+            UnoSolver.uno_set_initial_dual_iterate_component(inner, i, 0.0)
         end
         # First there is VectorNonlinearOracle...
         for (_, cache) in model.vector_nonlinear_oracle_constraints
             if cache.start !== nothing
                 for i in 1:cache.set.output_dimension
-                    UnoSolver.uno_set_initial_dual_iterate_component(inner, offset+i-1, _dual_start(model, cache.start[i], -1))
+                    UnoSolver.uno_set_initial_dual_iterate_component(inner, offset+i, _dual_start(model, cache.start[i], -1))
                 end
             end
             offset += cache.set.output_dimension
         end
         # ...then come the ScalarNonlinearFunctions
         for (key, val) in model.mult_g_nlp
-            UnoSolver.uno_set_initial_dual_iterate_component(inner, offset+key.value-1, _dual_start(model, val, -1))
+            UnoSolver.uno_set_initial_dual_iterate_component(inner, offset+key.value, _dual_start(model, val, -1))
         end
     else
         for (i, start) in enumerate(model.nlp_dual_start::Vector{Float64})
             y0_i = _dual_start(model, start, -1)
-            UnoSolver.uno_set_initial_dual_iterate_component(inner, offset+i-1, y0_i)
+            UnoSolver.uno_set_initial_dual_iterate_component(inner, offset+i, y0_i)
         end
     end
 
@@ -1615,7 +1615,7 @@ function MOI.get(
         p = model.parameters[vi]
         return model.nlp_model[p]
     end
-    return UnoSolver.uno_get_primal_solution_component(model.solver, column(vi)-1)
+    return UnoSolver.uno_get_primal_solution_component(model.solver, column(vi))
 end
 
 ### MOI.ConstraintPrimal
@@ -1687,7 +1687,7 @@ function MOI.get(
 )
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
-    λ = UnoSolver.uno_get_constraint_dual_solution_component(model.solver, row(model, ci)-1)
+    λ = UnoSolver.uno_get_constraint_dual_solution_component(model.solver, row(model, ci))
     return _dual_multiplier(model) * λ
 end
 
@@ -1702,8 +1702,8 @@ function MOI.get(
 ) where {S<:_SETS}
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
-    xL_i = UnoSolver.uno_get_lower_bound_dual_solution_component(model.solver, ci.value-1)
-    xU_i = UnoSolver.uno_get_upper_bound_dual_solution_component(model.solver, ci.value-1)
+    xL_i = UnoSolver.uno_get_lower_bound_dual_solution_component(model.solver, ci.value)
+    xU_i = UnoSolver.uno_get_upper_bound_dual_solution_component(model.solver, ci.value)
     return _reduced_cost_to_dual(S, _dual_multiplier(model) * (xL_i + xU_i))
 end
 
@@ -1714,6 +1714,6 @@ function MOI.get(model::Optimizer, attr::MOI.NLPBlockDual)
     s = _dual_multiplier(model)
     return Float64[
         s * UnoSolver.uno_get_constraint_dual_solution_component(model.solver, i)
-        for i in length(model.qp_data):(model.inner.ncon-1)
+        for i in (length(model.qp_data)+1):model.inner.ncon
     ]
 end

--- a/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl
+++ b/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl
@@ -788,7 +788,7 @@ function MOI.get(
     x = [MOI.get(model, MOI.VariablePrimal(), xi) for xi in f.variables]
     s.set.eval_jacobian(J, x)
     λ = Float64[
-        UnoSolver.uno_get_constraint_dual_solution_component(model.solver, r - 1)
+        UnoSolver.uno_get_constraint_dual_solution_component(model.solver, r)
         for r in row(model, ci)
     ]
     dual = zeros(MOI.dimension(s.set))
@@ -807,7 +807,7 @@ function MOI.get(
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
     λ = Float64[
-        UnoSolver.uno_get_constraint_dual_solution_component(model.solver, r - 1)
+        UnoSolver.uno_get_constraint_dual_solution_component(model.solver, r)
         for r in row(model, ci)
     ]
     return _dual_multiplier(model) * λ

--- a/interfaces/Julia/test/C_wrapper.jl
+++ b/interfaces/Julia/test/C_wrapper.jl
@@ -221,14 +221,14 @@ end
     uno_set_variables_lower_bounds(model, lvar)
     uno_set_variables_upper_bounds(model, uvar)
     for i = 1:nvar
-      UnoSolver.uno_set_variable_lower_bound(model, i-1, lvar[i])
-      UnoSolver.uno_set_variable_upper_bound(model, i-1, uvar[i])
+      UnoSolver.uno_set_variable_lower_bound(model, i, lvar[i])
+      UnoSolver.uno_set_variable_upper_bound(model, i, uvar[i])
     end
     uno_set_constraints_lower_bounds(model, lcon)
     uno_set_constraints_upper_bounds(model, ucon)
     for i = 1:ncon
-      UnoSolver.uno_set_constraint_lower_bound(model, i-1, lcon[i])
-      UnoSolver.uno_set_constraint_upper_bound(model, i-1, ucon[i])
+      UnoSolver.uno_set_constraint_lower_bound(model, i, lcon[i])
+      UnoSolver.uno_set_constraint_upper_bound(model, i, ucon[i])
     end
 
     solver = uno_solver()
@@ -481,8 +481,8 @@ end
     uno_set_variables_lower_bounds(model, lvar)
     uno_set_variables_upper_bounds(model, uvar)
     for i = 1:nvar
-      UnoSolver.uno_set_variable_lower_bound(model, i-1, lvar[i])
-      UnoSolver.uno_set_variable_upper_bound(model, i-1, uvar[i])
+      UnoSolver.uno_set_variable_lower_bound(model, i, lvar[i])
+      UnoSolver.uno_set_variable_upper_bound(model, i, uvar[i])
     end
 
     solver = uno_solver()

--- a/interfaces/Julia/test/NLP_wrapper.jl
+++ b/interfaces/Julia/test/NLP_wrapper.jl
@@ -25,13 +25,13 @@
         UnoSolver.uno_get_upper_bound_dual_solution(solver, upper_bound_dual_solution)
 
         for i in 1:nlp.meta.nvar
-            @test primal_solution[i] == UnoSolver.uno_get_primal_solution_component(solver, i-1)
-            @test lower_bound_dual_solution[i] == UnoSolver.uno_get_lower_bound_dual_solution_component(solver, i-1)
-            @test upper_bound_dual_solution[i] == UnoSolver.uno_get_upper_bound_dual_solution_component(solver, i-1)
+            @test primal_solution[i] == UnoSolver.uno_get_primal_solution_component(solver, i)
+            @test lower_bound_dual_solution[i] == UnoSolver.uno_get_lower_bound_dual_solution_component(solver, i)
+            @test upper_bound_dual_solution[i] == UnoSolver.uno_get_upper_bound_dual_solution_component(solver, i)
         end
 
         for j in 1:nlp.meta.ncon
-            @test constraint_dual_solution[j] == UnoSolver.uno_get_constraint_dual_solution_component(solver, j-1)
+            @test constraint_dual_solution[j] == UnoSolver.uno_get_constraint_dual_solution_component(solver, j)
         end
 
         finalize(nlp)
@@ -62,13 +62,13 @@
         UnoSolver.uno_get_upper_bound_dual_solution(solver, upper_bound_dual_solution)
 
         for i in 1:nlp.meta.nvar
-            @test stats.solution[i] == UnoSolver.uno_get_primal_solution_component(solver, i-1)
-            @test stats.multipliers_L[i] == UnoSolver.uno_get_lower_bound_dual_solution_component(solver, i-1)
-            @test stats.multipliers_U[i] == UnoSolver.uno_get_upper_bound_dual_solution_component(solver, i-1)
+            @test stats.solution[i] == UnoSolver.uno_get_primal_solution_component(solver, i)
+            @test stats.multipliers_L[i] == UnoSolver.uno_get_lower_bound_dual_solution_component(solver, i)
+            @test stats.multipliers_U[i] == UnoSolver.uno_get_upper_bound_dual_solution_component(solver, i)
         end
 
         for j in 1:nlp.meta.ncon
-            @test stats.multipliers[j] == UnoSolver.uno_get_constraint_dual_solution_component(solver, j-1)
+            @test stats.multipliers[j] == UnoSolver.uno_get_constraint_dual_solution_component(solver, j)
         end
 
         finalize(nlp)
@@ -107,13 +107,13 @@ end
                 UnoSolver.uno_get_upper_bound_dual_solution(solver, upper_bound_dual_solution)
 
                 for i in 1:nlp.meta.nvar
-                    @test primal_solution[i] == UnoSolver.uno_get_primal_solution_component(solver, i-1)
-                    @test lower_bound_dual_solution[i] == UnoSolver.uno_get_lower_bound_dual_solution_component(solver, i-1)
-                    @test upper_bound_dual_solution[i] == UnoSolver.uno_get_upper_bound_dual_solution_component(solver, i-1)
+                    @test primal_solution[i] == UnoSolver.uno_get_primal_solution_component(solver, i)
+                    @test lower_bound_dual_solution[i] == UnoSolver.uno_get_lower_bound_dual_solution_component(solver, i)
+                    @test upper_bound_dual_solution[i] == UnoSolver.uno_get_upper_bound_dual_solution_component(solver, i)
                 end
 
                 for j in 1:nlp.meta.ncon
-                    @test constraint_dual_solution[j] == UnoSolver.uno_get_constraint_dual_solution_component(solver, j-1)
+                    @test constraint_dual_solution[j] == UnoSolver.uno_get_constraint_dual_solution_component(solver, j)
                 end
 
                 finalize(nlp)
@@ -144,13 +144,13 @@ end
                 UnoSolver.uno_get_upper_bound_dual_solution(solver, upper_bound_dual_solution)
 
                 for i in 1:nlp.meta.nvar
-                    @test stats.solution[i] == UnoSolver.uno_get_primal_solution_component(solver, i-1)
-                    @test stats.multipliers_L[i] == UnoSolver.uno_get_lower_bound_dual_solution_component(solver, i-1)
-                    @test stats.multipliers_U[i] == UnoSolver.uno_get_upper_bound_dual_solution_component(solver, i-1)
+                    @test stats.solution[i] == UnoSolver.uno_get_primal_solution_component(solver, i)
+                    @test stats.multipliers_L[i] == UnoSolver.uno_get_lower_bound_dual_solution_component(solver, i)
+                    @test stats.multipliers_U[i] == UnoSolver.uno_get_upper_bound_dual_solution_component(solver, i)
                 end
 
                 for j in 1:nlp.meta.ncon
-                    @test stats.multipliers[j] == UnoSolver.uno_get_constraint_dual_solution_component(solver, j-1)
+                    @test stats.multipliers[j] == UnoSolver.uno_get_constraint_dual_solution_component(solver, j)
                 end
 
                 finalize(nlp)

--- a/interfaces/Python/cpp_classes/PythonModel.cpp
+++ b/interfaces/Python/cpp_classes/PythonModel.cpp
@@ -13,7 +13,7 @@
 namespace uno {
    PythonModel::PythonModel(const PythonUserModel& user_model):
       Model("Python model", static_cast<size_t>(user_model.number_variables), static_cast<size_t>(user_model.number_constraints),
-         static_cast<double>(user_model.optimization_sense), static_cast<double>(user_model.lagrangian_sign_convention)),
+         static_cast<double>(user_model.optimization_sense), static_cast<double>(user_model.lagrangian_sign_convention), 0),
          user_model(user_model),
          nonlinear_constraints(this->number_constraints),
          equality_constraints_collection(this->equality_constraints),

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -237,7 +237,7 @@ namespace uno {
          const Evaluations& evaluations, size_t major_iterations, const Timer& timer) const {
       const size_t number_subproblems_solved = (this->globalization_mechanism != nullptr) ?
          this->globalization_mechanism->get_number_subproblems_solved() : 0;
-      return {model.number_variables, model.number_constraints, optimization_status, solution.status,
+      return {model.number_variables, model.number_constraints, model.base_indexing, optimization_status, solution.status,
          evaluations.objective, solution.progress.infeasibility, solution.residuals.stationarity,
          solution.residuals.complementarity, solution.primals, solution.multipliers.constraints,
          solution.multipliers.lower_bounds, solution.multipliers.upper_bounds, major_iterations, timer.get_duration(),

--- a/uno/model/BoundRelaxedModel.cpp
+++ b/uno/model/BoundRelaxedModel.cpp
@@ -8,7 +8,7 @@
 namespace uno {
    BoundRelaxedModel::BoundRelaxedModel(const Model& original_model, const Options& options):
          Model(original_model.name + " -> bounds relaxed", original_model.number_variables, original_model.number_constraints,
-            original_model.optimization_sense, original_model.lagrangian_sign_convention),
+            original_model.optimization_sense, original_model.lagrangian_sign_convention, original_model.base_indexing),
          model(original_model),
          relaxation_factor(options.get_double("primal_tolerance")),
          relaxed_variables_lower_bounds(this->number_variables),

--- a/uno/model/FixedBoundsConstraintsModel.cpp
+++ b/uno/model/FixedBoundsConstraintsModel.cpp
@@ -10,7 +10,7 @@ namespace uno {
          Model(original_model.name + " -> no fixed bounds", original_model.number_variables,
             // move the fixed variables to the set of general constraints
             original_model.number_constraints + original_model.get_fixed_variables().size(),
-            original_model.optimization_sense, original_model.lagrangian_sign_convention),
+            original_model.optimization_sense, original_model.lagrangian_sign_convention, original_model.base_indexing),
          model(original_model),
          equality_constraints(concatenate(this->model.get_equality_constraints(), Range(this->model.number_constraints, this->number_constraints))),
          linear_constraints(concatenate(this->model.get_linear_constraints(), Range(this->model.number_constraints, this->number_constraints))),

--- a/uno/model/HomogeneousEqualityConstrainedModel.cpp
+++ b/uno/model/HomogeneousEqualityConstrainedModel.cpp
@@ -13,7 +13,7 @@ namespace uno {
    HomogeneousEqualityConstrainedModel::HomogeneousEqualityConstrainedModel(const Model& original_model):
          Model(original_model.name + " -> equality constrained", original_model.number_variables +
             original_model.get_inequality_constraints().size(), original_model.number_constraints,
-            original_model.optimization_sense, original_model.lagrangian_sign_convention),
+            original_model.optimization_sense, original_model.lagrangian_sign_convention, original_model.base_indexing),
          model(original_model),
          // all constraints are equality constraints
          equality_constraints(Range(this->number_constraints)),

--- a/uno/model/Model.cpp
+++ b/uno/model/Model.cpp
@@ -15,9 +15,10 @@
 namespace uno {
    // abstract Problem class
    Model::Model(std::string name, size_t number_variables, size_t number_constraints, double objective_sign,
-                double lagrangian_sign_convention) :
+            double lagrangian_sign_convention, uno_int base_indexing) :
          name(std::move(name)), number_variables(number_variables), number_constraints(number_constraints),
-         optimization_sense(objective_sign), lagrangian_sign_convention(lagrangian_sign_convention) {
+         optimization_sense(objective_sign), lagrangian_sign_convention(lagrangian_sign_convention),
+         base_indexing(base_indexing) {
    }
 
    bool Model::has_inequality_constraints() const {

--- a/uno/model/Model.hpp
+++ b/uno/model/Model.hpp
@@ -29,14 +29,15 @@ namespace uno {
    class Model {
    public:
       Model(std::string name, size_t number_variables, size_t number_constraints, double optimization_sense,
-            double lagrangian_sign_convention);
+         double lagrangian_sign_convention, uno_int base_indexing);
       virtual ~Model() = default;
 
       const std::string name;
       const size_t number_variables; /*!< Number of variables */
       const size_t number_constraints; /*!< Number of constraints */
       const double optimization_sense; /*!< 1: minimization, -1: maximization */
-      double lagrangian_sign_convention;
+      const double lagrangian_sign_convention;
+      const uno_int base_indexing; // 0 for C-style indexing, 1 for Fortran-style indexing
 
       [[nodiscard]] virtual ProblemType get_problem_type() const = 0;
       [[nodiscard]] bool has_inequality_constraints() const;

--- a/uno/optimization/Result.hpp
+++ b/uno/optimization/Result.hpp
@@ -6,6 +6,7 @@
 
 #include "Iterate.hpp"
 #include "OptimizationStatus.hpp"
+#include "../interfaces/C/uno_int.h"
 
 namespace uno {
    class Result {
@@ -14,6 +15,7 @@ namespace uno {
 
       size_t number_variables;
       size_t number_constraints;
+      uno_int base_indexing;
       const OptimizationStatus optimization_status;
       const SolutionStatus solution_status;
       double solution_objective;


### PR DESCRIPTION
So far:
In Uno functions such as `uno_get_primal_solution_component(solver, index)`, the index should be in [0, upper_bound) (C style).

Now:
The index can be passed in the native base indexing (e.g., from 1 in Julia) and will be handled internally by Uno based on the model's `base_indexing` attribute.