### PR TITLE
[Release] Prep for v2.8.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use Uno, please cite both the software (Zenodo DOI) and the article below."
 title: "Uno"
-version: 2.7.6
+version: 2.8.0
 doi: 10.5281/zenodo.21103041
 url: "https://github.com/cvanaret/Uno"
 authors:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # define the project
-project(Uno VERSION 2.7.6
+project(Uno VERSION 2.8.0
         DESCRIPTION "Uno (Unifying Nonlinear Optimization)"
         LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,8 +148,8 @@ You can pass the following options as `-DOPTION=value`:
 > `-DHSL_RUNTIME_LOADING=ON` requires a shared build (`-DBUILD_SHARED_LIBS=ON`): the mode is meant to `dlopen` a shared library `libhsl` from a shared `libuno`, so a static-only build is rejected by CMake.
 >
 > With `-DHSL_RUNTIME_LOADING=ON`, Uno is built without linking any HSL library and instead `dlopen`s it on first use (as IPOPT does), so the same binary can be shipped with or without HSL. At runtime, the shared library is resolved in this order:
-> 1. the `hsllib` [option](options.md) (empty by default);
+> 1. the `libhsl_path` [option](options.md) (empty by default);
 > 2. the `UNO_HSL_LIBRARY` environment variable;
 > 3. the platform default `libhsl.so` / `libhsl.dylib` / `libhsl.dll`.
 >
-> Since the default `linear_solver` is auto-selected before user options are parsed, use `UNO_HSL_LIBRARY` (rather than the `hsllib` option) if you want `MA27`/`MA57`/`MA86` to be picked automatically when the library is not on the default search path.
+> Since the default `linear_solver` is auto-selected before user options are parsed, use `UNO_HSL_LIBRARY` (rather than the `libhsl_path` option) if you want `MA27`/`MA57`/`MA86` to be picked automatically when the library is not on the default search path.

--- a/docs/options.md
+++ b/docs/options.md
@@ -25,9 +25,9 @@ Defaults are taken from `uno/options/DefaultOptions.cpp`.
 
 If not provided, the solver is chosen automatically from the available solvers (if any).
 
-| Option    | Type   | Default | Description |
-| :---      | :---   | :---    | :---        |
-| `hsllib`  | string | `""`    | Name/path of the HSL shared library to `dlopen` for `MA27`/`MA57`/`MA86` (only used when Uno is built with `-DHSL_RUNTIME_LOADING=ON`). An empty value resolves at runtime to the platform default `libhsl.{so,dylib,dll}`. See the [installation guide](installation.md#cmake-options) for the resolution order and the `UNO_HSL_LIBRARY` environment variable. |
+| Option         | Type   | Default | Description                                                                                                                                                                                                                                                                                                                                                      |
+|:---------------| :---   | :---    |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `libhsl_path`  | string | `""`    | Name/path of the HSL shared library to `dlopen` for `MA27`/`MA57`/`MA86` (only used when Uno is built with `-DHSL_RUNTIME_LOADING=ON`). An empty value resolves at runtime to the platform default `libhsl.{so,dylib,dll}`. See the [installation guide](installation.md#cmake-options) for the resolution order and the `UNO_HSL_LIBRARY` environment variable. |
 
 ## Termination
 

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -59,8 +59,8 @@ extern "C" {
 
    // current Uno version
    const uno_int UNO_VERSION_MAJOR = 2;
-   const uno_int UNO_VERSION_MINOR = 7;
-   const uno_int UNO_VERSION_PATCH = 6;
+   const uno_int UNO_VERSION_MINOR = 8;
+   const uno_int UNO_VERSION_PATCH = 0;
 
    // options iterator
    typedef void* uno_options_iterator;

--- a/interfaces/Fortran/uno_c.f90
+++ b/interfaces/Fortran/uno_c.f90
@@ -77,8 +77,8 @@ integer(uno_int), parameter :: UNO_UNBOUNDED                   = 6
 ! Uno version
 !---------------------------------------------
 integer(uno_int), parameter :: UNO_VERSION_MAJOR = 2
-integer(uno_int), parameter :: UNO_VERSION_MINOR = 7
-integer(uno_int), parameter :: UNO_VERSION_PATCH = 6
+integer(uno_int), parameter :: UNO_VERSION_MINOR = 8
+integer(uno_int), parameter :: UNO_VERSION_PATCH = 0
 
 !---------------------------------------------
 ! uno_objective_callback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "unopy"
-version = "0.4.12"
+version = "0.4.13"
 description = "With Uno, finally take full control of your SQP/barrier solver for nonlinearly constrained optimization"
 readme = "interfaces/Python/README.md"
 authors = [

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
@@ -16,7 +16,7 @@ namespace uno {
    PrimalDualInertiaCorrection::PrimalDualInertiaCorrection(const Options& options):
          InertiaCorrectionStrategy(),
          optional_linear_solver_name(options.get_string("linear_solver")),
-         hsllib(options.get_string_optional("hsllib").value_or("")),
+         libhsl_path(options.get_string_optional("libhsl_path").value_or("")),
          regularization_failure_threshold(options.get_double("regularization_failure_threshold")),
          primal_regularization_initial_factor(options.get_double("primal_regularization_initial_factor")),
          dual_regularization_fraction(options.get_double("dual_regularization_fraction")),
@@ -35,7 +35,7 @@ namespace uno {
          const Inertia& expected_inertia, double* hessian_values) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
-         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->hsllib);
+         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
          this->optional_linear_solver->get_linear_system().initialize_augmented_system(subproblem);
          this->optional_linear_solver->initialize_memory();
          this->optional_linear_solver->do_symbolic_analysis();
@@ -56,7 +56,7 @@ namespace uno {
          double dual_regularization_parameter, const Inertia& expected_inertia, double* primal_regularization_values,
          double* dual_regularization_values) {
       if (this->optional_linear_solver == nullptr) {
-         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->hsllib);
+         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
          this->optional_linear_solver->get_linear_system().initialize_augmented_system(subproblem);
          this->optional_linear_solver->initialize_memory();
          this->optional_linear_solver->do_symbolic_analysis();

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.hpp
@@ -37,7 +37,7 @@ namespace uno {
 
    protected:
       const std::string& optional_linear_solver_name;
-      const std::string hsllib;
+      const std::string libhsl_path;
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> optional_linear_solver{};
       double primal_regularization{0.};
       double dual_regularization{0.};

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
@@ -15,7 +15,7 @@ namespace uno {
    PrimalInertiaCorrection::PrimalInertiaCorrection(const Options& options):
          InertiaCorrectionStrategy(),
          optional_linear_solver_name(options.get_string("linear_solver")),
-         hsllib(options.get_string_optional("hsllib").value_or("")),
+         libhsl_path(options.get_string_optional("libhsl_path").value_or("")),
          regularization_initial_factor(options.get_double("primal_regularization_initial_factor")),
          regularization_increase_factor(options.get_double("regularization_increase_factor")),
          regularization_failure_threshold(options.get_double("regularization_failure_threshold")) {
@@ -30,7 +30,7 @@ namespace uno {
          const Inertia& expected_inertia, double* hessian_values) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
-         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->hsllib);
+         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
          this->optional_linear_solver->get_linear_system().initialize_hessian(subproblem);
          this->optional_linear_solver->initialize_memory();
          this->optional_linear_solver->do_symbolic_analysis();
@@ -91,7 +91,7 @@ namespace uno {
          double* dual_regularization_values) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
-         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->hsllib);
+         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
          this->optional_linear_solver->get_linear_system().initialize_hessian(subproblem);
          this->optional_linear_solver->initialize_memory();
          this->optional_linear_solver->do_symbolic_analysis();

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.hpp
@@ -38,7 +38,7 @@ namespace uno {
 
    protected:
       const std::string& optional_linear_solver_name;
-      const std::string hsllib;
+      const std::string libhsl_path;
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> optional_linear_solver{};
       double regularization_factor{0.};
       const double regularization_initial_factor{};

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -15,7 +15,7 @@ namespace uno {
    EQPSolver::EQPSolver(const Options& options):
          SubproblemSolver(),
          linear_solver(SymmetricIndefiniteLinearSolverFactory::create(options.get_string("linear_solver"),
-            options.get_string_optional("hsllib").value_or(""))) {
+            options.get_string_optional("libhsl_path").value_or(""))) {
    }
 
    void EQPSolver::initialize_memory(const Subproblem& subproblem) {

--- a/uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp
+++ b/uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp
@@ -5,7 +5,7 @@
 #include "tools/DynamicLoader.hpp"
 #include "tools/Logger.hpp"
 
-// default library name: libhsl.<platform shared-lib extension> (matches IPOPT's hsllib)
+// default library name: libhsl.<platform shared-lib extension>
 #if defined(_WIN32)
 #define UNO_HSL_DEFAULT_LIBRARY "libhsl.dll"
 #elif defined(__APPLE__)
@@ -44,7 +44,7 @@ namespace uno {
       const std::string name = resolve_library_name(user_library_name, "UNO_HSL_LIBRARY", UNO_HSL_DEFAULT_LIBRARY);
 
       // cache success only: a failed probe (e.g. the early available_solvers() check with no name) must not block a
-      // later load with an explicit hsllib path.
+      // later load with an explicit libhsl_path.
       if (hsl_handle != nullptr) {
          // the first successful load wins; warn if an explicit, different library was requested too late
          if (!user_library_name.empty() && name != hsl_loaded_name) {

--- a/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.cpp
+++ b/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.cpp
@@ -41,10 +41,10 @@ namespace uno {
 
 namespace uno {
    std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> SymmetricIndefiniteLinearSolverFactory::create(
-         const std::string& linear_solver, [[maybe_unused]] const std::string& hsllib) {
+         const std::string& linear_solver, [[maybe_unused]] const std::string& libhsl_path) {
 #ifdef HSL_RUNTIME_LOADING
       // honor the requested HSL library name before LIBHSL_isfunctional() triggers the (cached) load
-      load_hsl_library(hsllib);
+      load_hsl_library(libhsl_path);
 #endif
 #if defined(HAS_HSL) || defined(HAS_MA57)
       if (linear_solver == "MA57"

--- a/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.hpp
+++ b/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.hpp
@@ -15,9 +15,9 @@ namespace uno {
 
    class SymmetricIndefiniteLinearSolverFactory {
    public:
-      // hsllib: runtime HSL library name for MA27/MA57 (empty = platform default libhsl.<ext>)
+      // libhsl_path: runtime HSL library name for MA27/MA57 (empty = platform default libhsl.<ext>)
       static std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> create(const std::string& linear_solver,
-         const std::string& hsllib = "");
+         const std::string& libhsl_path = "");
 
       // return the list of available solvers
       static std::vector<std::string> available_solvers();

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -19,7 +19,7 @@ namespace uno {
          SubproblemSolver(),
          hessian_model(hessian_model),
          linear_solver(SymmetricIndefiniteLinearSolverFactory::create(options.get_string("linear_solver"),
-            options.get_string_optional("hsllib").value_or(""))) {
+            options.get_string_optional("libhsl_path").value_or(""))) {
       assert(!this->hessian_model.has_hessian_matrix());
    }
 

--- a/uno/options/DefaultOptions.cpp
+++ b/uno/options/DefaultOptions.cpp
@@ -165,14 +165,14 @@ namespace uno {
          options.set_string("LP_solver", *LPSolverFactory::available_solvers.begin(), true);
       }
       // linear solver
-      // HSL runtime loading: this runs before user options are parsed, so it can't see "hsllib" below.
+      // HSL runtime loading: this runs before user options are parsed, so it can't see "libhsl_path" below.
       // Set UNO_HSL_LIBRARY to auto-select MA27/MA57, or choose linear_solver explicitly.
       const auto linear_solvers = SymmetricIndefiniteLinearSolverFactory::available_solvers();
       if (!linear_solvers.empty()) {
          options.set_string("linear_solver", linear_solvers[0], true);
       }
-      // name of the HSL shared library to dlopen for MA27/MA57 at runtime
-      // (empty = platform default libhsl.{so,dylib,dll}); mirrors IPOPT's hsllib option
-      options.set_string("hsllib", "", true);
+      // path to the HSL shared library to dlopen for MA27/MA57 at runtime
+      // (empty = platform default libhsl.{so,dylib,dll})
+      options.set_string("libhsl_path", "", true);
    }
 } // namespace


### PR DESCRIPTION
## Pre-release

- [x] Change the version number in `CITATION.cff`
- [x] Change the version number in `CMakeLists.txt`
- [x] Change the version number in `interfaces/C/Uno_C_API.h`
- [x] Change the version number in `interfaces/Fortran/uno_c.f90`
- [x] Making a release of `unopy`
  - [x] Change the version number in `pyproject.toml`
  - [x] The title of the test commit should start with `[unopy] Test release`
- [x] The PR should have the title `[Release] Prep for vX.Y.Z.`
- [x] The commit messages in this PR do not contain `[ci skip]`

## Post-release

- `Uno_jll.jl` and `UnoSolver.jl`
  - [x] Update the [Yggdrasil tarballs](https://github.com/JuliaPackaging/Yggdrasil/blob/master/U/Uno/build_tarballs.jl)
  - [ ] Change the `Uno_jll` version number in `interfaces/Julia/Project.toml`
  - [ ] Change the patch version number in `interfaces/Julia/Project.toml`
- [ ] Update the logo in [the Github settings](https://github.com/cvanaret/Uno/settings)
- [ ] Write release notes once release and artifacts are available

@jgillis: I renamed `hsllib` into `libhsl_path`.