### PR TITLE
[CI] pyOptSparse tests

### DIFF
--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -75,24 +75,14 @@ jobs:
       - name: Install pyOptSparse (no external solvers)
         run: |
           cd pyoptsparse
-
-          # Install core package only
           pip install .
-
-          # Install test dependencies if present
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       # -------------------------
-      # Run tests
+      # Run Uno tests
       # -------------------------
       - name: Run pyOptSparse tests (unopy only)
         run: |
           pip install pytest pytest-timeout parameterized
           cd pyoptsparse
-
-          # Ensure we only test Uno/unopy:
-          # (pyoptsparse selects solvers dynamically; if others are installed they may run.
-          # We avoid installing IPOPT, SNOPT, etc., so only pure-Python / available solvers remain.)
-
-          pytest tests -v -k "uno or unopy or UNO or Unopy or test_uno or test_unopy" \
-            --maxfail=1 --disable-warnings --timeout=5
+          pytest tests -v -k "Uno" --maxfail=1 --timeout=120 --timeout-method=thread

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -82,7 +82,7 @@ jobs:
       # -------------------------
       - name: Run pyOptSparse tests (Uno/unopy only)
         run: |
-          pip install pytest
+          pip install pytest parameterized
           cd pyoptsparse
 
           # Ensure we only test Uno/unopy:

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -1,0 +1,70 @@
+name: pyOptSparse tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-pyoptsparse-unopy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - name: Checkout Uno
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      # -------------------------
+      # Install Uno / unopy
+      # -------------------------
+      - name: Install unopy (local build)
+        run: |
+          pip install numpy scipy
+          pip install .
+
+      # -------------------------
+      # Clone pyOptSparse
+      # -------------------------
+      - name: Clone pyOptSparse
+        run: |
+          git clone https://github.com/mdolab/pyoptsparse.git
+          cd pyoptsparse
+          git checkout main
+
+      # -------------------------
+      # Install pyOptSparse WITHOUT external solvers
+      # -------------------------
+      - name: Install pyOptSparse (no external solvers)
+        run: |
+          cd pyoptsparse
+
+          # Install core package only
+          pip install -e .
+
+          # Install test dependencies if present
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      # -------------------------
+      # Run tests
+      # -------------------------
+      - name: Run pyOptSparse tests (Uno/unopy only)
+        run: |
+          cd pyoptsparse
+
+          # Ensure we only test Uno/unopy:
+          # (pyoptsparse selects solvers dynamically; if others are installed they may run.
+          # We avoid installing IPOPT, SNOPT, etc., so only pure-Python / available solvers remain.)
+
+          pytest tests -v -k "uno or unopy or UNO or Unopy or test_uno or test_unopy" \
+            --maxfail=1 --disable-warnings

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -87,7 +87,7 @@ jobs:
       # -------------------------
       - name: Run pyOptSparse tests (Uno/unopy only)
         run: |
-          pip install pytest parameterized
+          pip install pytest pytest-timeout parameterized
           cd pyoptsparse
 
           # Ensure we only test Uno/unopy:
@@ -95,4 +95,4 @@ jobs:
           # We avoid installing IPOPT, SNOPT, etc., so only pure-Python / available solvers remain.)
 
           pytest tests -v -k "uno or unopy or UNO or Unopy or test_uno or test_unopy" \
-            --maxfail=1 --disable-warnings
+            --maxfail=1 --disable-warnings --timeout=5

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -60,9 +60,9 @@ jobs:
       # -------------------------
       - name: Clone pyOptSparse
         run: |
-          git clone https://github.com/mdolab/pyoptsparse.git
+          git clone https://github.com/robfalck/pyoptsparse
           cd pyoptsparse
-          git checkout main
+          git checkout unopy
 
       # -------------------------
       # Install pyOptSparse WITHOUT external solvers
@@ -82,6 +82,7 @@ jobs:
       # -------------------------
       - name: Run pyOptSparse tests (Uno/unopy only)
         run: |
