### PR TITLE
Upgrade to UnoUtils v2026.7.2

### DIFF
--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -145,7 +145,7 @@ cmake .. \
     -DBUILD_TESTING=OFF \
     -DBUILD_CXX_EXE=OFF \
     -DBLAS_LIBRARIES=${libdir}/libopenblas.${dlext} \
-    -DBUILD_SHARED_EXTRAS_LIB=OFF \
+    -DBUILD_SHARED_EXTRAS_LIB=ON \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
 if [[ "${target}" == *-linux* ]]; then

--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -145,6 +145,7 @@ cmake .. \
     -DBUILD_TESTING=OFF \
     -DBUILD_CXX_EXE=OFF \
     -DBLAS_LIBRARIES=${libdir}/libopenblas.${dlext} \
+    -DBUILD_SHARED_EXTRAS_LIB=OFF \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
 if [[ "${target}" == *-linux* ]]; then
@@ -175,12 +176,13 @@ cmake \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DAMPLSOLVER=${libdir}/libasl.${dlext} \
-    -DHIGHS=${libdir}/libhighs.${dlext} \
+    -DHIGHS="${libdir}/libhighs.${dlext};${libdir}/libhighs_extras.${dlext}" \
     -DBQPD=${prefix}/lib/libbqpd.a \
     -DHSL=${libdir}/libhsl.${dlext} \
     -DSPRAL=${libdir}/libspral.${dlext} \
     -DMUMPS_INCLUDE_DIR=${includedir} \
     -DMETIS_INCLUDE_DIR=${includedir} \
+    -DHIGHS_INCLUDE_DIR=${includedir}/highs \
     -DSPRAL_INCLUDE_DIR=${includedir} \
     -DMUMPS_LIBRARY="${libdir}/libdmumps.${dlext}" \
     -DMUMPS_COMMON_LIBRARY="${libdir}/libmumps_common.${dlext}" \

--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -176,7 +176,7 @@ cmake \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} \
     -DCMAKE_BUILD_TYPE=Release \
     -DAMPLSOLVER=${libdir}/libasl.${dlext} \
-    -DHIGHS="${libdir}/libhighs.${dlext};${libdir}/libhighs_extras.${dlext}" \
+    -DHIGHS=${libdir}/libhighs.${dlext} \
     -DBQPD=${prefix}/lib/libbqpd.a \
     -DHSL=${libdir}/libhsl.${dlext} \
     -DSPRAL=${libdir}/libspral.${dlext} \

--- a/.github/julia/build_tarballs_utils.jl
+++ b/.github/julia/build_tarballs_utils.jl
@@ -5,7 +5,7 @@
 using BinaryBuilder, Pkg
 
 name = "UnoUtils"
