### PR TITLE
Update the references of Uno

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,15 +1,43 @@
 cff-version: 1.2.0
-message: "If you use Uno, please cite both the software (Zenodo DOI) and the article below."
+message: "If you use Uno, please cite it using the metadata from this file."
 title: "Uno"
 version: 2.8.0
-doi: 10.5281/zenodo.21103041
+doi: 10.5281/zenodo.18795863
 url: "https://github.com/cvanaret/Uno"
 authors:
 - family-names: "Vanaret"
   given-names: "Charlie"
   orcid: "https://orcid.org/0000-0002-1131-7631"
+- family-names: "Montoison"
+  given-names: "Alexis"
+  orcid: "https://orcid.org/0000-0002-3403-5450"
+contact:
+- family-names: "Vanaret"
+  given-names: "Charlie"
+  orcid: "https://orcid.org/0000-0002-1131-7631"
 preferred-citation:
   type: article
+  authors:
+  - family-names: "Vanaret"
+    given-names: "Charlie"
+    orcid: "https://orcid.org/0000-0002-1131-7631"
+  - family-names: "Montoison"
+    given-names: "Alexis"
+    orcid: "https://orcid.org/0000-0002-3403-5450"
+  title: "Uno: a composable framework for nonlinearly constrained optimization"
+  journal: "Journal of Open Source Software"
+  publisher:
+    name: "Open Journals"
+  year: 2026
+  date-published: 2026-07-14
+  doi: 10.21105/joss.10229
+  issn: 2475-9066
+  volume: 11
+  issue: 123
+  start: 10229
+  url: "https://joss.theoj.org/papers/10.21105/joss.10229"
+references:
+- type: article
   authors:
   - family-names: "Vanaret"
     given-names: "Charlie"

--- a/README.md
+++ b/README.md
@@ -39,21 +39,27 @@ Our [theory paper](https://link.springer.com/article/10.1007/s12532-026-00310-9)
 
 ```
 @article{VanaretLeyffer2026,
-  author = {Vanaret, Charlie and Leyffer, Sven},
-  title = {Implementing a unified solver for nonlinearly constrained optimization},
+  author  = {Vanaret, Charlie and Leyffer, Sven},
+  title   = {Implementing a unified solver for nonlinearly constrained optimization},
   journal = {Mathematical Programming Computation},
-  year = {2026},
-  doi = {10.1007/s12532-026-00310-9}
+  year    = {2026},
+  doi     = {10.1007/s12532-026-00310-9}
 }
 ```
 
-We also submitted a [software article](https://github.com/openjournals/joss-reviews/issues/10229) to the Journal of Open Source Software (JOSS):
+Our [software article](https://joss.theoj.org/papers/10.21105/joss.10229) published in the Journal of Open Source Software (JOSS) may be cited with the following BibTeX entry:
+
 ```
-@unpublished{VanaretMontoison2026,
-  author = {Vanaret, Charlie and Montoison, Alexis},
-  title = {Uno: a composable framework for nonlinearly constrained optimization},
-  year = {2026},
-  note = {Submitted to the Journal of Open Source Software}
+@article{VanaretMontoison2026,
+  author    = {Vanaret, Charlie and Montoison, Alexis},
+  title     = {Uno: a composable framework for nonlinearly constrained optimization},
+  journal   = {Journal of Open Source Software},
+  publisher = {The Open Journal},
+  year      = {2026},
+  volume    = {11},
+  number    = {123},
+  pages     = {10229},
+  doi       = {10.21105/joss.10229}
 }
 ```
 

--- a/docs/citing_uno.md
+++ b/docs/citing_uno.md
@@ -4,20 +4,26 @@ Our [theory paper](https://link.springer.com/article/10.1007/s12532-026-00310-9)
 
 ```
 @article{VanaretLeyffer2026,
-  author = {Vanaret, Charlie and Leyffer, Sven},
-  title = {Implementing a unified solver for nonlinearly constrained optimization},
+  author  = {Vanaret, Charlie and Leyffer, Sven},
+  title   = {Implementing a unified solver for nonlinearly constrained optimization},
   journal = {Mathematical Programming Computation},
-  year = {2026},
-  doi = {10.1007/s12532-026-00310-9}
+  year    = {2026},
+  doi     = {10.1007/s12532-026-00310-9}
 }
 ```
 
-We also submitted a [short article](https://github.com/openjournals/joss-reviews/issues/10229) to the Journal of Open Source Software (JOSS):
+Our [software article](https://joss.theoj.org/papers/10.21105/joss.10229) published in the Journal of Open Source Software (JOSS) may be cited with the following BibTeX entry:
+
 ```
-@unpublished{VanaretMontoison2026,
-  author = {Vanaret, Charlie and Montoison, Alexis},
-  title = {Uno: a composable framework for nonlinearly constrained optimization},
-  year = {2026},
-  note = {Submitted to the Journal of Open Source Software}
+@article{VanaretMontoison2026,
+  author    = {Vanaret, Charlie and Montoison, Alexis},
+  title     = {Uno: a composable framework for nonlinearly constrained optimization},
+  journal   = {Journal of Open Source Software},
+  publisher = {The Open Journal},
+  year      = {2026},
+  volume    = {11},
+  number    = {123},
+  pages     = {10229},
+  doi       = {10.21105/joss.10229}
 }
 ```


### PR DESCRIPTION
@cvanaret Note that for Zenedo, you can use a DOI that is always related to the latest release of Uno without the need to update it.

- Add the reference to the JOSS paper