### PR TITLE
Add option utilities to C interface

### DIFF
--- a/interfaces/C/README.md
+++ b/interfaces/C/README.md
@@ -129,13 +129,6 @@ uno_set_solver_bool_option(solver, "print_solution", true);
 uno_set_solver_string_option(solver, "hessian_model", "exact");
 ```
 
-To get the type, name, and index of a Uno option:
-```c
-uno_get_solver_option_type(solver, "max_iterations");
-uno_int index = uno_get_solver_option_index("max_iterations"); // -1 if not found
-const char* name = uno_get_solver_option_name(0); // NULL if not found
-```
-
 Options can also be loaded from a file that contains an `option value` pair per line (the example file `uno_default.opt` in the root directory contains Uno's default options). The options are set in this particular order. Anything that follows a `#` is treated as a comment and is ignored.
 ```c
 uno_load_solver_option_file(solver, "uno.opt");
@@ -153,6 +146,32 @@ const char* uno_get_solver_string_option(solver, "hessian_model");
 Setting a preset has Uno mimic an existing solver:
 ```c
 uno_set_solver_preset(solver, "filtersqp");
+```
+
+Getting the type of an option from the Uno solver:
+```c
+uno_int uno_get_solver_option_type(solver, "max_iterations");
+```
+
+Iterating over the Uno options:
+```c
+uno_option_iterator uno_option_begin_iterator();
+uno_option_iterator uno_option_end_iterator();
+void uno_option_next_iterator(&option_iterator);
+const char* uno_option_iterator_name(option_iterator);
+uno_int uno_option_iterator_type(option_iterator);
+void uno_option_destroy_iterator(&option_iterator);
+```
+
+The iterator is automatically destroyed when the end is reached in `uno_option_next_iterator`. After destruction, the iterator is set to null.
+
+Example of iterating over Uno options:
+```c
+for (uno_option_iterator it = uno_option_begin_iterator(); it != uno_option_end_iterator(); uno_option_next_iterator(&it)) {
+   const char* name = uno_option_iterator_name(it);
+   uno_int type = uno_option_iterator_type(it);
+   // user's code ...
+}
 ```
 
 ## Setting solver callbacks

--- a/interfaces/C/README.md
+++ b/interfaces/C/README.md
@@ -133,7 +133,7 @@ To get the type, name, and index of a Uno option:
 ```c
 uno_get_solver_option_type(solver, "max_iterations");
 uno_int index = uno_get_solver_option_index("max_iterations"); // -1 if not found
-const char* name = uno_get_solver_option_name(0); // nullptr if not found
+const char* name = uno_get_solver_option_name(0); // NULL if not found
 ```
 
 Options can also be loaded from a file that contains an `option value` pair per line (the example file `uno_default.opt` in the root directory contains Uno's default options). The options are set in this particular order. Anything that follows a `#` is treated as a comment and is ignored.

--- a/interfaces/C/README.md
+++ b/interfaces/C/README.md
@@ -163,7 +163,7 @@ uno_int uno_option_iterator_type(option_iterator);
 void uno_option_destroy_iterator(&option_iterator);
 ```
 
-The iterator is automatically destroyed when the end is reached in `uno_option_next_iterator`. After destruction, the iterator is set to null.
+The iterator is automatically destroyed when the end is reached in `uno_option_next_iterator` (no call to `uno_option_destroy_iterator` is required). After destruction, the iterator is set to null.
 
 Example of iterating over Uno options:
 ```c