+          pip install pytest
           cd pyoptsparse
 
           # Ensure we only test Uno/unopy:

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -28,10 +28,13 @@ jobs:
       # -------------------------
       # Install Uno / unopy
       # -------------------------
-      - name: Install unopy (local build)
+      - name: Download dependencies
+        run: bash dependencies/scripts/download_dependencies.sh
+      
+      - name: Compile and install unopy
         run: |
           pip install numpy scipy
-          pip install .
+          CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install . -v
 
       # -------------------------
       # Clone pyOptSparse

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -85,7 +85,7 @@ jobs:
       # -------------------------
       # Run tests
       # -------------------------
-      - name: Run pyOptSparse tests (Uno/unopy only)
+      - name: Run pyOptSparse tests (unopy only)
         run: |
           pip install pytest pytest-timeout parameterized
           cd pyoptsparse

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -2,7 +2,26 @@ name: pyOptSparse tests
 
 on:
   push:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - '*.cff'
+      - '*.yml'
+      - '*.yaml'
+      - 'docs/**'
   pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - '*.cff'
+      - '*.yml'
+      - '*.yaml'
+      - 'docs/**'
+
+env:
+  BUILD_TYPE: Debug
 
 jobs:
   test-pyoptsparse-unopy:

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -41,9 +41,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip setuptools wheel
-
       # -------------------------
       # Install Uno / unopy
       # -------------------------
@@ -56,23 +53,31 @@ jobs:
           CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) pip install . -v
 
       # -------------------------
-      # Clone pyOptSparse
+      # Install pyOptSparse
       # -------------------------
+      
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake build-essential
+            
+      - name: Install Python build tools
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install numpy scipy ninja cmake
+      
       - name: Clone pyOptSparse
         run: |
           git clone https://github.com/robfalck/pyoptsparse
           cd pyoptsparse
           git checkout unopy
 
-      # -------------------------
-      # Install pyOptSparse WITHOUT external solvers
-      # -------------------------
       - name: Install pyOptSparse (no external solvers)
         run: |
           cd pyoptsparse
 
           # Install core package only
-          pip install -e .
+          pip install .
 
           # Install test dependencies if present
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/pyoptsparse-tests.yml
+++ b/.github/workflows/pyoptsparse-tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout Uno

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
@@ -199,13 +199,13 @@ namespace uno {
       this->current_index = (this->current_index + 1) % this->memory_size;
    }
 
-   // compute δ = sᵀy / yᵀy at the last entry
+   // compute δ = yᵀy / sᵀy at the last entry
    double LBFGSHessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
       const double sTy = this->D[this->current_index];
       const auto y = this->Y.column(this->current_index);
       const double yTy = dot(y, y);
       // TODO safeguard
-      return std::min(this->delta_upper_bound, sTy/yTy);
+      return std::min(this->delta_upper_bound, yTy/sTy);
    }
 } // namespace

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
@@ -199,13 +199,13 @@ namespace uno {
       this->current_index = (this->current_index + 1) % this->memory_size;
    }
 
-   // compute δ = yᵀy / sᵀy at the last entry
+   // compute δ = sᵀy / yᵀy at the last entry
    double LBFGSHessian::compute_delta() const {
       assert(0 < this->number_entries_in_memory);
       const double sTy = this->D[this->current_index];
       const auto y = this->Y.column(this->current_index);
       const double yTy = dot(y, y);
       // TODO safeguard
-      return std::min(this->delta_upper_bound, yTy/sTy);
+      return std::min(this->delta_upper_bound, sTy/yTy);
    }
 } // namespace


### PR DESCRIPTION
Runs the pyOptSparse tests with the current unopy version (other solvers are ignored).

Note: we currently run the following tests: https://github.com/robfalck/pyoptsparse/blob/unopy/tests
This link must be updated when https://github.com/mdolab/pyoptsparse/pull/483 is merged.

Closes https://github.com/cvanaret/Uno/issues/711