-version = v"2026.7.1"
+version = v"2026.7.2"
 
 # Collection of sources
 sources = [
@@ -291,6 +291,6 @@ build_tarballs(
     products,
     dependencies;
     julia_compat = "1.6",
-    preferred_gcc_version = v"13.2.0",
+    preferred_gcc_version = v"13.2.0", # with BinaryBuilder{Base} developed
     clang_use_lld=false,
 )

--- a/.github/julia/build_tarballs_utils.jl
+++ b/.github/julia/build_tarballs_utils.jl
@@ -208,6 +208,7 @@ cmake .. \
     -DBUILD_TESTING=OFF \
     -DBUILD_CXX_EXE=OFF \
     -DBLAS_LIBRARIES=${prefix}/lib/libblas.a \
+    -DBUILD_SHARED_EXTRAS_LIB=OFF \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
 if [[ "${target}" == *-linux* ]]; then
@@ -268,6 +269,7 @@ products = [
     FileProduct("lib/libmumps_common.a", :libmumps_common_a),
     FileProduct("lib/libdmumps.a", :libdmumps_a),
     FileProduct("lib/libhighs.a", :libhighs_a),
+    FileProduct("lib/libhighs_extras.a", :libhighs_extras_a),
     FileProduct("lib/libspral.a", :libspral_a),
     # FileProduct("lib/libhwloc.a", :libhwloc_a),
 ]

--- a/.github/julia/build_tarballs_utils.jl
+++ b/.github/julia/build_tarballs_utils.jl
@@ -5,7 +5,7 @@
 using BinaryBuilder, Pkg
 
 name = "UnoUtils"
-version = v"2026.6.30"
+version = v"2026.7.1"
 
 # Collection of sources
 sources = [
@@ -291,6 +291,6 @@ build_tarballs(
     products,
     dependencies;
     julia_compat = "1.6",
-    preferred_gcc_version = v"10.2.0",
+    preferred_gcc_version = v"13.2.0",
     clang_use_lld=false,
 )

--- a/.github/julia/build_tarballs_yggdrasil.jl
+++ b/.github/julia/build_tarballs_yggdrasil.jl
@@ -51,12 +51,13 @@ cmake \
     -DCMAKE_EXE_LINKER_FLAGS="${SANITIZER_FLAGS}" \
     -DCMAKE_SHARED_LINKER_FLAGS="${SANITIZER_FLAGS}" \
     -DAMPLSOLVER=${libdir}/libasl.${dlext} \
-    -DHIGHS=${libdir}/libhighs.${dlext} \
+    -DHIGHS="${libdir}/libhighs.${dlext};${libdir}/libhighs_extras.${dlext}" \
     -DBQPD=${prefix}/lib/libbqpd.a \
     -DHSL=${libdir}/libhsl.${dlext} \
     -DBLA_VENDOR="libblastrampoline" \
     -DMUMPS_INCLUDE_DIR=${includedir} \
     -DMETIS_INCLUDE_DIR=${includedir} \
+    -DHIGHS_INCLUDE_DIR=${includedir}/highs \
     -DSPRAL_INCLUDE_DIR=${includedir} \
     -DMUMPS_LIBRARY="${libdir}/libdmumps.${dlext}" \
     -DMUMPS_COMMON_LIBRARY="${libdir}/libmumps_common.${dlext}" \

--- a/.github/julia/build_tarballs_yggdrasil.jl
+++ b/.github/julia/build_tarballs_yggdrasil.jl
@@ -51,7 +51,7 @@ cmake \
     -DCMAKE_EXE_LINKER_FLAGS="${SANITIZER_FLAGS}" \
     -DCMAKE_SHARED_LINKER_FLAGS="${SANITIZER_FLAGS}" \
     -DAMPLSOLVER=${libdir}/libasl.${dlext} \
-    -DHIGHS="${libdir}/libhighs.${dlext};${libdir}/libhighs_extras.${dlext}" \
+    -DHIGHS=${libdir}/libhighs.${dlext} \
     -DBQPD=${prefix}/lib/libbqpd.a \
     -DHSL=${libdir}/libhsl.${dlext} \
     -DBLA_VENDOR="libblastrampoline" \

--- a/.github/workflows/Fortran-tests-linux.yml
+++ b/.github/workflows/Fortran-tests-linux.yml
@@ -44,12 +44,13 @@ jobs:
           cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                                                -DMUMPS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
                                                -DMETIS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
+                                               -DHIGHS_INCLUDE_DIR=${{github.workspace}}/dependencies/include/highs \
                                                -DBQPD=${{github.workspace}}/dependencies/lib/libbqpd.a \
                                                -DMUMPS_LIBRARY=${{github.workspace}}/dependencies/lib/libdmumps.a \
                                                -DMUMPS_COMMON_LIBRARY=${{github.workspace}}/dependencies/lib/libmumps_common.a \
                                                -DMUMPS_PORD_LIBRARY=${{github.workspace}}/dependencies/lib/libpord.a \
                                                -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}/dependencies/lib/libmpiseq.a \
-                                               -DHIGHS=${{github.workspace}}/dependencies/lib/libhighs.a \
+                                               -DHIGHS="${{github.workspace}}/dependencies/lib/libhighs.a;${{github.workspace}}/dependencies/lib/libhighs_extras.a" \
                                                -DMETIS_LIBRARY=${{github.workspace}}/dependencies/lib/libmetis.a \
                                                -DBLAS_LIBRARIES="${{github.workspace}}/dependencies/lib/libblas.a;${{github.workspace}}/dependencies/lib/libcblas.a" \
                                                -DLAPACK_LIBRARIES=${{github.workspace}}/dependencies/lib/liblapack.a \
@@ -61,7 +62,7 @@ jobs:
 
       - name: Compile Fortran tests
         working-directory: ${{github.workspace}}/interfaces/Fortran
-        run: gfortran example_uno.f90 -o example_uno -L../../build -luno -L${{github.workspace}}/dependencies/lib -lhighs -ldmumps -lmumps_common -lmpiseq -lpord -lmetis -lbqpd -llapack -lcblas -lblas -lstdc++
+        run: gfortran example_uno.f90 -o example_uno -L../../build -luno -L${{github.workspace}}/dependencies/lib -lhighs -lhighs_extras -ldmumps -lmumps_common -lmpiseq -lpord -lmetis -lbqpd -llapack -lcblas -lblas -lstdc++
 
       - name: Run Fortran tests
         working-directory: ${{github.workspace}}/interfaces/Fortran

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -120,9 +120,13 @@ jobs:
         run: cibuildwheel --output-dir ${{github.workspace}}/wheelhouse
         shell: pwsh
         env:
+          CC: C:/mingw64/bin/gcc.exe
+          CXX: C:/mingw64/bin/g++.exe
+          CMAKE_C_COMPILER: C:/mingw64/bin/gcc.exe
+          CMAKE_CXX_COMPILER: C:/mingw64/bin/g++.exe
           UNO_BUNDLE_RUNTIME: "1"
           CIBW_SKIP: cp314t-* cp*-*_i686 *-win32
-          CIBW_BEFORE_BUILD_WINDOWS: >
+          CIBW_BEFORE_ALL_WINDOWS: >
             C:/msys64/usr/bin/bash -lc "cd \"$(cygpath -u '{package}')\" && ./dependencies/scripts/download_dependencies.sh" &&
             pwsh -Command "Get-ChildItem -Path '{package}/dependencies' -Recurse |
             ForEach-Object { $_.LastWriteTime = Get-Date }"
@@ -133,10 +137,6 @@ jobs:
             CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
             CMAKE_GENERATOR="MinGW Makefiles"
             CMAKE_MAKE_PROGRAM=C:/mingw64/bin/mingw32-make.exe
-            CC=C:/mingw64/bin/gcc.exe
-            CXX=C:/mingw64/bin/g++.exe
-            CMAKE_C_COMPILER=C:/mingw64/bin/gcc.exe
-            CMAKE_CXX_COMPILER=C:/mingw64/bin/g++.exe
             CMAKE_Fortran_COMPILER=C:/mingw64/bin/gfortran.exe
           CIBW_CONFIG_SETTINGS_WINDOWS: >
             cmake.define.METIS_LIBRARY=dependencies/bin/libmetis.dll

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -124,7 +124,6 @@ jobs:
           CXX: C:/mingw64/bin/g++.exe
           CMAKE_C_COMPILER: C:/mingw64/bin/gcc.exe
           CMAKE_CXX_COMPILER: C:/mingw64/bin/g++.exe
-          UNO_BUNDLE_RUNTIME: "1"
           CIBW_SKIP: cp314t-* cp*-*_i686 *-win32
           CIBW_BEFORE_ALL_WINDOWS: >
             C:/msys64/usr/bin/bash -lc "cd \"$(cygpath -u '{package}')\" && ./dependencies/scripts/download_dependencies.sh" &&
@@ -132,15 +131,14 @@ jobs:
             ForEach-Object { $_.LastWriteTime = Get-Date }"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
             pwsh -Command "$env:SOURCE_DATE_EPOCH='315532800';
-            delvewheel repair --add-path 'C:/msys64/mingw64/bin;dependencies/bin;dependencies/lib' -w {dest_dir} {wheel}"
+            delvewheel repair --add-path 'C:/mingw64/bin;dependencies/bin' -w {dest_dir} {wheel}"
           CIBW_ENVIRONMENT_WINDOWS: >
-            CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+            CMAKE_BUILD_PARALLEL_LEVEL=$NUMBER_OF_PROCESSORS
             CMAKE_GENERATOR="MinGW Makefiles"
             CMAKE_MAKE_PROGRAM=C:/mingw64/bin/mingw32-make.exe
             CMAKE_Fortran_COMPILER=C:/mingw64/bin/gfortran.exe
           CIBW_CONFIG_SETTINGS_WINDOWS: >
             cmake.define.METIS_LIBRARY=dependencies/bin/libmetis.dll
-            cmake.define.AUXILIARY_LIBRARIES=dependencies/lib/libstdc++.a
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -120,6 +120,7 @@ jobs:
         run: cibuildwheel --output-dir ${{github.workspace}}/wheelhouse
         shell: pwsh
         env:
+          UNO_BUNDLE_RUNTIME: "1"
           CIBW_SKIP: cp314t-* cp*-*_i686 *-win32
           CIBW_BEFORE_BUILD_WINDOWS: >
             C:/msys64/usr/bin/bash -lc "cd \"$(cygpath -u '{package}')\" && ./dependencies/scripts/download_dependencies.sh" &&

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -137,7 +137,7 @@ jobs:
             CMAKE_Fortran_COMPILER=C:/mingw64/bin/gfortran.exe
           CIBW_CONFIG_SETTINGS_WINDOWS: >
             cmake.define.METIS_LIBRARY=dependencies/bin/libmetis.dll
-            cmake.define.AUXILIARY_LIBRARIES="dependencies/lib/libhighs_extras.a;dependencies/lib/libstdc++.a"
+            cmake.define.AUXILIARY_LIBRARIES=dependencies/lib/libstdc++.a
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -137,7 +137,7 @@ jobs:
             CMAKE_Fortran_COMPILER=C:/mingw64/bin/gfortran.exe
           CIBW_CONFIG_SETTINGS_WINDOWS: >
             cmake.define.METIS_LIBRARY=dependencies/bin/libmetis.dll
-            cmake.define.AUXILIARY_LIBRARIES=dependencies/lib/libstdc++.a
+            cmake.define.AUXILIARY_LIBRARIES="dependencies/lib/libstdc++.a;dependencies/lib/libhighs_extras.a"
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -120,6 +120,7 @@ jobs:
         run: cibuildwheel --output-dir ${{github.workspace}}/wheelhouse
         shell: pwsh
         env:
+          UNO_TOOLCHAIN: mingw
           CC: C:/mingw64/bin/gcc.exe
           CXX: C:/mingw64/bin/g++.exe
           CMAKE_C_COMPILER: C:/mingw64/bin/gcc.exe

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -137,7 +137,7 @@ jobs:
             CMAKE_Fortran_COMPILER=C:/mingw64/bin/gfortran.exe
           CIBW_CONFIG_SETTINGS_WINDOWS: >
             cmake.define.METIS_LIBRARY=dependencies/bin/libmetis.dll
-            cmake.define.AUXILIARY_LIBRARIES="dependencies/lib/libstdc++.a;dependencies/lib/libhighs_extras.a"
+            cmake.define.AUXILIARY_LIBRARIES="dependencies/lib/libhighs_extras.a;dependencies/lib/libstdc++.a"
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -132,6 +132,8 @@ jobs:
             CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
             CMAKE_GENERATOR="MinGW Makefiles"
             CMAKE_MAKE_PROGRAM=C:/mingw64/bin/mingw32-make.exe
+            CC=C:/mingw64/bin/gcc.exe
+            CXX=C:/mingw64/bin/g++.exe
             CMAKE_C_COMPILER=C:/mingw64/bin/gcc.exe
             CMAKE_CXX_COMPILER=C:/mingw64/bin/g++.exe
             CMAKE_Fortran_COMPILER=C:/mingw64/bin/gfortran.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,7 @@ jobs:
           -DCMAKE_FORTRAN_COMPILER=gfortran \
           -DMUMPS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
           -DMETIS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
+          -DHIGHS_INCLUDE_DIR=${{github.workspace}}/dependencies/include/highs \
           -DBQPD=${{github.workspace}}/dependencies/lib/libbqpd.a \
           -DMETIS_LIBRARY=${{github.workspace}}/dependencies/lib/libmetis.a \
           -DMUMPS_LIBRARY=${{github.workspace}}/dependencies/lib/libdmumps.a \
@@ -200,7 +201,7 @@ jobs:
           -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}/dependencies/lib/libmpiseq.a \
           -DBLAS_LIBRARIES="${{github.workspace}}/dependencies/lib/libcblas.a;${{github.workspace}}/dependencies/lib/libblas.a" \
           -DLAPACK_LIBRARIES=${{github.workspace}}/dependencies/lib/liblapack.a \
-          -DHIGHS=${{github.workspace}}/dependencies/lib/libhighs.a \
+          -DHIGHS="${{github.workspace}}/dependencies/lib/libhighs.a;${{github.workspace}}/dependencies/lib/libhighs_extras.a" \
           -DBUILD_STATIC_LIBS=ON \
           -DBUILD_SHARED_LIBS=ON
         
@@ -214,6 +215,7 @@ jobs:
           -DCMAKE_FORTRAN_COMPILER=ifx \
           -DMUMPS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
           -DMETIS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
