### PR TITLE
IPM: store fraction-to-boundary step lengths in `Direction`

### DIFF
--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -103,9 +103,9 @@ namespace uno {
             // take a step as a fraction of the direction
             GlobalizationMechanism::assemble_trial_iterate(model, current_iterate, trial_iterate, direction,
                // primal step length
-               step_length * direction.primal_step_length,
+               step_length * direction.primal_dual_step_length,
                // constraint dual step length: scale or not with the LS step length
-               (this->scale_duals_with_step_length ? step_length : 1.) * direction.primal_step_length,
+               (this->scale_duals_with_step_length ? step_length : 1.) * direction.primal_dual_step_length,
                // bound dual step length
                direction.bound_dual_step_length);
             statistics.set("||Step||", step_length * direction.norm);

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -101,9 +101,13 @@ namespace uno {
          bool is_acceptable = false;
          try {
             // take a step as a fraction of the direction
-            BacktrackingLineSearch::assemble_trial_iterate(model, current_iterate, trial_iterate, direction, step_length,
-               // scale or not the constraint dual direction with the LS step length
-               this->scale_duals_with_step_length ? step_length : 1.);
+            GlobalizationMechanism::assemble_trial_iterate(model, current_iterate, trial_iterate, direction,
+               // primal step length
+               step_length * direction.primal_step_length,
+               // constraint dual step length: scale or not with the LS step length
+               (this->scale_duals_with_step_length ? step_length : 1.) * direction.primal_step_length,
+               // bound dual step length
+               direction.bound_dual_step_length);
             statistics.set("||Step||", step_length * direction.norm);
 
             is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
@@ -24,7 +24,7 @@ namespace uno {
    }
 
    void GlobalizationMechanism::assemble_trial_iterate(const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
-         const Direction& direction, double primal_step_length, double dual_step_length) {
+         const Direction& direction, double primal_step_length, double constraint_dual_step_length, double bound_dual_step_length) {
       trial_iterate.set_number_variables(current_iterate.primals.size());
       trial_iterate.multipliers.constraints.resize(current_iterate.multipliers.constraints.size());
       trial_iterate.multipliers.lower_bounds.resize(current_iterate.multipliers.lower_bounds.size());
@@ -35,9 +35,9 @@ namespace uno {
       // project the trial iterate onto the bounds to avoid numerical errors
       model.project_onto_variable_bounds(trial_iterate.primals);
       // take dual step: line-search carried out only on constraint multipliers. Bound multipliers updated with full step
-      trial_iterate.multipliers.constraints = current_iterate.multipliers.constraints + dual_step_length * direction.multipliers.constraints;
-      trial_iterate.multipliers.lower_bounds = current_iterate.multipliers.lower_bounds + direction.multipliers.lower_bounds;
-      trial_iterate.multipliers.upper_bounds = current_iterate.multipliers.upper_bounds + direction.multipliers.upper_bounds;
+      trial_iterate.multipliers.constraints = current_iterate.multipliers.constraints + constraint_dual_step_length * direction.multipliers.constraints;
+      trial_iterate.multipliers.lower_bounds = current_iterate.multipliers.lower_bounds + bound_dual_step_length * direction.multipliers.lower_bounds;
+      trial_iterate.multipliers.upper_bounds = current_iterate.multipliers.upper_bounds + bound_dual_step_length * direction.multipliers.upper_bounds;
       trial_iterate.progress.reset();
       trial_iterate.status = SolutionStatus::NOT_OPTIMAL;
    }

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.hpp
@@ -39,7 +39,7 @@ namespace uno {
       Direction direction{};
 
       static void assemble_trial_iterate(const Model& model, Iterate& current_iterate, Iterate& trial_iterate,
-         const Direction& direction, double primal_step_length, double dual_step_length);
+         const Direction& direction, double primal_step_length, double constraint_dual_step_length, double bound_dual_step_length);
       static void set_primal_statistics(Statistics& statistics, const Model& model, const Iterate& iterate,
          const Evaluations& evaluations);
       static void set_dual_residuals_statistics(Statistics& statistics, const Iterate& iterate);

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -84,7 +84,7 @@ namespace uno {
             else {
                // take full primal-dual step
                GlobalizationMechanism::assemble_trial_iterate(model, current_iterate, trial_iterate, this->direction,
-                  this->direction.primal_step_length, this->direction.primal_step_length, this->direction.bound_dual_step_length);
+                  this->direction.primal_dual_step_length, this->direction.primal_dual_step_length, this->direction.bound_dual_step_length);
                this->reset_active_trust_region_multipliers(model, this->direction, trial_iterate);
 
                is_acceptable = this->is_iterate_acceptable(statistics, model, current_iterate, trial_iterate, this->direction,

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -83,7 +83,8 @@ namespace uno {
             }
             else {
                // take full primal-dual step
-               GlobalizationMechanism::assemble_trial_iterate(model, current_iterate, trial_iterate, this->direction, 1., 1.);
+               GlobalizationMechanism::assemble_trial_iterate(model, current_iterate, trial_iterate, this->direction,
+                  this->direction.primal_step_length, this->direction.primal_step_length, this->direction.bound_dual_step_length);
                this->reset_active_trust_region_multipliers(model, this->direction, trial_iterate);
 
                is_acceptable = this->is_iterate_acceptable(statistics, model, current_iterate, trial_iterate, this->direction,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -317,17 +317,15 @@ namespace uno {
       OptimizationProblem::assemble_primal_dual_direction(current_iterate, solution, direction);
 
       // compute the bound duals
-      this->compute_bound_dual_direction(current_iterate, direction);
+      compute_bound_dual_direction(current_iterate, direction);
 
-      // "fraction-to-boundary" rule for primal variables and constraints multipliers
+      // "fraction-to-boundary" rule for primal variables and bound constraints multipliers
       const double barrier_parameter = this->parameterization.get("barrier_parameter");
       const double tau = std::max(this->parameters.tau_min, 1. - barrier_parameter);
-      direction.primal_step_length = PrimalDualInteriorPointProblem::primal_fraction_to_boundary(current_iterate.primals,
-         direction.primals, tau);
-      direction.bound_dual_step_length = PrimalDualInteriorPointProblem::dual_fraction_to_boundary(current_iterate.multipliers,
-         direction.multipliers, tau);
+      direction.primal_dual_step_length = primal_fraction_to_boundary(current_iterate.primals, direction.primals, tau);
+      direction.bound_dual_step_length = dual_fraction_to_boundary(current_iterate.multipliers, direction.multipliers, tau);
       DEBUG << "Fraction-to-boundary rules:\n";
-      DEBUG << "primal step length = " << direction.primal_step_length << '\n';
+      DEBUG << "primal step length = " << direction.primal_dual_step_length << '\n';
       DEBUG << "bound dual step length = " << direction.bound_dual_step_length << "\n\n";
    }
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -322,18 +322,13 @@ namespace uno {
       // "fraction-to-boundary" rule for primal variables and constraints multipliers
       const double barrier_parameter = this->parameterization.get("barrier_parameter");
       const double tau = std::max(this->parameters.tau_min, 1. - barrier_parameter);
-      const double primal_step_length = PrimalDualInteriorPointProblem::primal_fraction_to_boundary(current_iterate.primals,
+      direction.primal_step_length = PrimalDualInteriorPointProblem::primal_fraction_to_boundary(current_iterate.primals,
          direction.primals, tau);
-      const double bound_dual_step_length = PrimalDualInteriorPointProblem::dual_fraction_to_boundary(current_iterate.multipliers,
+      direction.bound_dual_step_length = PrimalDualInteriorPointProblem::dual_fraction_to_boundary(current_iterate.multipliers,
          direction.multipliers, tau);
       DEBUG << "Fraction-to-boundary rules:\n";
-      DEBUG << "primal step length = " << primal_step_length << '\n';
-      DEBUG << "bound dual step length = " << bound_dual_step_length << "\n\n";
-      // scale the primal-dual variables
-      direction.primals.scale(primal_step_length);
-      direction.multipliers.constraints.scale(primal_step_length);
-      direction.multipliers.lower_bounds.scale(bound_dual_step_length);
-      direction.multipliers.upper_bounds.scale(bound_dual_step_length);
+      DEBUG << "primal step length = " << direction.primal_step_length << '\n';
+      DEBUG << "bound dual step length = " << direction.bound_dual_step_length << "\n\n";
    }
 
    double PrimalDualInteriorPointProblem::dual_regularization_factor() const {

--- a/uno/optimization/Direction.hpp
+++ b/uno/optimization/Direction.hpp
@@ -20,7 +20,7 @@ namespace uno {
 
       Vector<double> primals{}; /*!< Primal variables */
       Multipliers multipliers{}; /*!< Multipliers */
-      double primal_step_length{1.};
+      double primal_dual_step_length{1.};
       double bound_dual_step_length{1.};
 
       SubproblemStatus status{SubproblemStatus::OPTIMAL}; /*!< Status of the solution */

--- a/uno/optimization/Direction.hpp
+++ b/uno/optimization/Direction.hpp
@@ -20,6 +20,8 @@ namespace uno {
 
       Vector<double> primals{}; /*!< Primal variables */
       Multipliers multipliers{}; /*!< Multipliers */
+      double primal_step_length{1.};
+      double bound_dual_step_length{1.};
 
       SubproblemStatus status{SubproblemStatus::OPTIMAL}; /*!< Status of the solution */
 

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -169,6 +169,8 @@ namespace uno {
       view(direction.primals, 0, this->number_variables) = view(solution, 0, this->number_variables);
       // retrieve the duals with correct signs (note the sign flip)
       direction.multipliers.constraints = -view(solution, this->number_variables, this->number_variables + this->number_constraints);
+      // set the step lengths (direction unscaled)
+      direction.primal_dual_step_length = direction.bound_dual_step_length = 1.;
    }
 
    double OptimizationProblem::dual_regularization_factor() const {


### PR DESCRIPTION
IPM: do not take fraction-to-boundary step lengths immediately, store them in `Direction` instead, and take them in globalization mechanism.

Requirement for implementing Second-Order Correction steps.