### PR TITLE
Added flush calls to write the opt logger info to the disk immediately.

### DIFF
--- a/uno/tools/Statistics.cpp
+++ b/uno/tools/Statistics.cpp
@@ -142,6 +142,7 @@ namespace uno {
       }
       line.push_back('\n');
       INFO << line; // single insertion
+      Logger::flush();
    }
  
    void Statistics::print_header() {
@@ -158,6 +159,7 @@ namespace uno {
       }
       line.push_back('\n');
       INFO << line; // single insertion
+      Logger::flush();
  
       this->print_horizontal_line();
    }
@@ -174,6 +176,7 @@ namespace uno {
       }
       line.push_back('\n');
       INFO << line; // single insertion
+      Logger::flush();
    }
  
    void Statistics::print_footer() {


### PR DESCRIPTION
Problem: The current unopy logger file writes the optimization progress to the disk ONLY after the optimization is fully completed. This is not a problem if the optimization is fast. But for CFD-based optimization, each optimization iteration may take tens of minutes, so it is very useful to monitor the progress while the optimization is still running.

Fix: Add a few Logger:flush() calls to make the logger write the optimization progress to the disk immediately.