### PR TITLE
Correct syntax for external headers

### DIFF
--- a/interfaces/AMPL/AMPLModel.hpp
+++ b/interfaces/AMPL/AMPLModel.hpp
@@ -14,8 +14,8 @@
 #include "tools/NumberModelEvaluations.hpp"
 // include AMPL Solver Library (ASL)
 extern "C" {
-#include "asl_pfgh.h"
-#include "getstub.h"
+#include <asl_pfgh.h>
+#include <getstub.h>
 }
 
 namespace uno {

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -28,10 +28,9 @@ extern "C" {
       int kk, ll, kkk, lll, mxws, mxlws;
    } WSC;
 
-   extern void
-   BQPD(const int* n, const int* m, int* k, int* kmax, double* a, int* la, double* x, double* bl, double* bu, double* f, double* fmin, double* g,
-         double* r, double* w, double* e, int* ls, double* alp, int* lp, int* mlp, int* peq, double* ws, int* lws, const int* mode, int* ifail,
-         int* info, int* iprint, int* nout);
+   extern void BQPD(const int* n, const int* m, int* k, int* kmax, double* a, int* la, double* x, double* bl, double* bu,
+      double* f, double* fmin, double* g, double* r, double* w, double* e, int* ls, double* alp, int* lp, int* mlp, int* peq,
+      double* ws, int* lws, const int* mode, int* ifail, int* info, int* iprint, int* nout);
 }
 
 namespace uno {

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
@@ -4,8 +4,8 @@
 #ifndef UNO_HIGHSSOLVER_H
 #define UNO_HIGHSSOLVER_H
 
+#include <highs/Highs.h>
 #include "ingredients/subproblem_solvers/SubproblemSolver.hpp"
-#include "Highs.h"
 #include "HiGHSWorkspace.hpp"
 
 namespace uno {

--- a/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.hpp
@@ -4,7 +4,7 @@
 #ifndef UNO_MUMPSSOLVER_H
 #define UNO_MUMPSSOLVER_H
 
-#include "dmumps_c.h"
+#include <dmumps_c.h>
 #include "../DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "../COOLinearSystem.hpp"
 #include "linear_algebra/Indexing.hpp"

--- a/uno/ingredients/subproblem_solvers/SSIDS/SSIDSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SSIDS/SSIDSSolver.hpp
@@ -4,7 +4,7 @@
 #ifndef UNO_SSIDSSOLVER_H
 #define UNO_SSIDSSOLVER_H
 
-#include "spral_ssids.h"
+#include <spral_ssids.h>
 #include "../DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "../COOLinearSystem.hpp"
 #include "linear_algebra/Indexing.hpp"


### PR DESCRIPTION
Used correct syntax `#include <header>` for external headers.