--- a/interfaces/C/README.md
+++ b/interfaces/C/README.md
@@ -129,6 +129,13 @@ uno_set_solver_bool_option(solver, "print_solution", true);
 uno_set_solver_string_option(solver, "hessian_model", "exact");
 ```
 
+To get the type, name, and index of a Uno option:
+```c
+uno_get_solver_option_type(solver, "max_iterations");
+uno_int index = uno_get_solver_option_index("max_iterations"); // -1 if not found
+const char* name = uno_get_solver_option_name(0); // nullptr if not found
+```
+
 Options can also be loaded from a file that contains an `option value` pair per line (the example file `uno_default.opt` in the root directory contains Uno's default options). The options are set in this particular order. Anything that follows a `#` is treated as a comment and is ignored.
 ```c
 uno_load_solver_option_file(solver, "uno.opt");

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -893,11 +893,14 @@ bool uno_set_solver_string_option(void* solver, const char* option_name, const c
 }
 
 uno_int uno_get_solver_option_type(void* solver, const char* option_name) {
+/*
+   // solver not needed for option type - kept for back-compatibility
    if (solver == nullptr) {
       WARNING << "Please specify a valid solver."  << std::endl;
       return false;
    }
    Solver* uno_solver = static_cast<Solver*>(solver);
+*/
    try {
       return static_cast<uno_int>(Options::option_types.at(option_name));
    }

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -899,11 +899,34 @@ uno_int uno_get_solver_option_type(void* solver, const char* option_name) {
    }
    Solver* uno_solver = static_cast<Solver*>(solver);
    try {
-      return static_cast<uno_int>(uno_solver->options->get_option_type(option_name));
+      return static_cast<uno_int>(Options::option_types.at(option_name));
    }
    catch(const std::out_of_range&) {
       return UNO_OPTION_TYPE_NOT_FOUND;
    }
+}
+
+uno_int uno_get_solver_option_index(const char* option_name) {
+   const std::string option_name_str(option_name);
+   uno_int it = 0;
+   for (const auto& [name, value] : Options::option_types) {
+      if (name == option_name_str) {
+         return it;
+      }
+      ++it;
+   }
+   return -1;
+}
+
+const char* uno_get_solver_option_name(uno_int option_index) {
+   uno_int it = 0;
+   for (const auto& [name, value] : Options::option_types) {
+      if (it == option_index) {
+         return name.c_str();
+      }
+      ++it;
+   }
+   return nullptr;
 }
 
 bool uno_load_solver_option_file(void* solver, const char* file_name) {

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -1078,7 +1078,7 @@ const char* uno_get_solver_string_option(void* solver, const char* option_name) 
    }
    catch(const std::out_of_range& e) {
       // handle missing optional options
-      if (std::string(option_name)=="option_file" || std::string(option_name)=="preset") {
+      if (strcmp(option_name, "option_file") == 0 || strcmp(option_name, "preset") == 0){
          return nullptr;
       }
       throw e;

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -25,6 +25,8 @@
 
 using namespace uno;
 
+using OptionIterator = decltype(Options::option_types)::const_iterator;
+
 using CUserModel = UserModel<uno_objective_callback, uno_objective_gradient_callback, uno_constraints_callback,
    uno_constraints_jacobian_callback, uno_constraints_jacobian_operator_callback, uno_constraints_jacobian_transposed_operator_callback,
    uno_lagrangian_hessian_callback, uno_lagrangian_hessian_operator_callback, std::vector<double>, void*>;
@@ -893,43 +895,73 @@ bool uno_set_solver_string_option(void* solver, const char* option_name, const c
 }
 
 uno_int uno_get_solver_option_type(void* solver, const char* option_name) {
-/*
-   // solver not needed for option type - kept for back-compatibility
    if (solver == nullptr) {
       WARNING << "Please specify a valid solver."  << std::endl;
       return false;
    }
    Solver* uno_solver = static_cast<Solver*>(solver);
-*/
    try {
-      return static_cast<uno_int>(Options::option_types.at(option_name));
+      return static_cast<uno_int>(uno_solver->options->get_option_type(option_name));
    }
    catch(const std::out_of_range&) {
       return UNO_OPTION_TYPE_NOT_FOUND;
    }
 }
 
-uno_int uno_get_solver_option_index(const char* option_name) {
-   const std::string option_name_str(option_name);
-   uno_int it = 0;
-   for (const auto& [name, value] : Options::option_types) {
-      if (name == option_name_str) {
-         return it;
-      }
-      ++it;
+uno_option_iterator uno_option_begin_iterator() {
+   if (Options::option_types.begin()==Options::option_types.end()) {
+      // empty list
+      return nullptr;
    }
-   return -1;
+   return new OptionIterator(Options::option_types.begin());
 }
 
-const char* uno_get_solver_option_name(uno_int option_index) {
-   uno_int it = 0;
-   for (const auto& [name, value] : Options::option_types) {
-      if (it == option_index) {
-         return name.c_str();
-      }
-      ++it;
-   }
+uno_option_iterator uno_option_end_iterator() {
+   // nullptr is the sentinel for end iterator
    return nullptr;
+}
+
+void uno_option_next_iterator(uno_option_iterator* it) {
+   if (it == nullptr) {
+      WARNING << "Please specify a valid option iterator."  << std::endl;
+      return;
+   }
+   if (*it == nullptr) {
+      // do not increment if end has been reached
+      return;
+   }
+   auto& iterator = *static_cast<OptionIterator*>(*it);
+   ++iterator;
+   if (iterator == Options::option_types.end()) {
+      // end reached: destroy
+      uno_option_destroy_iterator(it);
+   }  
+}
+
+const char* uno_option_iterator_name(uno_option_iterator it) {
+   if (it == nullptr) {
+      // nullptr if iterator is null
+      return nullptr;
+   }
+   auto& iterator = *static_cast<OptionIterator*>(it);
+   return iterator->first.c_str();
+}
+
+uno_int uno_option_iterator_type(uno_option_iterator it) {
+   if (it == nullptr) {
+      // option not found if iterator is null
+      return UNO_OPTION_TYPE_NOT_FOUND;
+   }
+   auto& iterator = *static_cast<OptionIterator*>(it);
+   return static_cast<uno_int>(iterator->second);
+}
+
+void uno_option_destroy_iterator(uno_option_iterator* it) {
+   if (it == nullptr || *it == nullptr) {
+      return;
+   }
+   delete static_cast<OptionIterator*>(*it);
+   *it = nullptr;
 }
 
 bool uno_load_solver_option_file(void* solver, const char* file_name) {
@@ -1041,7 +1073,16 @@ const char* uno_get_solver_string_option(void* solver, const char* option_name) 
       throw std::runtime_error("Please specify a valid solver.");
    }
    Solver* uno_solver = static_cast<Solver*>(solver);
-   return uno_solver->options->get_string(option_name).c_str();
+   try {
+      return uno_solver->options->get_string(option_name).c_str();
+   }
+   catch(const std::out_of_range& e) {
+      // handle missing optional options
+      if (std::string(option_name)=="option_file" || std::string(option_name)=="preset") {
+         return nullptr;
+      }
+      throw e;
+   }
 }
 
 // auxiliary function

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -886,6 +886,10 @@ bool uno_set_solver_string_option(void* solver, const char* option_name, const c
    // handle the preset separately
    if (strcmp(option_name, "preset") == 0) {
       return uno_set_solver_preset(solver, option_value);
+   } 
+   // handle the option_file separately
+   else if (strcmp(option_name, "option_file") == 0) {
+      return uno_load_solver_option_file(solver, option_value);
    }
    else {
       Solver* uno_solver = static_cast<Solver*>(solver);

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -1077,15 +1077,15 @@ const char* uno_get_solver_string_option(void* solver, const char* option_name) 
       throw std::runtime_error("Please specify a valid solver.");
    }
    Solver* uno_solver = static_cast<Solver*>(solver);
-   try {
-      return uno_solver->options->get_string(option_name).c_str();
-   }
-   catch(const std::out_of_range& e) {
-      // handle missing optional options
-      if (strcmp(option_name, "option_file") == 0 || strcmp(option_name, "preset") == 0){
+   // handle the preset and option_file separately
+   if (strcmp(option_name, "option_file") == 0 || strcmp(option_name, "preset") == 0) {
+      try {
+         return uno_solver->options->get_string(option_name).c_str();
+      } catch(const std::out_of_range&) {
          return nullptr;
       }
-      throw e;
+   } else {
+      return uno_solver->options->get_string(option_name).c_str();
    }
 }
 

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -304,7 +304,7 @@ extern "C" {
 
    // gets the name of a particular option in the Uno solver.
    // takes as input the index of the option.
-   // returns the name of the option.
+   // returns the name of the option (NULL when out of range).
    const char* uno_get_solver_option_name(uno_int option_index);
 
    // [optional] loads the options from a given option file.

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -297,6 +297,16 @@ extern "C" {
    // the possible types are integer, double, bool and string.
    uno_int uno_get_solver_option_type(void* solver, const char* option_name);
 
+   // gets the index of a particular option in the Uno solver.
+   // takes as input the name of the option.
+   // returns the index of the option.
+   uno_int uno_get_solver_option_index(const char* option_name);
+
+   // gets the name of a particular option in the Uno solver.
+   // takes as input the index of the option.
+   // returns the name of the option.
+   const char* uno_get_solver_option_name(uno_int option_index);
+
    // [optional] loads the options from a given option file.
    // takes as input the name of the option file.
    // returns true if it succeeded, false otherwise.

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -62,6 +62,9 @@ extern "C" {
    const uno_int UNO_VERSION_MINOR = 7;
    const uno_int UNO_VERSION_PATCH = 4;
 
+   // option iterator
+   typedef void* uno_option_iterator;
+
    // - takes as inputs a vector "x" of size "number_variables" and an object "user_data", and
    // stores the objective value of "x" in "objective_value".
    // - returns an integer that is 0 if the evaluation succeeded, and positive otherwise.
@@ -297,15 +300,13 @@ extern "C" {
    // the possible types are integer, double, bool and string.
    uno_int uno_get_solver_option_type(void* solver, const char* option_name);
 
-   // gets the index of a particular option in the Uno solver.
-   // takes as input the name of the option.
-   // returns the index of the option.
-   uno_int uno_get_solver_option_index(const char* option_name);
-
-   // gets the name of a particular option in the Uno solver.
-   // takes as input the index of the option.
-   // returns the name of the option (NULL when out of range).
-   const char* uno_get_solver_option_name(uno_int option_index);
+   // iterate over the Uno option types and names
+   uno_option_iterator uno_option_begin_iterator();
+   uno_option_iterator uno_option_end_iterator();
+   void uno_option_next_iterator(uno_option_iterator* it);
+   const char* uno_option_iterator_name(uno_option_iterator it);
+   uno_int uno_option_iterator_type(uno_option_iterator it);
+   void uno_option_destroy_iterator(uno_option_iterator* it);
 
    // [optional] loads the options from a given option file.
    // takes as input the name of the option file.

--- a/interfaces/C/example/example_hs015.c
+++ b/interfaces/C/example/example_hs015.c
@@ -71,10 +71,44 @@ void print_vector(const double* vector, uno_int size) {
       printf("\n");
 }
 
+void print_uno_options() {
+       // temporary solver for default options
+      void* solver = uno_create_solver();
+      printf("Uno options:\n");
+      for (uno_option_iterator it = uno_option_begin_iterator(); it != uno_option_end_iterator(); uno_option_next_iterator(&it)) {
+            const char* name = uno_option_iterator_name(it);
+            uno_int type = uno_option_iterator_type(it);
+            if (type==UNO_OPTION_TYPE_DOUBLE) {
+                  double value = uno_get_solver_double_option(solver, name);
+                  printf("\t%s: %f\n", name, value);
+            }
+            else if (type==UNO_OPTION_TYPE_INTEGER) {
+                  int value = uno_get_solver_integer_option(solver, name);
+                  printf("\t%s: %d\n", name, value);
+            }
+            else if (type==UNO_OPTION_TYPE_STRING) {
+                  const char* value = uno_get_solver_string_option(solver, name);
+                  if (value) {
+                        printf("\t%s: %s\n", name, value);
+                  }
+            }
+            else if (type==UNO_OPTION_TYPE_BOOL) {
+                  bool value = uno_get_solver_bool_option(solver, name);
+                  printf("\t%s: %d\n", name, value);
+            }
+      }
+      uno_destroy_solver(solver);
+}
+
 int main() {
       uno_int uno_major, uno_minor, uno_patch;
       uno_get_version(&uno_major, &uno_minor, &uno_patch);
       printf("Uno v%d.%d.%d\n", uno_major, uno_minor, uno_patch);
+
+/*
+      // print all options
+      print_uno_options();
+*/
 
       // model creation
       const uno_int base_indexing = UNO_ZERO_BASED_INDEXING;

--- a/interfaces/Fortran/uno_c.f90
+++ b/interfaces/Fortran/uno_c.f90
@@ -636,6 +636,65 @@ interface
 end interface
 
 !---------------------------------------------
+! uno_option_begin_iterator
+!---------------------------------------------
+interface
+   function uno_option_begin_iterator() &
+      result(option_begin_iterator) &
+      bind(C, name="uno_option_begin_iterator")
+      import :: c_ptr
+      type(c_ptr) :: option_begin_iterator
+   end function uno_option_begin_iterator
+end interface
+
+!---------------------------------------------
+! uno_option_end_iterator
+!---------------------------------------------
+interface
+   function uno_option_end_iterator() &
+      result(option_end_iterator) &
+      bind(C, name="uno_option_end_iterator")
+      import :: c_ptr
+      type(c_ptr) :: option_end_iterator
+   end function uno_option_end_iterator
+end interface
+
+!---------------------------------------------
+! uno_option_next_iterator
+!---------------------------------------------
+interface
+   subroutine uno_option_next_iterator(it) &
+      bind(C, name="uno_option_next_iterator")
+      import :: c_ptr
+      type(c_ptr), value :: it
+   end subroutine uno_option_next_iterator
+end interface
+
+!---------------------------------------------
+! uno_option_iterator_type
+!---------------------------------------------
+interface
+   function uno_option_iterator_type(it) &
+      result(option_iterator_type) &
+      bind(C, name="uno_option_iterator_type")
+      import :: c_ptr, uno_int
+      type(c_ptr), value :: it
+      integer(uno_int) :: option_iterator_type
+   end function uno_option_iterator_type
+end interface
+
+!---------------------------------------------
+! uno_option_destroy_iterator
+!---------------------------------------------
+interface
+   subroutine uno_option_destroy_iterator(it) &
+      bind(C, name="uno_option_destroy_iterator")
+      import :: c_ptr
+      type(c_ptr), value :: it
+   end subroutine uno_option_destroy_iterator
+end interface
+
+!---------------------------------------------
 ! uno_set_solver_callbacks
 !---------------------------------------------
 interface

--- a/interfaces/Fortran/uno_fortran.f90
+++ b/interfaces/Fortran/uno_fortran.f90
@@ -255,6 +255,72 @@ function uno_get_solver_option_type(solver, option_name) result(solver_option_ty
 end function uno_get_solver_option_type
 
 !---------------------------------------------
+! uno_get_solver_option_index
+!---------------------------------------------
+function uno_get_solver_option_index(option_name) result(solver_option_index)
+   character(len=*) :: option_name
+   integer(uno_int) :: solver_option_index
+   character(c_char), allocatable :: option_name_c(:)
+   integer :: i, n
+
+   interface
+      function uno_get_solver_option_index_c(option_name) &
+         result(solver_option_index) &
+         bind(C, name="uno_get_solver_option_index")
+         import :: c_char, uno_int
+         character(c_char) :: option_name(*)
+         integer(uno_int) :: solver_option_index
+      end function uno_get_solver_option_index_c
+   end interface
+
+   n = len_trim(option_name)
+   allocate(option_name_c(n+1))
+   do i = 1, n
+      option_name_c(i) = option_name(i:i)
+   end do
+   option_name_c(n+1) = c_null_char
+   solver_option_index = uno_get_solver_option_index_c(option_name_c)
+   deallocate(option_name_c)
+end function uno_get_solver_option_index
+
+!---------------------------------------------
+! uno_get_solver_option_name
+!---------------------------------------------
+function uno_get_solver_option_name(option_index) &
+   result(solver_option_name)
+   integer(uno_int), value :: option_index
+   character(:), allocatable :: solver_option_name
+   type(c_ptr) :: ptr_solver_option_name_c
+   integer :: i, n
+   character(c_char), pointer :: solver_option_name_c(:)
+
+   interface
+      function uno_get_solver_option_name_c(option_index) &
+         result(solver_option_name) &
+         bind(C, name="uno_get_solver_option_name")
+         import :: uno_int, c_ptr
+         integer(uno_int), value :: option_index
+         type(c_ptr) :: solver_option_name
+      end function uno_get_solver_option_name_c
+   end interface
+
+   ptr_solver_option_name_c = uno_get_solver_option_name_c(option_index)
+   if (.not. c_associated(ptr_solver_option_name_c)) then
+      solver_option_name = ""
+      return
+   end if
+   call c_f_pointer(ptr_solver_option_name_c, solver_option_name_c, [huge(0)])
+   n = 0
+   do while (solver_option_name_c(n+1) /= c_null_char)
+      n = n + 1
+   end do
+   allocate(character(len=n)::solver_option_name)
+   do i = 1, n
+      solver_option_name(i:i) = solver_option_name_c(i)
+   end do
+end function uno_get_solver_option_name
+
+!---------------------------------------------
 ! uno_load_solver_option_file
 !---------------------------------------------
 function uno_load_solver_option_file(solver, file_name) result(success)

--- a/interfaces/Fortran/uno_fortran.f90
+++ b/interfaces/Fortran/uno_fortran.f90
@@ -255,70 +255,41 @@ function uno_get_solver_option_type(solver, option_name) result(solver_option_ty
 end function uno_get_solver_option_type
 
 !---------------------------------------------
-! uno_get_solver_option_index
+! uno_option_iterator_name
 !---------------------------------------------
-function uno_get_solver_option_index(option_name) result(solver_option_index)
-   character(len=*) :: option_name
-   integer(uno_int) :: solver_option_index
-   character(c_char), allocatable :: option_name_c(:)
+function uno_option_iterator_name(it) &
+   result(option_iterator_name)
+   type(c_ptr), value :: it
+   character(:), allocatable :: option_iterator_name
+   type(c_ptr) :: ptr_option_iterator_name_c
    integer :: i, n
+   character(c_char), pointer :: option_iterator_name_c(:)
 
    interface
-      function uno_get_solver_option_index_c(option_name) &
-         result(solver_option_index) &
-         bind(C, name="uno_get_solver_option_index")
-         import :: c_char, uno_int
-         character(c_char) :: option_name(*)
-         integer(uno_int) :: solver_option_index
-      end function uno_get_solver_option_index_c
+      function uno_option_iterator_name_c(it) &
+         result(option_iterator_name) &
+         bind(C, name="uno_option_iterator_name")
+         import :: c_ptr
+         type(c_ptr), value :: it
+         type(c_ptr) :: option_iterator_name
+      end function uno_option_iterator_name_c
    end interface
 
-   n = len_trim(option_name)
-   allocate(option_name_c(n+1))
-   do i = 1, n
-      option_name_c(i) = option_name(i:i)
-   end do
-   option_name_c(n+1) = c_null_char
-   solver_option_index = uno_get_solver_option_index_c(option_name_c)
-   deallocate(option_name_c)
-end function uno_get_solver_option_index
-
-!---------------------------------------------
-! uno_get_solver_option_name
-!---------------------------------------------
-function uno_get_solver_option_name(option_index) &
-   result(solver_option_name)
-   integer(uno_int), value :: option_index
-   character(:), allocatable :: solver_option_name
-   type(c_ptr) :: ptr_solver_option_name_c
-   integer :: i, n
-   character(c_char), pointer :: solver_option_name_c(:)
-
-   interface
-      function uno_get_solver_option_name_c(option_index) &
-         result(solver_option_name) &
-         bind(C, name="uno_get_solver_option_name")
-         import :: uno_int, c_ptr
-         integer(uno_int), value :: option_index
-         type(c_ptr) :: solver_option_name
-      end function uno_get_solver_option_name_c
-   end interface
-
-   ptr_solver_option_name_c = uno_get_solver_option_name_c(option_index)
-   if (.not. c_associated(ptr_solver_option_name_c)) then
-      solver_option_name = ""
+   ptr_option_iterator_name_c = uno_option_iterator_name_c(it)
+   if (.not. c_associated(ptr_option_iterator_name_c)) then
+      option_iterator_name = ""
       return
    end if
-   call c_f_pointer(ptr_solver_option_name_c, solver_option_name_c, [huge(0)])
+   call c_f_pointer(ptr_option_iterator_name_c, option_iterator_name_c, [huge(0)])
    n = 0
-   do while (solver_option_name_c(n+1) /= c_null_char)
+   do while (option_iterator_name_c(n+1) /= c_null_char)
       n = n + 1
    end do
-   allocate(character(len=n)::solver_option_name)
+   allocate(character(len=n)::option_iterator_name)
    do i = 1, n
-      solver_option_name(i:i) = solver_option_name_c(i)
+      option_iterator_name(i:i) = option_iterator_name_c(i)
    end do
-end function uno_get_solver_option_name
+end function uno_option_iterator_name
 
 !---------------------------------------------
 ! uno_load_solver_option_file

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -202,6 +202,14 @@ function uno_get_solver_option_type(solver, option_name)
                                              option_name::Cstring)::Int32
 end
 
+function uno_get_solver_option_index(option_name)
+    @ccall libuno.uno_get_solver_option_index(option_name::Cstring)::Int32
+end
+
+function uno_get_solver_option_name(option_index)
+    @ccall libuno.uno_get_solver_option_name(option_index::Int32)::Cstring
+end
+
 function uno_load_solver_option_file(solver, file_name)
     @ccall libuno.uno_load_solver_option_file(solver::Ptr{Cvoid}, file_name::Cstring)::Bool
 end

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -38,6 +38,8 @@ const UNO_FEASIBLE_SMALL_STEP = Cint(4)
 const UNO_INFEASIBLE_SMALL_STEP = Cint(5)
 const UNO_UNBOUNDED = Cint(6)
 
+const uno_option_iterator = Ptr{Cvoid}
+
 function uno_get_version(major, minor, patch)
     @ccall libuno.uno_get_version(major::Ptr{Int32}, minor::Ptr{Int32},
                                   patch::Ptr{Int32})::Cvoid
@@ -202,12 +204,28 @@ function uno_get_solver_option_type(solver, option_name)
                                              option_name::Cstring)::Int32
 end
 
-function uno_get_solver_option_index(option_name)
-    @ccall libuno.uno_get_solver_option_index(option_name::Cstring)::Int32
+function uno_option_begin_iterator()
+    @ccall libuno.uno_option_begin_iterator()::uno_option_iterator
 end
 
-function uno_get_solver_option_name(option_index)
-    @ccall libuno.uno_get_solver_option_name(option_index::Int32)::Cstring
+function uno_option_end_iterator()
+    @ccall libuno.uno_option_end_iterator()::uno_option_iterator
+end
+
+function uno_option_next_iterator(it)
+    @ccall libuno.uno_option_next_iterator(it::Ptr{uno_option_iterator})::Cvoid
+end
+
+function uno_option_iterator_name(it)
+    @ccall libuno.uno_option_iterator_name(it::uno_option_iterator)::Cstring
+end
+
+function uno_option_iterator_type(it)
+    @ccall libuno.uno_option_iterator_type(it::uno_option_iterator)::Int32
+end
+
+function uno_option_destroy_iterator(it)
+    @ccall libuno.uno_option_destroy_iterator(it::Ptr{uno_option_iterator})::Cvoid
 end
 
 function uno_load_solver_option_file(solver, file_name)

--- a/uno/options/DefaultOptions.cpp
+++ b/uno/options/DefaultOptions.cpp
@@ -32,6 +32,7 @@ namespace uno {
       options.set_double("unbounded_objective_threshold", -1e20);
 
       /** main options **/
+      options.set_bool("write_solution_to_file", false);
       // logging level (SILENT|DISCRETE|WARNING|INFO|DEBUG|DEBUG2|DEBUG3)
       options.set_string("logger", "INFO");
       // Hessian model (exact|LBFGS|identity|zero)


### PR DESCRIPTION
Hi Charlie,
I have added a couple of utility functions in the C inteface. These may be usefull for iterating over all options.
I also noticed that in `uno_get_solver_option_type(void* solver, const char* option_name)` the `solver` input may be also removed, as the option type may be obtained directily from `Options::option_types`. For now, I kept the that function as is, since it may break examples or the other interfaces.