### PR TITLE
[unopy] Fixed pyproject.toml error (used to be a soft deprecation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/cvanaret/Uno/issues"
 
 [tool.scikit-build]
 cmake.source-dir = "."
-cmake.verbose = true
+build.verbose = true
 wheel.cmake = true
 wheel.packages = ["interfaces/Python/unopy"]  # point to a dir containing __init__.py
 


### PR DESCRIPTION
Replaced `cmake.verbose` with `build.verbose` in pyproject.toml (used to be a soft deprecation)