### PR TITLE
[CI] Accelerate the parallel Julia CI jobs

### DIFF
--- a/.github/workflows/julia-tests-ubuntu.yml
+++ b/.github/workflows/julia-tests-ubuntu.yml
@@ -104,7 +104,10 @@ jobs:
         with:
           version: "1.10"
           arch: x64
-      - uses: julia-actions/cache@v2
+
+      - uses: julia-actions/cache@v3
+        with:
+          include-matrix: false
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Use a shared cache for all the Julia CI jobs.