### PR TITLE
Added flush calls to write the opt logger info to the disk immediately.

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -253,22 +253,27 @@ namespace uno {
          warmstart_information.no_changes();
       }
 
-      // check termination
-      if (this->current_phase == Phase::OPTIMALITY) {
-         this->compute_residuals(this->original_problem, trial_iterate, evaluation_cache.trial_evaluations);
-         trial_iterate.status = this->check_termination(this->original_problem, trial_iterate,
-            evaluation_cache.trial_evaluations);
-         if (accept_iterate) {
+      // Rejected line-search trials only need function values. Trust-region trials still need residuals because their
+      // derivatives can update the Hessian model before the subproblem is solved again with a smaller radius.
+      if (uses_trust_region || accept_iterate) {
+         // check termination
+         if (this->current_phase == Phase::OPTIMALITY) {
+            this->compute_residuals(this->original_problem, trial_iterate, evaluation_cache.trial_evaluations);
+            trial_iterate.status = this->check_termination(this->original_problem, trial_iterate,
+               evaluation_cache.trial_evaluations);
+         }
+         else {
+            this->compute_residuals(this->feasibility_problem, trial_iterate, evaluation_cache.trial_evaluations);
+            trial_iterate.status = this->check_termination(this->feasibility_problem, trial_iterate,
+               evaluation_cache.trial_evaluations);
+         }
+
+         if (accept_iterate && this->current_phase == Phase::OPTIMALITY) {
             user_callbacks.notify_acceptable_iterate(trial_iterate.primals, trial_iterate.multipliers,
                this->original_problem.get_objective_multiplier(), trial_iterate.progress.infeasibility,
                trial_iterate.residuals.stationarity, trial_iterate.residuals.complementarity);
          }
-      }
-      else {
-         this->compute_residuals(this->feasibility_problem, trial_iterate, evaluation_cache.trial_evaluations);
-         trial_iterate.status = this->check_termination(this->feasibility_problem, trial_iterate,
-            evaluation_cache.trial_evaluations);
-         if (accept_iterate) {
+         else if (accept_iterate) {
             user_callbacks.notify_acceptable_iterate(trial_iterate.primals, trial_iterate.multipliers,
                this->feasibility_problem.get_objective_multiplier(), trial_iterate.progress.infeasibility,
                trial_iterate.residuals.stationarity, trial_iterate.residuals.complementarity);

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -99,12 +99,16 @@ namespace uno {
       const bool accept_iterate = ConstraintRelaxationStrategy::is_iterate_acceptable(statistics, this->globalization_strategy,
          subproblem, this->subproblem_solver->get_workspace(), current_iterate, trial_iterate, direction, step_length,
          evaluation_cache);
-      this->compute_residuals(this->original_problem, trial_iterate, evaluation_cache.trial_evaluations);
-      trial_iterate.status = this->check_termination(this->original_problem, trial_iterate, evaluation_cache.trial_evaluations);
-      if (accept_iterate) {
-         user_callbacks.notify_acceptable_iterate(trial_iterate.primals, trial_iterate.multipliers,
-            this->original_problem.get_objective_multiplier(), trial_iterate.progress.infeasibility,
-            trial_iterate.residuals.stationarity, trial_iterate.residuals.complementarity);
+      // Rejected line-search trials only need function values. Trust-region trials retain their existing derivative-based
+      // residual and Hessian-model updates before the subproblem is solved again with a smaller radius.
+      if (uses_trust_region || accept_iterate) {
+         this->compute_residuals(this->original_problem, trial_iterate, evaluation_cache.trial_evaluations);
+         trial_iterate.status = this->check_termination(this->original_problem, trial_iterate, evaluation_cache.trial_evaluations);
+         if (accept_iterate) {
+            user_callbacks.notify_acceptable_iterate(trial_iterate.primals, trial_iterate.multipliers,
+               this->original_problem.get_objective_multiplier(), trial_iterate.progress.infeasibility,
+               trial_iterate.residuals.stationarity, trial_iterate.residuals.complementarity);
+         }
       }
       if (uses_trust_region || accept_iterate) {
          this->hessian_model->notify_trial_iterate(statistics, current_iterate, trial_iterate, evaluation_cache);

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -131,16 +131,10 @@ namespace uno {
          }
          else { // minimum_step_length reached
             DEBUG << "The line search step length is smaller than " << this->minimum_step_length << '\n';
-            // check if we can terminate at a first-order point
-            if (trial_iterate.status != SolutionStatus::NOT_OPTIMAL) {
-               statistics.set("Status", "accepted (small step length)");
-               termination = true;
-            }
-            else {
-               // switch to solving the feasibility problem
-               statistics.set("Status", "small step length");
-               return false;
-            }
+            // Do not evaluate derivatives at a rejected line-search trial merely to test first-order termination.
+            // Let the caller switch to the feasibility problem or report line-search failure instead.
+            statistics.set("Status", "small step length");
+            return false;
          }
       } // end while loop
       return true;

--- a/uno/tools/Statistics.cpp
+++ b/uno/tools/Statistics.cpp
@@ -142,6 +142,7 @@ namespace uno {
       }
       line.push_back('\n');
       INFO << line; // single insertion
+      Logger::flush();
    }
  
    void Statistics::print_header() {
@@ -158,6 +159,7 @@ namespace uno {
       }
       line.push_back('\n');
       INFO << line; // single insertion
+      Logger::flush();
  
       this->print_horizontal_line();
    }
@@ -174,6 +176,7 @@ namespace uno {
       }
       line.push_back('\n');
       INFO << line; // single insertion
+      Logger::flush();
    }
  
    void Statistics::print_footer() {


### PR DESCRIPTION
Problem: The current unopy logger file writes the optimization progress to the disk ONLY after the optimization is fully completed. This is not a problem if the optimization is fast. But for CFD-based optimization, each optimization iteration may take tens of minutes, so it is very useful to monitor the progress while the optimization is still running.

Fix: Add a few Logger:flush() calls to make the logger write the optimization progress to the disk immediately.