### PR TITLE
[CI] Optimize the way workflows are triggered

### DIFF
--- a/.github/workflows/C-test-example.yml
+++ b/.github/workflows/C-test-example.yml
@@ -21,14 +21,10 @@ on:
       - 'docs/**'
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -44,8 +40,6 @@ jobs:
 
       - name: Configure Uno CMake
         shell: bash
-        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
         run: |
           cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                                                -DBQPD=${{github.workspace}}/dependencies/lib/libbqpd.a \
@@ -63,8 +57,6 @@ jobs:
       - name: Configure example CMake
         working-directory: ${{github.workspace}}/interfaces/C/example
         shell: bash
-        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
         run: |
           cmake -B ${{github.workspace}}/interfaces/C/example/build \
                 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -4,22 +4,18 @@ name: Build Python wheels
 on:
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - '*.md'
-      - 'LICENSE'
-      - '*.cff'
-      - '*.yml'
-      - '*.yaml'
-      - 'docs/**'
+    paths:
+      - "uno/**"
+      - "interfaces/UserModel.hpp"
+      - "interfaces/Python/**"
+      - ".github/workflows/build-python-wheels.yml"
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - '*.md'
-      - 'LICENSE'
-      - '*.cff'
-      - '*.yml'
-      - '*.yaml'
-      - 'docs/**'
+    paths:
+      - "uno/**"
+      - "interfaces/UserModel.hpp"
+      - "interfaces/Python/**"
+      - ".github/workflows/build-python-wheels.yml"
 
 env:
   CIBW_TEST_COMMAND: python {project}/interfaces/Python/example/example_hs015.py


### PR DESCRIPTION
Experimentation:
Trigger `build-python-wheels.yml` only when changes to `uno`, `interfaces/UserModel.hpp`, `interfaces/Python/**` and itself