+          -DHIGHS_INCLUDE_DIR=${{github.workspace}}/dependencies/include/highs \
           -DBQPD=${{github.workspace}}/dependencies/lib/libbqpd.a \
           -DMETIS_LIBRARY=${{github.workspace}}/dependencies/lib/libmetis.a \
           -DMUMPS_LIBRARY=${{github.workspace}}/dependencies/lib/libdmumps.a \
@@ -222,7 +224,7 @@ jobs:
           -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}/dependencies/lib/libmpiseq.a \
           -DBLAS_LIBRARIES="${{github.workspace}}/dependencies/lib/libcblas.a;${{github.workspace}}/dependencies/lib/libblas.a" \
           -DLAPACK_LIBRARIES=${{github.workspace}}/dependencies/lib/liblapack.a \
-          -DHIGHS=${{github.workspace}}/dependencies/lib/libhighs.a \
+          -DHIGHS="${{github.workspace}}/dependencies/lib/libhighs.a;${{github.workspace}}/dependencies/lib/libhighs_extras.a" \
           -DBUILD_STATIC_LIBS=ON \
           -DBUILD_SHARED_LIBS=ON
 
@@ -243,6 +245,7 @@ jobs:
           -DOpenMP_omp_LIBRARY=${{ env.OPENMP_LIB }} \
           -DMUMPS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
           -DMETIS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
+          -DHIGHS_INCLUDE_DIR=${{github.workspace}}/dependencies/include/highs \
           -DBQPD=${{github.workspace}}/dependencies/lib/libbqpd.a \
           -DMETIS_LIBRARY=${{github.workspace}}/dependencies/lib/libmetis.a \
           -DMUMPS_LIBRARY=${{github.workspace}}/dependencies/lib/libdmumps.a \
@@ -251,7 +254,7 @@ jobs:
           -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}/dependencies/lib/libmpiseq.a \
           -DBLAS_LIBRARIES="${{github.workspace}}/dependencies/lib/libcblas.a;${{github.workspace}}/dependencies/lib/libblas.a" \
           -DLAPACK_LIBRARIES=${{github.workspace}}/dependencies/lib/liblapack.a \
-          -DHIGHS=${{github.workspace}}/dependencies/lib/libhighs.a \
+          -DHIGHS="${{github.workspace}}/dependencies/lib/libhighs.a;${{github.workspace}}/dependencies/lib/libhighs_extras.a" \
           -DBUILD_STATIC_LIBS=ON \
           -DBUILD_SHARED_LIBS=ON
 
@@ -265,6 +268,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ^
           -DMUMPS_INCLUDE_DIR=${{github.workspace}}\dependencies\include ^
           -DMETIS_INCLUDE_DIR=${{github.workspace}}\dependencies\include ^
+          -DHIGHS_INCLUDE_DIR=${{github.workspace}}\dependencies\include\highs ^
           -DBQPD=${{github.workspace}}\dependencies\lib\libbqpd.a ^
           -DMETIS_LIBRARY=${{github.workspace}}\dependencies\bin\libmetis.dll ^
           -DMUMPS_LIBRARY=${{github.workspace}}\dependencies\lib\libdmumps.a ^
@@ -273,7 +277,7 @@ jobs:
           -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}\dependencies\lib\libmpiseq.a ^
           -DBLAS_LIBRARIES="${{github.workspace}}\dependencies\lib\libcblas.a;${{github.workspace}}\dependencies\lib\libblas.a" ^
           -DLAPACK_LIBRARIES=${{github.workspace}}\dependencies\lib\liblapack.a ^
-          -DHIGHS=${{github.workspace}}\dependencies\lib\libhighs.a ^
+          -DHIGHS="${{github.workspace}}\dependencies\lib\libhighs.a;${{github.workspace}}\dependencies\lib\libhighs_extras.a" ^
           -DAUXILIARY_LIBRARIES=${{github.workspace}}\dependencies\lib\libstdc++.a ^
           -DBUILD_STATIC_LIBS=ON ^
           -DBUILD_SHARED_LIBS=ON .
@@ -290,6 +294,7 @@ jobs:
           -DCMAKE_Fortran_COMPILER=ifx ^
           -DMUMPS_INCLUDE_DIR=${{github.workspace}}\dependencies\include ^
           -DMETIS_INCLUDE_DIR=${{github.workspace}}\dependencies\include ^
+          -DHIGHS_INCLUDE_DIR=${{github.workspace}}\dependencies\include\highs ^
           -DBQPD=${{github.workspace}}\dependencies\lib\libbqpd.a ^
           -DMETIS_LIBRARY=${{github.workspace}}\dependencies\lib\libmetis.a ^
           -DMUMPS_LIBRARY=${{github.workspace}}\dependencies\lib\libdmumps.a ^
@@ -298,6 +303,7 @@ jobs:
           -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}\dependencies\lib\libmpiseq.a ^
           -DBLAS_LIBRARIES="${{github.workspace}}\dependencies\lib\libcblas.lib;${{github.workspace}}\dependencies\lib\libblas.lib" ^
           -DLAPACK_LIBRARIES=${{github.workspace}}\dependencies\lib\liblapack.lib ^
+          -DHIGHS="${{github.workspace}}\dependencies\lib\libhighs.a;${{github.workspace}}\dependencies\lib\libhighs_extras.a" ^
           -DBUILD_STATIC_LIBS=ON ^
           -DBUILD_SHARED_LIBS=OFF .
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,18 @@ jobs:
     # DEPENDENCIES
     # =========================================================
 
-    - name: Download dependencies
+    - name: Download dependencies (not MinGW)
+      if: matrix.toolchain != 'mingw'
       run: bash dependencies/scripts/download_dependencies.sh
+      
+    - name: Download dependencies (MinGW)
+      if: matrix.toolchain == 'mingw'
+      run: bash dependencies/scripts/download_dependencies.sh
+      env:
+        CC:  C:/mingw64/bin/gcc.exe
+        CXX: C:/mingw64/bin/g++.exe
+        CMAKE_C_COMPILER:   C:/mingw64/bin/gcc.exe
+        CMAKE_CXX_COMPILER: C:/mingw64/bin/g++.exe
 
     # =========================================================
     # MSVC: Download BLAS/LAPACK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,7 +294,6 @@ jobs:
           -DCMAKE_Fortran_COMPILER=ifx ^
           -DMUMPS_INCLUDE_DIR=${{github.workspace}}\dependencies\include ^
           -DMETIS_INCLUDE_DIR=${{github.workspace}}\dependencies\include ^
-          -DHIGHS_INCLUDE_DIR=${{github.workspace}}\dependencies\include\highs ^
           -DBQPD=${{github.workspace}}\dependencies\lib\libbqpd.a ^
           -DMETIS_LIBRARY=${{github.workspace}}\dependencies\lib\libmetis.a ^
           -DMUMPS_LIBRARY=${{github.workspace}}\dependencies\lib\libdmumps.a ^
@@ -303,7 +302,6 @@ jobs:
           -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}\dependencies\lib\libmpiseq.a ^
           -DBLAS_LIBRARIES="${{github.workspace}}\dependencies\lib\libcblas.lib;${{github.workspace}}\dependencies\lib\libblas.lib" ^
           -DLAPACK_LIBRARIES=${{github.workspace}}\dependencies\lib\liblapack.lib ^
-          -DHIGHS="${{github.workspace}}\dependencies\lib\libhighs.a;${{github.workspace}}\dependencies\lib\libhighs_extras.a" ^
           -DBUILD_STATIC_LIBS=ON ^
           -DBUILD_SHARED_LIBS=OFF .
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,6 @@ jobs:
           -DBLAS_LIBRARIES="${{github.workspace}}\dependencies\lib\libcblas.a;${{github.workspace}}\dependencies\lib\libblas.a" ^
           -DLAPACK_LIBRARIES=${{github.workspace}}\dependencies\lib\liblapack.a ^
           -DHIGHS="${{github.workspace}}\dependencies\lib\libhighs.a;${{github.workspace}}\dependencies\lib\libhighs_extras.a" ^
-          -DAUXILIARY_LIBRARIES=${{github.workspace}}\dependencies\lib\libstdc++.a ^
           -DBUILD_STATIC_LIBS=ON ^
           -DBUILD_SHARED_LIBS=ON .
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
 
     env:
       BUILD_TYPE: ${{ matrix.build_type }}
+      UNO_TOOLCHAIN: ${{ matrix.toolchain }}
 
     defaults:
       run:

