### PR TITLE
Fixed `Options::set` for booleans

### DIFF
--- a/uno/options/Options.cpp
+++ b/uno/options/Options.cpp
@@ -133,7 +133,7 @@ namespace uno {
             this->set_double(option_name, std::stod(option_value), flag_as_overwritten);
          }
          else if (type == OptionType::BOOL) {
-            this->set_bool(option_name, option_value == "yes", flag_as_overwritten);
+            this->set_bool(option_name, option_value == "yes" || option_value == "true", flag_as_overwritten);
          }
          else if (type == OptionType::STRING) {
             this->set_string(option_name, option_value, flag_as_overwritten);


### PR DESCRIPTION
  Booleans were only allowed the `yes` value... :face_with_head_bandage: Added `true`.