### PR TITLE
conda patch

### DIFF
--- a/interfaces/Python/unopy/__init__.py
+++ b/interfaces/Python/unopy/__init__.py
@@ -4,7 +4,7 @@ import sys
 # load bundled DLLs from unopy.libs
 basedir = os.path.dirname(__file__)
 subdir = os.path.join(basedir, '..', 'unopy.libs')
-if os.name == 'nt':
+if os.name == 'nt' and os.path.isdir(subdir):
     # Prepend to PATH so our DLLs are found before any system MinGW ones
     os.environ['PATH'] = subdir + os.pathsep + os.environ.get('PATH', '')
     os.add_dll_directory(subdir)


### PR DESCRIPTION
In https://github.com/conda-forge/staged-recipes/pull/33412, @ewu63 made two patches that should be adopted upstream:
- ~~[0001-cmake-compile-options.patch](https://github.com/conda-forge/staged-recipes/pull/33412/changes#diff-278edc0068ddfe19f4a5ec8bf6accb976438440207fa4a77e1d51cfb16b3a49a)~~
- [x] [0003-skip-dll-dir-when-absent.patch](https://github.com/conda-forge/staged-recipes/pull/33412/changes#diff-219a5b80bcb4978e3d33826a060c39c85c578655b274c23b3183d708e8fc35f8)

@ewu63 The second patch is easy to test, but you seemed to have written the first patch based on an old version of the Uno CMake file. Could you update it to the current version?