--- a/.github/workflows/cutest-hs15-test.yml
+++ b/.github/workflows/cutest-hs15-test.yml
@@ -59,6 +59,7 @@ jobs:
             -DCMAKE_FORTRAN_COMPILER=gfortran \
             -DMUMPS_INCLUDE_DIR=${{ github.workspace }}/dependencies/include \
             -DMETIS_INCLUDE_DIR=${{ github.workspace }}/dependencies/include \
+            -DHIGHS_INCLUDE_DIR=${{ github.workspace }}/dependencies/include/highs \
             -DBQPD=${{ github.workspace }}/dependencies/lib/libbqpd.a \
             -DMETIS_LIBRARY=${{ github.workspace }}/dependencies/lib/libmetis.a \
             -DMUMPS_LIBRARY=${{ github.workspace }}/dependencies/lib/libdmumps.a \
@@ -67,7 +68,7 @@ jobs:
             -DMUMPS_MPISEQ_LIBRARY=${{ github.workspace }}/dependencies/lib/libmpiseq.a \
             -DBLAS_LIBRARIES="${{ github.workspace }}/dependencies/lib/libcblas.a;${{ github.workspace }}/dependencies/lib/libblas.a" \
             -DLAPACK_LIBRARIES=${{ github.workspace }}/dependencies/lib/liblapack.a \
-            -DHIGHS=${{ github.workspace }}/dependencies/lib/libhighs.a \
+            -DHIGHS="${{github.workspace}}/dependencies/lib/libhighs.a;${{github.workspace}}/dependencies/lib/libhighs_extras.a" \
             -DBUILD_STATIC_LIBS=OFF \
             -DBUILD_SHARED_LIBS=ON
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -124,6 +124,7 @@ jobs:
             -DCMAKE_SHARED_LINKER_FLAGS="${SANITIZER_FLAGS}" \
             -DMUMPS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
             -DMETIS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
+            -DHIGHS_INCLUDE_DIR=${{github.workspace}}/dependencies/include/highs \
             -DBQPD=${{github.workspace}}/dependencies/lib/libbqpd.a \
             -DMETIS_LIBRARY=${{github.workspace}}/dependencies/lib/libmetis.a \
             -DMUMPS_LIBRARY=${{github.workspace}}/dependencies/lib/libdmumps.a \
@@ -132,7 +133,7 @@ jobs:
             -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}/dependencies/lib/libmpiseq.a \
             -DBLAS_LIBRARIES="${{github.workspace}}/dependencies/lib/libcblas.a;${{github.workspace}}/dependencies/lib/libblas.a" \
             -DLAPACK_LIBRARIES=${{github.workspace}}/dependencies/lib/liblapack.a \
-            -DHIGHS=${{github.workspace}}/dependencies/lib/libhighs.a \
+            -DHIGHS="${{github.workspace}}/dependencies/lib/libhighs.a;${{github.workspace}}/dependencies/lib/libhighs_extras.a" \
             -DBUILD_STATIC_LIBS=OFF \
             -DBUILD_SHARED_LIBS=ON
 
@@ -154,6 +155,7 @@ jobs:
             -DOpenMP_omp_LIBRARY=${{ env.OPENMP_LIB }} \
             -DMUMPS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
             -DMETIS_INCLUDE_DIR=${{github.workspace}}/dependencies/include \
+            -DHIGHS_INCLUDE_DIR=${{github.workspace}}/dependencies/include/highs \
             -DBQPD=${{github.workspace}}/dependencies/lib/libbqpd.a \
             -DMETIS_LIBRARY=${{github.workspace}}/dependencies/lib/libmetis.a \
             -DMUMPS_LIBRARY=${{github.workspace}}/dependencies/lib/libdmumps.a \
@@ -162,7 +164,7 @@ jobs:
             -DMUMPS_MPISEQ_LIBRARY=${{github.workspace}}/dependencies/lib/libmpiseq.a \
             -DBLAS_LIBRARIES="${{github.workspace}}/dependencies/lib/libcblas.a;${{github.workspace}}/dependencies/lib/libblas.a" \
             -DLAPACK_LIBRARIES=${{github.workspace}}/dependencies/lib/liblapack.a \
-            -DHIGHS=${{github.workspace}}/dependencies/lib/libhighs.a \
+            -DHIGHS="${{github.workspace}}/dependencies/lib/libhighs.a;${{github.workspace}}/dependencies/lib/libhighs_extras.a" \
             -DBUILD_STATIC_LIBS=ON \
             -DBUILD_SHARED_LIBS=OFF
 
@@ -179,6 +181,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER=gfortran \
             -DMUMPS_INCLUDE_DIR=${GITHUB_WORKSPACE}/dependencies/include \
             -DMETIS_INCLUDE_DIR=/mingw64/include \
+            -DHIGHS_INCLUDE_DIR=${GITHUB_WORKSPACE}/dependencies/include/highs \
             -DBQPD=${GITHUB_WORKSPACE}/dependencies/lib/libbqpd.a \
             -DMETIS_LIBRARY=/mingw64/lib/libmetis.a \
             -DMUMPS_LIBRARY=${GITHUB_WORKSPACE}/dependencies/lib/libdmumps.a \
@@ -187,7 +190,7 @@ jobs:
             -DMUMPS_MPISEQ_LIBRARY=${GITHUB_WORKSPACE}/dependencies/lib/libmpiseq.a \
             -DBLAS_LIBRARIES="${GITHUB_WORKSPACE}/dependencies/lib/libcblas.a;${GITHUB_WORKSPACE}/dependencies/lib/libblas.a" \
             -DLAPACK_LIBRARIES=${GITHUB_WORKSPACE}/dependencies/lib/liblapack.a \
-            -DHIGHS=${GITHUB_WORKSPACE}/dependencies/lib/libhighs.a \
+            -DHIGHS="${GITHUB_WORKSPACE}/dependencies/lib/libhighs.a;${GITHUB_WORKSPACE}/dependencies/lib/libhighs_extras.a" \
             -DBUILD_STATIC_LIBS=ON \
             -DBUILD_SHARED_LIBS=OFF
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,8 +379,7 @@ if(SKBUILD)
    target_link_libraries(unopy PUBLIC uno_dependencies)
    
    if(MINGW)
