### PR TITLE
Use Valgrind on the Fortran example

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,4 +1,4 @@
-name: Valgrind on the C example
+name: Valgrind on the C and Fortran examples
 
 on:
   push:
@@ -65,10 +65,18 @@ jobs:
                 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                 -DUNO=/usr/local/lib/libuno.so .
 
-      - name: Build example
+      - name: Build C example
         working-directory: ${{github.workspace}}/interfaces/C/example
         run: cmake --build ${{github.workspace}}/interfaces/C/example/build --config ${{env.BUILD_TYPE}}
 
-      - name: Run Valgrind on example
+      - name: Run Valgrind on C example
         working-directory: ${{github.workspace}}/interfaces/C/example/build
         run: valgrind --leak-check=full -s ./example_hs015
+
+      - name: Compile Fortran example
+        working-directory: ${{github.workspace}}/interfaces/Fortran
+        run: gfortran example_uno.f90 -o example_uno /usr/local/lib/libuno.so -Wl,-rpath,/usr/local/lib
+
+      - name: Run Valgrind on Fortran example
+        working-directory: ${{github.workspace}}/interfaces/Fortran
+        run: valgrind --leak-check=full -s ./example_uno

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -31,6 +31,9 @@ jobs:
         os: [ubuntu-latest]
         architecture: [x64]
 
+    env:
+      VALGRIND: valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --errors-for-leak-kinds=definite,possible --error-exitcode=1
+
     steps:
       - uses: actions/checkout@v4
       
@@ -71,7 +74,7 @@ jobs:
 
       - name: Run Valgrind on C example
         working-directory: ${{github.workspace}}/interfaces/C/example/build
-        run: valgrind --leak-check=full -s ./example_hs015
+        run: $VALGRIND --leak-check=full -s ./example_hs015
 
       - name: Compile Fortran example
         working-directory: ${{github.workspace}}/interfaces/Fortran
@@ -79,4 +82,4 @@ jobs:
 
       - name: Run Valgrind on Fortran example
         working-directory: ${{github.workspace}}/interfaces/Fortran
-        run: valgrind --leak-check=full -s ./example_uno
+        run: $VALGRIND --leak-check=full -s ./example_uno

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -1182,6 +1182,7 @@ void uno_destroy_solver(void* solver) {
       Solver* uno_solver = static_cast<Solver*>(solver);
       delete uno_solver->solver;
       delete uno_solver->options;
+      delete uno_solver->user_callbacks;
       if (uno_solver->result != nullptr) {
          delete uno_solver->result;
       }

--- a/interfaces/Fortran/example_uno.f90
+++ b/interfaces/Fortran/example_uno.f90
@@ -197,6 +197,8 @@ program example_uno
     !---------------------------------------------------
     ! Cleanup
     !---------------------------------------------------
+    deallocate(logger)
+    deallocate(method_description)
     call uno_destroy_solver(solver)
     call uno_destroy_model(model)
 


### PR DESCRIPTION
Update the CI workflow to also run Valgrind on the Fortran example.