### PR TITLE
Set macos-15 manually in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           shell: bash
 
         # ---------- MACOS ----------
-        - os: macos-latest
+        - os: macos-15
           toolchain: gcc
           build_type: Debug
           shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,8 +103,8 @@ jobs:
       run: |
         brew install libomp
         LIBGFORTRAN_FOLDER=$(dirname "$(gfortran-15 -print-file-name=libgfortran.dylib)")
-          echo "LIBGFORTRAN_FOLDER=$LIBGFORTRAN_FOLDER" >> $GITHUB_ENV
-          echo "OPENMP_LIB=$(brew --prefix libomp)/lib/libomp.dylib" >> $GITHUB_ENV
+        echo "LIBGFORTRAN_FOLDER=$LIBGFORTRAN_FOLDER" >> $GITHUB_ENV
+        echo "OPENMP_LIB=$(brew --prefix libomp)/lib/libomp.dylib" >> $GITHUB_ENV
 
     # ----- MSVC -----
     - name: MSVC environment

--- a/.github/workflows/cutest-hs15-test.yml
+++ b/.github/workflows/cutest-hs15-test.yml
@@ -43,13 +43,6 @@ jobs:
       - name: Checkout Uno
         uses: actions/checkout@v4
 
-      # Match the libgfortran5 ABI of Uno's precompiled dependencies (BQPD, UnoUtils).
-      - name: Install GCC / gfortran 14
-        uses: fortran-lang/setup-fortran@main
-        with:
-          compiler: gcc
-          version: '14'
-
       # ----------------------------------------------------------------
       # 1) Build & install Uno  ->  /usr/local/lib/libuno.so
       #    (this is the path CUTEst's default `uno` package links against)

--- a/.github/workflows/julia-tests-jll.yml
+++ b/.github/workflows/julia-tests-jll.yml
@@ -26,7 +26,7 @@ jobs:
             arch: 'arm64'
             version: '1'
             allow_failure: false
-          - os: macos-latest
+          - os: macos-15
             arch: 'arm64'
             version: '1'
             allow_failure: false
@@ -41,7 +41,7 @@ jobs:
           echo "OMP_PROC_BIND=TRUE"    >> "$GITHUB_ENV"
 
       - name: Install compilers (macOS)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-15'
         uses: fortran-lang/setup-fortran@main
         with:
           compiler: 'gcc'

--- a/.github/workflows/julia-tests-jll.yml
+++ b/.github/workflows/julia-tests-jll.yml
@@ -40,13 +40,6 @@ jobs:
           echo "OMP_CANCELLATION=TRUE" >> "$GITHUB_ENV"
           echo "OMP_PROC_BIND=TRUE"    >> "$GITHUB_ENV"
 
-      - name: Install compilers (macOS)
-        if: matrix.os == 'macos-15'
-        uses: fortran-lang/setup-fortran@main
-        with:
-          compiler: 'gcc'
-          version: '14'
-
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
             libuno-extension: dylib
 
           - build: aarch64-apple-darwin-cxx11
-            os: macos-latest
+            os: macos-15
             os-name: macOS
             arch: aarch64
             extension: tar.gz

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
             shell: bash
 
           # ---------- MACOS ----------
-          - os: macos-latest
+          - os: macos-15
             toolchain: gcc
             build_type: Debug
             shell: bash


### PR DESCRIPTION
MacOS runners are being upgraded to macOS 26. I had to set macos-15 in the workflows manually.

Follow-up of https://github.com/cvanaret/Uno/pull/793