-	   target_link_options(unopy PRIVATE
-         -static-libstdc++ -static-libgcc -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic)
+	   target_link_options(unopy PRIVATE -static-libstdc++)
 	endif()
 
    if(UNO_PYBIND11_DETAILED_ERRORS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,13 @@ function(resolve_library_paths input_list output_list)
    set(${output_list} "${result}" PARENT_SCOPE)
 endfunction()
 
+# additional libraries to link against
+set(AUXILIARY_LIBRARIES "" CACHE STRING "Additional libraries to link against")
+if(AUXILIARY_LIBRARIES)
+   resolve_library_paths(AUXILIARY_LIBRARIES ABSOLUTE_AUXILIARY_LIBRARIES)
+   target_link_libraries(uno_dependencies INTERFACE ${ABSOLUTE_AUXILIARY_LIBRARIES})
+endif()
+
 # LAPACK
 if(LAPACK_LIBRARIES)
    resolve_library_paths(LAPACK_LIBRARIES ABSOLUTE_LAPACK_LIBRARIES)
@@ -286,13 +293,6 @@ if(BLAS_LIBRARIES)
 else()
    find_package(BLAS REQUIRED)
    target_link_libraries(uno_dependencies INTERFACE BLAS::BLAS)
-endif()
-
-# additional libraries to link against
-set(AUXILIARY_LIBRARIES "" CACHE STRING "Additional libraries to link against")
-if(AUXILIARY_LIBRARIES)
-   resolve_library_paths(AUXILIARY_LIBRARIES ABSOLUTE_AUXILIARY_LIBRARIES)
-   target_link_libraries(uno_dependencies INTERFACE ${ABSOLUTE_AUXILIARY_LIBRARIES})
 endif()
 
 # ======================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,13 +270,6 @@ function(resolve_library_paths input_list output_list)
    set(${output_list} "${result}" PARENT_SCOPE)
 endfunction()
 
-# additional libraries to link against
-set(AUXILIARY_LIBRARIES "" CACHE STRING "Additional libraries to link against")
-if(AUXILIARY_LIBRARIES)
-   resolve_library_paths(AUXILIARY_LIBRARIES ABSOLUTE_AUXILIARY_LIBRARIES)
-   target_link_libraries(uno_dependencies INTERFACE ${ABSOLUTE_AUXILIARY_LIBRARIES})
-endif()
-
 # LAPACK
 if(LAPACK_LIBRARIES)
    resolve_library_paths(LAPACK_LIBRARIES ABSOLUTE_LAPACK_LIBRARIES)
@@ -293,6 +286,13 @@ if(BLAS_LIBRARIES)
 else()
    find_package(BLAS REQUIRED)
    target_link_libraries(uno_dependencies INTERFACE BLAS::BLAS)
+endif()
+
+# additional libraries to link against
+set(AUXILIARY_LIBRARIES "" CACHE STRING "Additional libraries to link against")
+if(AUXILIARY_LIBRARIES)
+   resolve_library_paths(AUXILIARY_LIBRARIES ABSOLUTE_AUXILIARY_LIBRARIES)
+   target_link_libraries(uno_dependencies INTERFACE ${ABSOLUTE_AUXILIARY_LIBRARIES})
 endif()
 
 # ======================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,8 +182,7 @@ if(HIGHS)
    target_link_libraries(uno_dependencies INTERFACE ${HIGHS})
    target_compile_definitions(uno_dependencies INTERFACE HAS_HIGHS)
 
-   get_filename_component(HIGHS_DIRECTORY ${HIGHS} DIRECTORY)
-   target_include_directories(uno_dependencies SYSTEM INTERFACE ${HIGHS_DIRECTORY}/../include/highs)
+   target_include_directories(uno_dependencies SYSTEM INTERFACE ${HIGHS_INCLUDE_DIR})
 
    target_sources(compiled_uno_files PRIVATE
            uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,11 @@ if(SKBUILD)
    pybind11_add_module(unopy SHARED $<TARGET_OBJECTS:compiled_uno_files> ${PYTHON_MODULE_FILES})
 
    target_link_libraries(unopy PUBLIC uno_dependencies)
+   
+   if(MINGW)
+	   target_link_options(unopy PRIVATE
+         -static-libstdc++ -static-libgcc -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic)
+	endif()
 
    if(UNO_PYBIND11_DETAILED_ERRORS)
       target_compile_definitions(unopy PRIVATE PYBIND11_DETAILED_ERROR_MESSAGES)

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -39,7 +39,7 @@ tar -xzf BQPD.tar.gz
 pwd
 
 # download UnoUtils: MUMPS (+ METIS, BLAS and LAPACK) and HiGHS
-VERSION="2026.7.1"
+VERSION="2026.7.2"
 REPO="https://github.com/amontoison/UnoUtils_jll.jl/releases/download/UnoUtils-v${VERSION}%2B0"
 ASSET_NAME="UnoUtils.v${VERSION}.${ARCH}-${OS}-libgfortran5-cxx11.tar.gz"
 ASSET_URL="${REPO}/${ASSET_NAME}"

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -53,10 +53,9 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	# delete UnoUtils' HiGHS
 	rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
 	
-	# This runs in cibuildwheel's MSYS2 (MSYS) login shell. /mingw64/bin -- the
-	# toolchain we actually build with -- is not on PATH here, and the Windows
-	# CPython isn't either, so pip is out. Use pacman, and expose mingw64.
-	export PATH="/mingw64/bin:$PATH"
+	# This runs in cibuildwheel's MSYS2 (MSYS) login shell
+	# The Windows is not on PATH here, CPython isn't either, so pip is out
+	# Use pacman, and expose mingw64.
 	if ! command -v cmake >/dev/null 2>&1 || ! command -v ninja >/dev/null 2>&1; then
 		pacman -Sy --needed --noconfirm mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
 	fi

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -39,7 +39,7 @@ tar -xzf BQPD.tar.gz
 pwd
 
 # download UnoUtils: MUMPS (+ METIS, BLAS and LAPACK) and HiGHS
-VERSION="2026.4.29"
+VERSION="2026.6.30"
 REPO="https://github.com/amontoison/UnoUtils_jll.jl/releases/download/UnoUtils-v${VERSION}%2B0"
 ASSET_NAME="UnoUtils.v${VERSION}.${ARCH}-${OS}-libgfortran5-cxx11.tar.gz"
 ASSET_URL="${REPO}/${ASSET_NAME}"

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -115,7 +115,7 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	cp -a "${BUILD_ROOT}/install/include/." include
 	rm -rf "${BUILD_ROOT}"
 
-	if [[ -n "${CIBW_BUILD:-}" ]]; then            # wheel build only; tests link libstdc++ dynamically
+	if [[ -n "${UNO_BUNDLE_RUNTIME:-}" ]]; then            # wheel build only; tests link libstdc++ dynamically
 		LIBSTDCXX="$("$CXX_BIN" -print-file-name=libstdc++.a || true)"
 		[[ "$LIBSTDCXX" != "libstdc++.a" ]] && command -v cygpath >/dev/null 2>&1 && LIBSTDCXX="$(cygpath -u "$LIBSTDCXX")"
 		if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -52,19 +52,17 @@ pwd
 if [[ "$OS" == "w64-mingw32" ]]; then
 	# delete UnoUtils' HiGHS
 	rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
-
-	# cibuildwheel's shell has a minimal PATH; pull cmake + ninja from PyPI
-	PY="$(command -v python3 || command -v python)"
-	[[ -z "$PY" ]] && { echo "python not on PATH"; exit 1; }
-	"$PY" -m pip install --quiet "cmake<4" ninja
-	CMAKE_BIN="$("$PY" -c 'import cmake;  print(cmake.CMAKE_BIN_DIR)')"
-	NINJA_BIN="$("$PY" -c 'import ninja;  print(ninja.BIN_DIR)')"
-	if command -v cygpath >/dev/null 2>&1; then        # normalise C:\… -> /c/… for bash
-		CMAKE_BIN="$(cygpath -u "$CMAKE_BIN")"
-		NINJA_BIN="$(cygpath -u "$NINJA_BIN")"
+	
+	# This runs in cibuildwheel's MSYS2 (MSYS) login shell. /mingw64/bin -- the
+	# toolchain we actually build with -- is not on PATH here, and the Windows
+	# CPython isn't either, so pip is out. Use pacman, and expose mingw64.
+	export PATH="/mingw64/bin:$PATH"
+	if ! command -v cmake >/dev/null 2>&1 || ! command -v ninja >/dev/null 2>&1; then
+		pacman -Sy --needed --noconfirm mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
 	fi
-	export PATH="${CMAKE_BIN}:${NINJA_BIN}:$PATH"
-	GEN_FLAGS=(-G Ninja)
+	GEN_FLAGS=(-G Ninja
+		-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
+		-DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++)
 
 	# fetch HiGHS source
 	BUILD_ROOT="$(mktemp -d)"

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -48,8 +48,8 @@ curl -L -o UnoUtils.tar.gz "$ASSET_URL"
 tar -xzf UnoUtils.tar.gz
 pwd
 
-# on Windows, compile HiGHS on the fly and replace that of UnoUtils
-if [[ "$OS" == "w64-mingw32" ]]; then
+# on MinGW, compile HiGHS on the fly and replace that of UnoUtils
+if [[ "$OS" == "w64-mingw32" && "${UNO_TOOLCHAIN:-mingw}" == "mingw" ]]; then
 	# delete UnoUtils' HiGHS
 	rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
 	

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -53,15 +53,17 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	# delete UnoUtils' HiGHS
 	rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
 
-	# clone HiGHS
+	# fetch HiGHS source
 	BUILD_ROOT="$(mktemp -d)"
 	VERSION="v1.15.0"
-	REPO="https://github.com/ERGO-Code/HiGHS.git"
-	GEN_FLAGS=(-G "MinGW Makefiles")
+	ASSET_URL="https://github.com/ERGO-Code/HiGHS/archive/refs/tags/${VERSION}.tar.gz"
+	echo "Downloading: ${ASSET_URL}"
+	curl -fL -o "${BUILD_ROOT}/HiGHS-src.tar.gz" "$ASSET_URL"
+	tar -xzf "${BUILD_ROOT}/HiGHS-src.tar.gz" -C "$SRC_DIR" --strip-components=1
 
-	git clone --depth 1 --branch "${VERSION}" "${REPO}" "${BUILD_ROOT}/HiGHS"
+	# build
 	cmake -S "${BUILD_ROOT}/HiGHS" -B "${BUILD_ROOT}/build" \
-		"${GEN_FLAGS[@]}" \
+		-G "MinGW Makefiles" \
 		-DCMAKE_INSTALL_PREFIX="${BUILD_ROOT}/install" \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=OFF \
@@ -70,7 +72,7 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 		-DBUILD_EXAMPLES=OFF \
 		-DBUILD_TESTING=OFF \
 		-DBUILD_CXX_EXE=OFF \
-		-DBLAS_LIBRARIES=lib/libblas.a \
+		-DBLAS_LIBRARIES="${PWD}/lib/libblas.a" \
 		-DBUILD_SHARED_EXTRAS_LIB=OFF \
 		-DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
@@ -81,14 +83,13 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	cp -a "${BUILD_ROOT}/install/include/." include
 	rm -rf "${BUILD_ROOT}"
 
-
-    CXX="${CXX:-g++}"
-    LIBSTDCXX="$("$CXX" -print-file-name=libstdc++.a)"
-    if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
-        echo "Could not locate libstdc++.a via $CXX"; exit 1
-    fi
-    echo "Using $LIBSTDCXX ($($CXX -dumpversion))"
-    cp "$LIBSTDCXX" "lib/libstdc++.a"
+	CXX="${CXX:-g++}"
+	LIBSTDCXX="$("$CXX" -print-file-name=libstdc++.a)"
+	if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
+	  echo "Could not locate libstdc++.a via $CXX"; exit 1
+	fi
+	echo "Using $LIBSTDCXX ($($CXX -dumpversion))"
+	cp "$LIBSTDCXX" "lib/libstdc++.a"
 fi
 
 # delete unwanted directories

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -53,12 +53,11 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	# delete UnoUtils' HiGHS
 	rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
 	
-	# This runs in cibuildwheel's MSYS2 (MSYS) login shell. /mingw64/bin -- the
-	# toolchain we actually build with -- is not on PATH here, and the Windows
-	# CPython isn't either, so pip is out. Use pacman, and expose mingw64.
+	# The toolchain is C:/mingw64 via the pinned CMAKE_*_COMPILER/CC/CXX;
+	# /mingw64/bin supplies only cmake/make
 	export PATH="$PATH:/mingw64/bin"
-	if ! command -v cmake >/dev/null 2>&1 || ! command -v ninja >/dev/null 2>&1; then
-		pacman -Sy --needed --noconfirm mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+	if ! command -v cmake >/dev/null 2>&1; then
+		pacman -Sy --needed --noconfirm mingw-w64-x86_64-cmake
 	fi
 
 	# fetch HiGHS source
@@ -114,16 +113,6 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	cp -a "${BUILD_ROOT}/install/lib/."     lib
 	cp -a "${BUILD_ROOT}/install/include/." include
 	rm -rf "${BUILD_ROOT}"
-
-	if [[ -n "${UNO_BUNDLE_RUNTIME:-}" ]]; then            # wheel build only; tests link libstdc++ dynamically
-		LIBSTDCXX="$("$CXX_BIN" -print-file-name=libstdc++.a || true)"
-		[[ "$LIBSTDCXX" != "libstdc++.a" ]] && command -v cygpath >/dev/null 2>&1 && LIBSTDCXX="$(cygpath -u "$LIBSTDCXX")"
-		if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
-			echo "Could not locate libstdc++.a via $CXX_BIN"; exit 1
-		fi
-		echo "Bundling $LIBSTDCXX"
-		cp "$LIBSTDCXX" "lib/libstdc++.a"
-	fi
 fi
 
 # delete unwanted directories

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -60,9 +60,6 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	if ! command -v cmake >/dev/null 2>&1 || ! command -v ninja >/dev/null 2>&1; then
 		pacman -Sy --needed --noconfirm mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
 	fi
-	GEN_FLAGS=(-G Ninja
-		-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
-		-DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++)
 
 	# fetch HiGHS source
 	BUILD_ROOT="$(mktemp -d)"
@@ -73,10 +70,21 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	curl -fL -o "${BUILD_ROOT}/HiGHS-src.tar.gz" "$ASSET_URL"
 	tar -xzf "${BUILD_ROOT}/HiGHS-src.tar.gz" -C "${BUILD_ROOT}/HiGHS" --strip-components=1
 
+	GEN_FLAGS=(-G "Unix Makefiles"
+		-DCMAKE_MAKE_PROGRAM=C:/mingw64/bin/mingw32-make.exe
+		-DCMAKE_C_COMPILER=C:/mingw64/bin/gcc.exe
+		-DCMAKE_CXX_COMPILER=C:/mingw64/bin/g++.exe)
+		
+	# native cmake needs Windows paths, not MSYS ones
+	SRC_W="$(cygpath -m "${BUILD_ROOT}/HiGHS")"
+	BLD_W="$(cygpath -m "${BUILD_ROOT}/build")"
+	PREFIX_W="$(cygpath -m "${BUILD_ROOT}/install")"
+	BLAS_W="$(cygpath -m "${PWD}/lib/libblas.a")"
+
 	# build
-	cmake -S "${BUILD_ROOT}/HiGHS" -B "${BUILD_ROOT}/build" \
+	cmake -S "$SRC_W" -B "$BLD_W" \
 		"${GEN_FLAGS[@]}" \
-		-DCMAKE_INSTALL_PREFIX="${BUILD_ROOT}/install" \
+		-DCMAKE_INSTALL_PREFIX="$PREFIX_W" \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=OFF \
 		-DZLIB=OFF \
@@ -84,12 +92,12 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 		-DBUILD_EXAMPLES=OFF \
 		-DBUILD_TESTING=OFF \
 		-DBUILD_CXX_EXE=OFF \
-		-DBLAS_LIBRARIES="${PWD}/lib/libblas.a" \
+		-DBLAS_LIBRARIES="$BLAS_W" \
 		-DBUILD_SHARED_EXTRAS_LIB=OFF \
 		-DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
-	cmake --build "${BUILD_ROOT}/build" --config Release --parallel
-	cmake --install "${BUILD_ROOT}/build" --config Release
+	cmake --build "$BLD_W" --config Release --parallel
+	cmake --install "$BLD_W" --config Release
 
 	cp -a "${BUILD_ROOT}/install/lib/."     lib
 	cp -a "${BUILD_ROOT}/install/include/." include

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -59,7 +59,7 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	ASSET_URL="https://github.com/ERGO-Code/HiGHS/archive/refs/tags/${VERSION}.tar.gz"
 	echo "Downloading: ${ASSET_URL}"
 	curl -fL -o "${BUILD_ROOT}/HiGHS-src.tar.gz" "$ASSET_URL"
-	tar -xzf "${BUILD_ROOT}/HiGHS-src.tar.gz" -C "$SRC_DIR" --strip-components=1
+	tar -xzf "${BUILD_ROOT}/HiGHS-src.tar.gz" -C "${BUILD_ROOT}/HiGHS" --strip-components=1
 
 	# build
 	cmake -S "${BUILD_ROOT}/HiGHS" -B "${BUILD_ROOT}/build" \

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -38,7 +38,7 @@ curl -L -o BQPD.tar.gz "$ASSET_URL"
 tar -xzf BQPD.tar.gz
 pwd
 
-# download UnoUtils: MUMPS (+ METIS, BLAS and LAPACK) and HiGHS
+# download UnoUtils: MUMPS (+ METIS, BLAS and LAPACK)
 VERSION="2026.7.2"
 REPO="https://github.com/amontoison/UnoUtils_jll.jl/releases/download/UnoUtils-v${VERSION}%2B0"
 ASSET_NAME="UnoUtils.v${VERSION}.${ARCH}-${OS}-libgfortran5-cxx11.tar.gz"
@@ -52,10 +52,48 @@ pwd
 # rm -rf lib/cmake/cblas* lib/cmake/lapack* lib/pkgconfig
 rm -rf lib/cmake lib/pkgconfig
 
+# delete UnoUtils' HiGHS
+rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
+
+# clone HiGHS
+BUILD_ROOT="$(mktemp -d)"
+VERSION="v1.15.0"
+REPO="https://github.com/ERGO-Code/HiGHS.git"
+GEN_FLAGS=()
+if [[ -n "${HIGHS_CMAKE_GENERATOR:-}" ]]; then
+    GEN_FLAGS=(-G "${HIGHS_CMAKE_GENERATOR}")
+elif [[ "$OS" == "w64-mingw32" ]]; then
+    GEN_FLAGS=(-G "MinGW Makefiles")
+fi
+
+git clone --depth 1 --branch "${VERSION}" "${REPO}" "${BUILD_ROOT}/HiGHS"
+cmake -S "${BUILD_ROOT}/HiGHS" -B "${BUILD_ROOT}/build" \
+	"${GEN_FLAGS[@]}" \
+	-DCMAKE_INSTALL_PREFIX="${BUILD_ROOT}/install" \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DBUILD_SHARED_LIBS=OFF \
+	-DZLIB=OFF \
+	-DHIPO=ON \
+	-DBUILD_EXAMPLES=OFF \
+	-DBUILD_TESTING=OFF \
+	-DBUILD_CXX_EXE=OFF \
+	-DBLAS_LIBRARIES=lib/libblas.a \
+	-DBUILD_SHARED_EXTRAS_LIB=OFF \
+	-DCMAKE_POSITION_INDEPENDENT_CODE=ON
+
+cmake --build "${BUILD_ROOT}/build" --config Release --parallel
+cmake --install "${BUILD_ROOT}/build" --config Release
+
+cp -a "${BUILD_ROOT}/install/lib/."     lib
+cp -a "${BUILD_ROOT}/install/include/." include
+rm -rf "${BUILD_ROOT}"
+
 if [[ "$OS" == "w64-mingw32" ]]; then
-    cd ..
-    ASSET_URL="https://github.com/JuliaLang/PackageCompiler.jl/releases/download/v1.0.0/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.tar.gz"
-    curl -L -o libstdc++.tar.gz "$ASSET_URL"
-    tar -xzf libstdc++.tar.gz
-    cp ./mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/libstdc++.a ./dependencies/lib/libstdc++.a
+    CXX="${CXX:-g++}"
+    LIBSTDCXX="$("$CXX" -print-file-name=libstdc++.a)"
+    if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
+        echo "Could not locate libstdc++.a via $CXX"; exit 1
+    fi
+    echo "Using $LIBSTDCXX ($($CXX -dumpversion))"
+    cp "$LIBSTDCXX" "lib/libstdc++.a"
 fi

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -55,6 +55,7 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 
 	# fetch HiGHS source
 	BUILD_ROOT="$(mktemp -d)"
+	mkdir "${BUILD_ROOT}/HiGHS"
 	VERSION="v1.15.0"
 	ASSET_URL="https://github.com/ERGO-Code/HiGHS/archive/refs/tags/${VERSION}.tar.gz"
 	echo "Downloading: ${ASSET_URL}"

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -53,6 +53,19 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	# delete UnoUtils' HiGHS
 	rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
 
+	# cibuildwheel's shell has a minimal PATH; pull cmake + ninja from PyPI
+	PY="$(command -v python3 || command -v python)"
+	[[ -z "$PY" ]] && { echo "python not on PATH"; exit 1; }
+	"$PY" -m pip install --quiet "cmake<4" ninja
+	CMAKE_BIN="$("$PY" -c 'import cmake;  print(cmake.CMAKE_BIN_DIR)')"
+	NINJA_BIN="$("$PY" -c 'import ninja;  print(ninja.BIN_DIR)')"
+	if command -v cygpath >/dev/null 2>&1; then        # normalise C:\… -> /c/… for bash
+		CMAKE_BIN="$(cygpath -u "$CMAKE_BIN")"
+		NINJA_BIN="$(cygpath -u "$NINJA_BIN")"
+	fi
+	export PATH="${CMAKE_BIN}:${NINJA_BIN}:$PATH"
+	GEN_FLAGS=(-G Ninja)
+
 	# fetch HiGHS source
 	BUILD_ROOT="$(mktemp -d)"
 	mkdir "${BUILD_ROOT}/HiGHS"
@@ -64,7 +77,7 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 
 	# build
 	cmake -S "${BUILD_ROOT}/HiGHS" -B "${BUILD_ROOT}/build" \
-		-G "MinGW Makefiles" \
+		"${GEN_FLAGS[@]}" \
 		-DCMAKE_INSTALL_PREFIX="${BUILD_ROOT}/install" \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=OFF \

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -53,9 +53,10 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	# delete UnoUtils' HiGHS
 	rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
 	
-	# This runs in cibuildwheel's MSYS2 (MSYS) login shell
-	# The Windows is not on PATH here, CPython isn't either, so pip is out
-	# Use pacman, and expose mingw64.
+	# This runs in cibuildwheel's MSYS2 (MSYS) login shell. /mingw64/bin -- the
+	# toolchain we actually build with -- is not on PATH here, and the Windows
+	# CPython isn't either, so pip is out. Use pacman, and expose mingw64.
+	export PATH="$PATH:/mingw64/bin"
 	if ! command -v cmake >/dev/null 2>&1 || ! command -v ninja >/dev/null 2>&1; then
 		pacman -Sy --needed --noconfirm mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
 	fi

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -70,10 +70,22 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	curl -fL -o "${BUILD_ROOT}/HiGHS-src.tar.gz" "$ASSET_URL"
 	tar -xzf "${BUILD_ROOT}/HiGHS-src.tar.gz" -C "${BUILD_ROOT}/HiGHS" --strip-components=1
 
+	# Build HiGHS with the SAME compiler the consuming workflow links with.
+	# A mismatch here is what produces the __emutls_v._ZSt*__once_call* and
+	# libstdc++ undefined references (e.g. GCC 8.1.0 emutls vs GCC 16 native TLS).
+	towin() { if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s' "$1"; fi; }
+	CC_BIN="${CMAKE_C_COMPILER:-${CC:-$(command -v gcc || true)}}"
+	CXX_BIN="${CMAKE_CXX_COMPILER:-${CXX:-$(command -v g++ || true)}}"
+	MAKE_BIN="${CMAKE_MAKE_PROGRAM:-$(command -v mingw32-make || command -v make || true)}"
+	if [[ -z "$CC_BIN" || -z "$CXX_BIN" || -z "$MAKE_BIN" ]]; then
+		echo "No MinGW toolchain found; set CMAKE_{C,CXX}_COMPILER/CMAKE_MAKE_PROGRAM or put gcc/g++/make on PATH"; exit 1
+	fi
+	echo "Building HiGHS with $CXX_BIN ($("$CXX_BIN" -dumpversion))"
+
 	GEN_FLAGS=(-G "Unix Makefiles"
-		-DCMAKE_MAKE_PROGRAM=C:/mingw64/bin/mingw32-make.exe
-		-DCMAKE_C_COMPILER=C:/mingw64/bin/gcc.exe
-		-DCMAKE_CXX_COMPILER=C:/mingw64/bin/g++.exe)
+		-DCMAKE_MAKE_PROGRAM="$(towin "$MAKE_BIN")"
+		-DCMAKE_C_COMPILER="$(towin "$CC_BIN")"
+		-DCMAKE_CXX_COMPILER="$(towin "$CXX_BIN")")
 		
 	# native cmake needs Windows paths, not MSYS ones
 	SRC_W="$(cygpath -m "${BUILD_ROOT}/HiGHS")"
@@ -103,16 +115,15 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	cp -a "${BUILD_ROOT}/install/include/." include
 	rm -rf "${BUILD_ROOT}"
 
-	CXX="${CXX:-C:/mingw64/bin/g++.exe}"
-	LIBSTDCXX="$("$CXX" -print-file-name=libstdc++.a || true)"
-	if [[ "$LIBSTDCXX" != "libstdc++.a" ]] && command -v cygpath >/dev/null 2>&1; then
-		LIBSTDCXX="$(cygpath -u "$LIBSTDCXX")"   # C:/… -> /c/… for bash cp/-f
+	if [[ -n "${CIBW_BUILD:-}" ]]; then            # wheel build only; tests link libstdc++ dynamically
+		LIBSTDCXX="$("$CXX_BIN" -print-file-name=libstdc++.a || true)"
+		[[ "$LIBSTDCXX" != "libstdc++.a" ]] && command -v cygpath >/dev/null 2>&1 && LIBSTDCXX="$(cygpath -u "$LIBSTDCXX")"
+		if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
+			echo "Could not locate libstdc++.a via $CXX_BIN"; exit 1
+		fi
+		echo "Bundling $LIBSTDCXX"
+		cp "$LIBSTDCXX" "lib/libstdc++.a"
 	fi
-	if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
-		echo "Could not locate libstdc++.a via $CXX"; exit 1
-	fi
-	echo "Using $LIBSTDCXX ($("$CXX" -dumpversion))"
-	cp "$LIBSTDCXX" "lib/libstdc++.a"
 fi
 
 # delete unwanted directories

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -39,7 +39,7 @@ tar -xzf BQPD.tar.gz
 pwd
 
 # download UnoUtils: MUMPS (+ METIS, BLAS and LAPACK) and HiGHS
-VERSION="2026.6.30"
+VERSION="2026.7.1"
 REPO="https://github.com/amontoison/UnoUtils_jll.jl/releases/download/UnoUtils-v${VERSION}%2B0"
 ASSET_NAME="UnoUtils.v${VERSION}.${ARCH}-${OS}-libgfortran5-cxx11.tar.gz"
 ASSET_URL="${REPO}/${ASSET_NAME}"

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -48,47 +48,40 @@ curl -L -o UnoUtils.tar.gz "$ASSET_URL"
 tar -xzf UnoUtils.tar.gz
 pwd
 
-# delete unwanted directories
-# rm -rf lib/cmake/cblas* lib/cmake/lapack* lib/pkgconfig
-rm -rf lib/cmake lib/pkgconfig
-
-# delete UnoUtils' HiGHS
-rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
-
-# clone HiGHS
-BUILD_ROOT="$(mktemp -d)"
-VERSION="v1.15.0"
-REPO="https://github.com/ERGO-Code/HiGHS.git"
-GEN_FLAGS=()
-if [[ -n "${HIGHS_CMAKE_GENERATOR:-}" ]]; then
-    GEN_FLAGS=(-G "${HIGHS_CMAKE_GENERATOR}")
-elif [[ "$OS" == "w64-mingw32" ]]; then
-    GEN_FLAGS=(-G "MinGW Makefiles")
-fi
-
-git clone --depth 1 --branch "${VERSION}" "${REPO}" "${BUILD_ROOT}/HiGHS"
-cmake -S "${BUILD_ROOT}/HiGHS" -B "${BUILD_ROOT}/build" \
-	"${GEN_FLAGS[@]}" \
-	-DCMAKE_INSTALL_PREFIX="${BUILD_ROOT}/install" \
-	-DCMAKE_BUILD_TYPE=Release \
-	-DBUILD_SHARED_LIBS=OFF \
-	-DZLIB=OFF \
-	-DHIPO=ON \
-	-DBUILD_EXAMPLES=OFF \
-	-DBUILD_TESTING=OFF \
-	-DBUILD_CXX_EXE=OFF \
-	-DBLAS_LIBRARIES=lib/libblas.a \
-	-DBUILD_SHARED_EXTRAS_LIB=OFF \
-	-DCMAKE_POSITION_INDEPENDENT_CODE=ON
-
-cmake --build "${BUILD_ROOT}/build" --config Release --parallel
-cmake --install "${BUILD_ROOT}/build" --config Release
-
-cp -a "${BUILD_ROOT}/install/lib/."     lib
-cp -a "${BUILD_ROOT}/install/include/." include
-rm -rf "${BUILD_ROOT}"
-
+# on Windows, compile HiGHS on the fly and replace that of UnoUtils
 if [[ "$OS" == "w64-mingw32" ]]; then
+	# delete UnoUtils' HiGHS
+	rm -rf lib/libhighs* include/highs include/Highs*.h bin/highs*
+
+	# clone HiGHS
+	BUILD_ROOT="$(mktemp -d)"
+	VERSION="v1.15.0"
+	REPO="https://github.com/ERGO-Code/HiGHS.git"
+	GEN_FLAGS=(-G "MinGW Makefiles")
+
+	git clone --depth 1 --branch "${VERSION}" "${REPO}" "${BUILD_ROOT}/HiGHS"
+	cmake -S "${BUILD_ROOT}/HiGHS" -B "${BUILD_ROOT}/build" \
+		"${GEN_FLAGS[@]}" \
+		-DCMAKE_INSTALL_PREFIX="${BUILD_ROOT}/install" \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIBS=OFF \
+		-DZLIB=OFF \
+		-DHIPO=ON \
+		-DBUILD_EXAMPLES=OFF \
+		-DBUILD_TESTING=OFF \
+		-DBUILD_CXX_EXE=OFF \
+		-DBLAS_LIBRARIES=lib/libblas.a \
+		-DBUILD_SHARED_EXTRAS_LIB=OFF \
+		-DCMAKE_POSITION_INDEPENDENT_CODE=ON
+
+	cmake --build "${BUILD_ROOT}/build" --config Release --parallel
+	cmake --install "${BUILD_ROOT}/build" --config Release
+
+	cp -a "${BUILD_ROOT}/install/lib/."     lib
+	cp -a "${BUILD_ROOT}/install/include/." include
+	rm -rf "${BUILD_ROOT}"
+
+
     CXX="${CXX:-g++}"
     LIBSTDCXX="$("$CXX" -print-file-name=libstdc++.a)"
     if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
@@ -97,3 +90,7 @@ if [[ "$OS" == "w64-mingw32" ]]; then
     echo "Using $LIBSTDCXX ($($CXX -dumpversion))"
     cp "$LIBSTDCXX" "lib/libstdc++.a"
 fi
+
+# delete unwanted directories
+# rm -rf lib/cmake/cblas* lib/cmake/lapack* lib/pkgconfig
+rm -rf lib/cmake lib/pkgconfig

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -103,12 +103,15 @@ if [[ "$OS" == "w64-mingw32" ]]; then
 	cp -a "${BUILD_ROOT}/install/include/." include
 	rm -rf "${BUILD_ROOT}"
 
-	CXX="${CXX:-g++}"
-	LIBSTDCXX="$("$CXX" -print-file-name=libstdc++.a)"
-	if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
-	  echo "Could not locate libstdc++.a via $CXX"; exit 1
+	CXX="${CXX:-C:/mingw64/bin/g++.exe}"
+	LIBSTDCXX="$("$CXX" -print-file-name=libstdc++.a || true)"
+	if [[ "$LIBSTDCXX" != "libstdc++.a" ]] && command -v cygpath >/dev/null 2>&1; then
+		LIBSTDCXX="$(cygpath -u "$LIBSTDCXX")"   # C:/… -> /c/… for bash cp/-f
 	fi
-	echo "Using $LIBSTDCXX ($($CXX -dumpversion))"
+	if [[ "$LIBSTDCXX" == "libstdc++.a" || ! -f "$LIBSTDCXX" ]]; then
+		echo "Could not locate libstdc++.a via $CXX"; exit 1
+	fi
+	echo "Using $LIBSTDCXX ($("$CXX" -dumpversion))"
 	cp "$LIBSTDCXX" "lib/libstdc++.a"
 fi
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -129,7 +129,8 @@ You can pass the following options as `-DOPTION=value`:
 | `MA27`                 | path to the MA27 library                                                                                   | `path_to_libma27`           |
 | `MA57`                 | path to the MA57 library                                                                                   | `path_to_libma57`           |
 | `HSL`                  | path to the HSL library                                                                                    | `path_to_libhsl`            |
-| `HIGHS`                | path to the HiGHS library                                                                                  | `path_to_libhighs`          |
+| `HIGHS`                | path to the HiGHS libraries (typically `libhighs` and `libhighs_extras`)                                   | `path_to_libhighs`          |
+| `HIGHS_INCLUDE_DIR`    | path to HiGHS include directory                                                                            | `path_to_highs_include_dir` |
 | `METIS`                | path to the METIS library                                                                                  | `path_to_libmetis`          |
 | `MUMPS_LIBRARY`        | path to the MUMPS library                                                                                  | `path_to_libdmumps`         |
 | `MUMPS_COMMON_LIBRARY` | path to the MUMPS common library                                                                           | `path_to_libmumps_common`   |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,5 @@ MUMPS_COMMON_LIBRARY = "dependencies/lib/libmumps_common.a"
 MUMPS_PORD_LIBRARY = "dependencies/lib/libpord.a"
 MUMPS_MPISEQ_LIBRARY = "dependencies/lib/libmpiseq.a"
 # HiGHS
-HIGHS = "dependencies/lib/libhighs.a"
+HIGHS = "dependencies/lib/libhighs.a;dependencies/lib/libhighs_extras.a;"
+HIGHS_INCLUDE_DIR = "dependencies/include"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ MUMPS_COMMON_LIBRARY = "dependencies/lib/libmumps_common.a"
 MUMPS_PORD_LIBRARY = "dependencies/lib/libpord.a"
 MUMPS_MPISEQ_LIBRARY = "dependencies/lib/libmpiseq.a"
 # HiGHS
-HIGHS = "dependencies/lib/libhighs.a;dependencies/lib/libhighs_extras.a;"
-HIGHS_INCLUDE_DIR = "dependencies/include"
+HIGHS = "dependencies/lib/libhighs.a;dependencies/lib/libhighs_extras.a"
+HIGHS_INCLUDE_DIR = "dependencies/include/highs"

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.hpp
@@ -5,7 +5,7 @@
 #define UNO_HIGHSSOLVER_H
 
 #include <memory>
-#include <highs/Highs.h>
+#include <Highs.h>
 #include "../QPSolver.hpp"
 
 namespace uno {


### PR DESCRIPTION
- UnoUtils: compiled HiGHS with `-DBUILD_SHARED_EXTRAS_LIB=OFF` to build `libhighs_extra.a`
- link `libhighs_extra.a` after `libhighs.a` in `HIGHS` CMake variable
- added `HIGHS_INCLUDE_DIR` CMake variable
- build HiGHS on the fly for MinGW
- libstdc++ handled in the CMakeLists, is not linked statically any more