### PR TITLE
Standalone dynamic loader (follow-up of #771)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,8 @@ endfunction()
 # ======================
 
 # HSL (MA27/MA57)
-# IPOPT-style runtime loading: don't link libhsl, dlopen it on first use and
-# resolve MA27/MA57 by symbol name (see uno/ingredients/subproblem_solvers/HSL).
+# runtime loading: don't link libhsl, dlopen it on first use and resolve MA27/MA57 by symbol name
+# (see uno/ingredients/subproblem_solvers/HSL).
 option(HSL_RUNTIME_LOADING "Load HSL (MA27/MA57) at runtime via dlopen instead of linking" OFF)
 set(_compile_ma57 OFF)
 set(_compile_ma27 OFF)
@@ -143,7 +143,7 @@ if(HSL_RUNTIME_LOADING)
    if(NOT BUILD_SHARED_LIBS)
       message(FATAL_ERROR "HSL_RUNTIME_LOADING=ON requires a shared build. Set -DBUILD_SHARED_LIBS=ON.")
    endif()
-   message(STATUS "HSL: IPOPT-style runtime loading enabled (libhsl resolved via dlopen)")
+   message(STATUS "HSL: runtime loading enabled (libhsl resolved via dlopen)")
    target_sources(compiled_uno_files PRIVATE uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp)
    target_compile_definitions(uno_dependencies INTERFACE HAS_HSL HSL_RUNTIME_LOADING)
    target_link_libraries(uno_dependencies INTERFACE ${CMAKE_DL_LIBS})

--- a/uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp
+++ b/uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp
@@ -5,13 +5,8 @@
 #include <cctype>
 #include <cstdlib>
 #include <string>
+#include "tools/DynamicLoader.hpp"
 #include "tools/Logger.hpp"
-
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <dlfcn.h>
-#endif
 
 // default library name: libhsl.<platform shared-lib extension> (matches IPOPT's hsllib)
 #if defined(_WIN32)
@@ -35,42 +30,8 @@ namespace uno {
    ma27cd_fp hsl_ma27cd = nullptr;
 
    namespace {
-#ifdef _WIN32
-      using LibraryHandle = HMODULE;
-      LibraryHandle open_library(const char* name) { return LoadLibraryA(name); }
-      void* raw_symbol(LibraryHandle handle, const char* symbol) {
-         return reinterpret_cast<void*>(GetProcAddress(handle, symbol));
-      }
-#else
-      using LibraryHandle = void*;
-      // match upstream IPOPT: resolve now, do not export the HSL symbols globally
-      LibraryHandle open_library(const char* name) { return dlopen(name, RTLD_NOW); }
-      void* raw_symbol(LibraryHandle handle, const char* symbol) { return dlsym(handle, symbol); }
-#endif
-
       LibraryHandle hsl_handle = nullptr;
       std::string hsl_loaded_name{}; // the library name that was actually dlopen'd (for the mismatch warning)
-
-      // Resolve a Fortran symbol trying the manglings IPOPT tries, so the runtime
-      // libhsl can have been built by any compiler regardless of how Uno was:
-      // base, base_, lower_, lower, UPPER_, UPPER.
-      void* resolve_symbol(LibraryHandle handle, const std::string& base) {
-         std::string lower = base, upper = base;
-         for (char& c: lower) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
-         for (char& c: upper) { c = static_cast<char>(std::toupper(static_cast<unsigned char>(c))); }
-         const std::string candidates[] = {base, base + "_", lower + "_", lower, upper + "_", upper};
-         for (const std::string& candidate: candidates) {
-            if (void* symbol = raw_symbol(handle, candidate.c_str())) {
-               return symbol;
-            }
-         }
-         return nullptr;
-      }
-
-      template <typename FunctionPointer>
-      void resolve(LibraryHandle handle, FunctionPointer& function_pointer, const std::string& base) {
-         function_pointer = reinterpret_cast<FunctionPointer>(resolve_symbol(handle, base));
-      }
    } // anonymous namespace
 
    bool load_hsl_library(const std::string& library_name) {
@@ -78,7 +39,8 @@ namespace uno {
       // done unconditionally so we can compare it against an already-loaded library below.
       std::string name = library_name;
       if (name.empty()) {
-         if (const char* env = std::getenv("UNO_HSL_LIBRARY")) {
+         const char* env = std::getenv("UNO_HSL_LIBRARY");
+         if (env != nullptr) {
             name = env;
          }
       }

--- a/uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp
+++ b/uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include "HSLLoader.hpp"
-#include <cctype>
-#include <cstdlib>
-#include <string>
 #include "tools/DynamicLoader.hpp"
 #include "tools/Logger.hpp"
 
@@ -34,25 +31,16 @@ namespace uno {
       std::string hsl_loaded_name{}; // the library name that was actually dlopen'd (for the mismatch warning)
    } // anonymous namespace
 
-   bool load_hsl_library(const std::string& library_name) {
+   bool load_hsl_library(const std::string& user_library_name) {
       // resolve the effective library name (explicit request > UNO_HSL_LIBRARY env > platform default),
       // done unconditionally so we can compare it against an already-loaded library below.
-      std::string name = library_name;
-      if (name.empty()) {
-         const char* env = std::getenv("UNO_HSL_LIBRARY");
-         if (env != nullptr) {
-            name = env;
-         }
-      }
-      if (name.empty()) {
-         name = UNO_HSL_DEFAULT_LIBRARY;
-      }
+      const std::string name = resolve_library_name(user_library_name, "UNO_HSL_LIBRARY", UNO_HSL_DEFAULT_LIBRARY);
 
-      // cache success only: a failed probe (e.g. the early available_solvers() check
-      // with no name) must not block a later load with an explicit hsllib path.
+      // cache success only: a failed probe (e.g. the early available_solvers() check with no name) must not block a
+      // later load with an explicit hsllib path.
       if (hsl_handle != nullptr) {
          // the first successful load wins; warn if an explicit, different library was requested too late
-         if (!library_name.empty() && name != hsl_loaded_name) {
+         if (!user_library_name.empty() && name != hsl_loaded_name) {
             WARNING << "Uno: the HSL library '" << hsl_loaded_name << "' is already loaded; ignoring the request for '"
                << name << "' (the first load wins)\n";
          }
@@ -91,8 +79,7 @@ namespace uno {
    }
 } // namespace
 
-// Mirrors the symbol the linked coinhsl meta-library exports; the
-// SymmetricIndefiniteLinearSolverFactory uses it to gate MA27/MA57.
+// Mirrors the symbol exported by libhsl. Used in SymmetricIndefiniteLinearSolverFactory to gate MA27/MA57.
 extern "C" bool LIBHSL_isfunctional() {
    return uno::ma57_symbols_available() || uno::ma27_symbols_available();
 }

--- a/uno/ingredients/subproblem_solvers/HSL/HSLLoader.hpp
+++ b/uno/ingredients/subproblem_solvers/HSL/HSLLoader.hpp
@@ -51,7 +51,7 @@ namespace uno {
 
    // dlopen the HSL library (default name per platform, overridable via the
    // UNO_HSL_LIBRARY environment variable) and resolve the symbols. Idempotent.
-   bool load_hsl_library(const std::string& library_name = "");
+   bool load_hsl_library(const std::string& user_library_name = "");
    bool ma57_symbols_available();
    bool ma27_symbols_available();
 } // namespace

--- a/uno/tools/DynamicLoader.cpp
+++ b/uno/tools/DynamicLoader.cpp
@@ -18,7 +18,7 @@ namespace uno {
       return reinterpret_cast<void*>(GetProcAddress(handle, symbol));
    }
 #else
-   // match upstream IPOPT: resolve now, do not export the HSL symbols globally
+   // resolve now, do not export the HSL symbols globally
    LibraryHandle open_library(const char* name) {
       return dlopen(name, RTLD_NOW);
    }
@@ -28,8 +28,7 @@ namespace uno {
    }
 #endif
 
-   // Resolve a Fortran symbol trying the manglings IPOPT tries, so the runtime
-   // libhsl can have been built by any compiler regardless of how Uno was:
+   // resolve a Fortran symbol by trying different manglings (the runtime libhsl may have been built by any compiler):
    // base, base_, lower_, lower, UPPER_, UPPER.
    void* resolve_symbol(LibraryHandle handle, const std::string& base) {
       std::string lower = base, upper = base;

--- a/uno/tools/DynamicLoader.cpp
+++ b/uno/tools/DynamicLoader.cpp
@@ -2,7 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include "DynamicLoader.hpp"
-
+#include <cstring>
+#include <cctype>
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
@@ -46,5 +47,19 @@ namespace uno {
          }
       }
       return nullptr;
+   }
+
+   // resolve the effective library name (explicit request > env > platform default)
+   std::string resolve_library_name(const std::string& user_library_name, const char* env_library_name, const char* default_library) {
+      std::string name = "";
+      if (!user_library_name.empty()) {
+         return user_library_name;
+      }
+      // user_library_name empty
+      const char* env_path = std::getenv(env_library_name);
+      if (env_path != nullptr && 0 < strlen(env_path)) {
+         return env_path;
+      }
+      return default_library;
    }
 } // namespace

--- a/uno/tools/DynamicLoader.cpp
+++ b/uno/tools/DynamicLoader.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Joris Gillis, Alexis Montoison and Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#include "DynamicLoader.hpp"
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
+namespace uno {
+#ifdef _WIN32
+   LibraryHandle open_library(const char* name) {
+      return LoadLibraryA(name);
+   }
+
+   void* raw_symbol(LibraryHandle handle, const char* symbol) {
+      return reinterpret_cast<void*>(GetProcAddress(handle, symbol));
+   }
+#else
+   // match upstream IPOPT: resolve now, do not export the HSL symbols globally
+   LibraryHandle open_library(const char* name) {
+      return dlopen(name, RTLD_NOW);
+   }
+
+   void* raw_symbol(LibraryHandle handle, const char* symbol) {
+      return dlsym(handle, symbol);
+   }
+#endif
+
+   // Resolve a Fortran symbol trying the manglings IPOPT tries, so the runtime
+   // libhsl can have been built by any compiler regardless of how Uno was:
+   // base, base_, lower_, lower, UPPER_, UPPER.
+   void* resolve_symbol(LibraryHandle handle, const std::string& base) {
+      std::string lower = base, upper = base;
+      for (char& c: lower) {
+         c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+      }
+      for (char& c: upper) {
+         c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+      }
+      const std::string candidates[] = {base, base + "_", lower + "_", lower, upper + "_", upper};
+      for (const std::string& candidate: candidates) {
+         void* symbol = raw_symbol(handle, candidate.c_str());
+         if (symbol != nullptr) {
+            return symbol;
+         }
+      }
+      return nullptr;
+   }
+} // namespace

--- a/uno/tools/DynamicLoader.hpp
+++ b/uno/tools/DynamicLoader.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Joris Gillis, Alexis Montoison and Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <string>
+
+namespace uno {
+#ifdef _WIN32
+   using LibraryHandle = HMODULE;
+#else
+   using LibraryHandle = void*;
+#endif
+
+   LibraryHandle open_library(const char* name);
+   void* raw_symbol(LibraryHandle handle, const char* symbol);
+   void* resolve_symbol(LibraryHandle handle, const std::string& base);
+
+   template <typename FunctionPointer>
+   void resolve(LibraryHandle handle, FunctionPointer& function_pointer, const std::string& base) {
+      function_pointer = reinterpret_cast<FunctionPointer>(resolve_symbol(handle, base));
+   }
+} // namespace

--- a/uno/tools/DynamicLoader.hpp
+++ b/uno/tools/DynamicLoader.hpp
@@ -22,4 +22,7 @@ namespace uno {
    void resolve(LibraryHandle handle, FunctionPointer& function_pointer, const std::string& base) {
       function_pointer = reinterpret_cast<FunctionPointer>(resolve_symbol(handle, base));
    }
+
+   [[nodiscard]] std::string resolve_library_name(const std::string& user_library_name, const char* env_library_name,
+      const char* default_library);
 } // namespace


### PR DESCRIPTION
Small refactoring to make the dynamic loader standalone (independent of HSL), so that it can be reused for loading other libraries (like libkrylov).

cc @amontoison @jgillis 