### PR TITLE
Option `write_solution_to_file` (used by AMPL and CUTEst)

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -55,6 +55,7 @@ If not provided, the solver is chosen automatically from the available solvers (
 | `protect_actual_reduction_against_roundoff` | bool | `false` | Whether the actual reduction is slightly modified to account for roundoff |
 | `protected_actual_reduction_macheps_coefficient` | double | 10 | Coefficient of the machine epsilon in the protected actual reduction |
 | `print_subproblem` | bool |  `false` | Whether the subproblem is printed in `DEBUG` mode |
+| `write_solution_to_file` | bool |  `false` | Whether the solution is printed to a file (used by AMPL and CUTEst) |
 
 ## Globalization strategy options
 

--- a/interfaces/AMPL/uno_ampl.cpp
+++ b/interfaces/AMPL/uno_ampl.cpp
@@ -25,7 +25,7 @@ namespace uno {
       const AMPLModel model(model_name);
       Uno uno{};
       Result result = uno.solve(model, options);
-      if (options.get_bool("AMPL_write_solution_to_file")) {
+      if (options.get_bool("write_solution_to_file")) {
          model.write_solution_to_file(result);
       }
       // std::cout << "memory_allocation_amount = " << memory_allocation_amount << '\n';
@@ -59,11 +59,11 @@ int main(int argc, char* argv[]) {
       // the -AMPL flag indicates that the solution should be written to the AMPL solution file
       size_t offset = 2;
       if (argc > 2 && std::string(argv[2]) == "-AMPL") {
-         options.set_bool("AMPL_write_solution_to_file", true);
+         options.set_bool("write_solution_to_file", true);
          ++offset;
       }
       else {
-         options.set_bool("AMPL_write_solution_to_file", false);
+         options.set_bool("write_solution_to_file", false);
       }
       try {
          // get the command line arguments (options start at index offset)

--- a/uno/options/Options.cpp
+++ b/uno/options/Options.cpp
@@ -99,6 +99,7 @@ namespace uno {
       {"linear_solver", OptionType::STRING},
       {"preset", OptionType::STRING},
       {"option_file", OptionType::STRING},
+      {"write_solution_to_file", OptionType::BOOL},
    };
 
    // setters

--- a/uno_default.opt
+++ b/uno_default.opt
@@ -58,6 +58,8 @@ protect_actual_reduction_against_roundoff false
 protected_actual_reduction_macheps_coefficient 10
 # Whether the subproblem is printed in DEBUG mode (bool)
 print_subproblem false
+# Whether the solution is printed to a file (used by AMPL and CUTEst) (bool)
+write_solution_to_file false
 
 ## Globalization strategy options
 # Fraction of the predicted reduction that should be achieved by the actual reduction in the Armijo condition (double)


### PR DESCRIPTION
Added the bool option `write_solution_to_file` (used by AMPL and CUTEst)

cc @nimgould