### PR TITLE
Move `Subproblem` and `SubproblemSolver` to `InequalityHandlingMethod`

### DIFF
--- a/.github/julia/runtests_uno_ipopt_mumps_lbfgs.jl
+++ b/.github/julia/runtests_uno_ipopt_mumps_lbfgs.jl
@@ -22,7 +22,7 @@ function Optimizer(options)
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_Uno_ipopt() = Optimizer(["logger=DEBUG3", "preset=ipopt", "linear_solver=MUMPS", "hessian_model=LBFGS", "unbounded_objective_threshold=-1e15"])
+Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solver=MUMPS", "hessian_model=LBFGS", "unbounded_objective_threshold=-1e15"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 
@@ -44,6 +44,39 @@ function strip_prefix(instances, prefix)
     return cleaned_instances
 end
 
+primal_target = Dict(
+    MINLPTests.FEASIBLE_PROBLEM => MOI.FEASIBLE_POINT,
+    # If Uno starts writing a .sol file with an infeasible point, change
+    # this to `=> MOI.INFEASIBLE_POINT`
+    MINLPTests.INFEASIBLE_PROBLEM => MOI.NO_SOLUTION,
+)
+objective_tol = 1e-4
+primal_tol = 1e-4
+
+# This function tests (potentially) non-convex nonlinear programs. The tests
+# are meant to be "easy" in the sense that most NLP solvers can find the
+# same global minimum, but a test failure can sometimes be allowed.
+nlp_expr_instances = strip_prefix(instances, "nlp_expr_")
+if !isempty(nlp_expr_instances)
+    MINLPTests.test_directory(
+        "nlp-expr",
+        Optimizer_Uno_ipopt;
+        include = nlp_expr_instances,
+        primal_target, objective_tol, primal_tol
+    )
+end
+# This function tests convex nonlinear programs. Test failures here should
+# never be allowed, because even local NLP solvers should find the global
+# optimum.
+nlp_cvx_expr_instances = strip_prefix(instances, "nlp_cvx_expr_")
+if !isempty(nlp_cvx_expr_instances)
+    MINLPTests.test_directory(
+        "nlp-cvx-expr",
+        Optimizer_Uno_ipopt;
+        include = nlp_cvx_expr_instances,
+        primal_target, objective_tol, primal_tol
+    )
+end
 
 # This testset runs the full gamut of MOI.Test.runtests. There are a number of
 # tests in here with weird edge cases, so a variety of exclusions are expected.
@@ -55,7 +88,6 @@ NLP_instances = readlines(joinpath(@__DIR__, "MOI/NLP.txt"))
 instances = vcat(bound_constrained_instances, general_instances)
 instances = intersect(instances, NLP_instances)
 MOI_instances = [Regex("^" * instance * "\$") for instance in instances] # exact match
-MOI_instances = String["test_nonlinear_expression_hs109"]
 #print("Instances: ", instances)
 
 if !isempty(MOI_instances)

--- a/.github/julia/runtests_uno_ipopt_mumps_lbfgs.jl
+++ b/.github/julia/runtests_uno_ipopt_mumps_lbfgs.jl
@@ -22,7 +22,7 @@ function Optimizer(options)
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_Uno_ipopt() = Optimizer(["logger=SILENT", "preset=ipopt", "linear_solver=MUMPS", "hessian_model=LBFGS", "unbounded_objective_threshold=-1e15"])
+Optimizer_Uno_ipopt() = Optimizer(["logger=DEBUG3", "preset=ipopt", "linear_solver=MUMPS", "hessian_model=LBFGS", "unbounded_objective_threshold=-1e15"])
 
 # This testset runs https://github.com/jump-dev/MINLPTests.jl
 
@@ -44,39 +44,6 @@ function strip_prefix(instances, prefix)
     return cleaned_instances
 end
 
-primal_target = Dict(
-    MINLPTests.FEASIBLE_PROBLEM => MOI.FEASIBLE_POINT,
-    # If Uno starts writing a .sol file with an infeasible point, change
-    # this to `=> MOI.INFEASIBLE_POINT`
-    MINLPTests.INFEASIBLE_PROBLEM => MOI.NO_SOLUTION,
-)
-objective_tol = 1e-4
-primal_tol = 1e-4
-
-# This function tests (potentially) non-convex nonlinear programs. The tests
-# are meant to be "easy" in the sense that most NLP solvers can find the
-# same global minimum, but a test failure can sometimes be allowed.
-nlp_expr_instances = strip_prefix(instances, "nlp_expr_")
-if !isempty(nlp_expr_instances)
-    MINLPTests.test_directory(
-        "nlp-expr",
-        Optimizer_Uno_ipopt;
-        include = nlp_expr_instances,
-        primal_target, objective_tol, primal_tol
-    )
-end
-# This function tests convex nonlinear programs. Test failures here should
-# never be allowed, because even local NLP solvers should find the global
-# optimum.
-nlp_cvx_expr_instances = strip_prefix(instances, "nlp_cvx_expr_")
-if !isempty(nlp_cvx_expr_instances)
-    MINLPTests.test_directory(
-        "nlp-cvx-expr",
-        Optimizer_Uno_ipopt;
-        include = nlp_cvx_expr_instances,
-        primal_target, objective_tol, primal_tol
-    )
-end
 
 # This testset runs the full gamut of MOI.Test.runtests. There are a number of
 # tests in here with weird edge cases, so a variety of exclusions are expected.
@@ -88,6 +55,7 @@ NLP_instances = readlines(joinpath(@__DIR__, "MOI/NLP.txt"))
 instances = vcat(bound_constrained_instances, general_instances)
 instances = intersect(instances, NLP_instances)
 MOI_instances = [Regex("^" * instance * "\$") for instance in instances] # exact match
+MOI_instances = String["test_nonlinear_expression_hs109"]
 #print("Instances: ", instances)
 
 if !isempty(MOI_instances)

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -13,7 +13,6 @@
 #include "optimization/OptimizationProblem.hpp"
 #include "options/Options.hpp"
 #include "tools/Logger.hpp"
-#include "tools/Statistics.hpp"
 
 namespace uno {
    ConstraintRelaxationStrategy::ConstraintRelaxationStrategy(const Options& options):

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -36,51 +36,6 @@ namespace uno {
 
    // protected member functions
 
-   void ConstraintRelaxationStrategy::evaluate_progress_measures(const OptimizationProblem& problem, Iterate& iterate,
-         Evaluations& evaluations) const {
-      problem.set_infeasibility_measure(iterate, evaluations, this->progress_norm);
-      problem.set_objective_measure(iterate, evaluations);
-      problem.set_auxiliary_measure(iterate);
-   }
-
-   bool ConstraintRelaxationStrategy::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, Iterate& current_iterate, Iterate& trial_iterate,
-         const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
-      subproblem.problem.postprocess_iterate(trial_iterate);
-      const double objective_multiplier = subproblem.problem.get_objective_multiplier();
-
-      // evaluate progress measures
-      trial_iterate.objective_multiplier = objective_multiplier;
-      //if (this->subproblem_definition_changed) {
-         //DEBUG << "The subproblem definition changed, the globalization strategy is reset and the auxiliary measure is recomputed\n";
-         //globalization_strategy.reset();
-         subproblem.problem.set_auxiliary_measure(current_iterate);
-         //this->subproblem_definition_changed = false;
-      //}
-      this->evaluate_progress_measures(subproblem.problem, trial_iterate, trial_evaluations);
-
-      bool accept_iterate = false;
-      if (direction.norm == 0.) {
-         DEBUG << "Zero step acceptable\n";
-         trial_evaluations.objective = subproblem.problem.model.evaluate_objective(trial_iterate.primals);
-         accept_iterate = true;
-         statistics.set("Status", "0 primal step");
-      }
-      else {
-         // determine acceptance wrt the globalization strategy
-         const ProgressMeasures predicted_reductions = subproblem.compute_predicted_reductions(direction, step_length,
-            this->progress_norm, current_evaluations, solver_workspace);
-         accept_iterate = globalization_strategy.is_iterate_acceptable(statistics, current_iterate.progress, trial_iterate.progress,
-            predicted_reductions, objective_multiplier);
-         // check that the derivatives exist at the accepted trial iterate (an exception is thrown upon evaluation failure)
-         if (accept_iterate) {
-            trial_evaluations.evaluate_objective_gradient(subproblem.problem.model, trial_iterate.primals);
-            trial_evaluations.evaluate_jacobian(subproblem.problem.model, trial_iterate.primals);
-         }
-      }
-      return accept_iterate;
-   }
-
    // stationarity errors:
    // - for KKT conditions: with standard multipliers and current objective multiplier
    // - for FJ conditions: with standard multipliers and 0 objective multiplier

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -17,7 +17,6 @@
 
 namespace uno {
    ConstraintRelaxationStrategy::ConstraintRelaxationStrategy(const Options& options):
-         progress_norm(norm_from_string(options.get_string("progress_norm"))),
          residual_norm(norm_from_string(options.get_string("residual_norm"))),
          residual_scaling_threshold(options.get_double("residual_scaling_threshold")),
          primal_tolerance(options.get_double("primal_tolerance")),

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -38,8 +38,8 @@ namespace uno {
       virtual Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) = 0;
       [[nodiscard]] virtual bool solving_feasibility_problem() const = 0;
-      virtual void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Direction& direction,
-         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) = 0;
+      virtual void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
+         WarmstartInformation& warmstart_information) = 0;
 
       // second-order corrections
       [[nodiscard]] virtual bool has_second_order_corrections() const = 0;
@@ -55,7 +55,6 @@ namespace uno {
       [[nodiscard]] size_t get_number_subproblems_solved() const;
 
    protected:
-      const Norm progress_norm;
       const Norm residual_norm;
       const double residual_scaling_threshold;
       const double primal_tolerance;

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -31,7 +31,7 @@ namespace uno {
       explicit ConstraintRelaxationStrategy(const Options& options);
       virtual ~ConstraintRelaxationStrategy();
 
-      virtual void initialize(Statistics& statistics, const Model& model, Iterate& initial_iterate, bool uses_trust_region,
+      virtual void initialize(Statistics& statistics, Iterate& initial_iterate, bool uses_trust_region,
          EvaluationCache& evaluation_cache, Options& options) = 0;
 
       // direction computation
@@ -67,10 +67,6 @@ namespace uno {
       const double unbounded_objective_threshold;
       size_t number_subproblems_solved{0};
 
-      void evaluate_progress_measures(const OptimizationProblem& problem, Iterate& iterate, Evaluations& evaluations) const;
-      bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy, const Subproblem& subproblem,
-         const SolverWorkspace& solver_workspace, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
-         double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const;
       void compute_residuals(const OptimizationProblem& problem, Iterate& iterate, Evaluations& evaluations) const;
       [[nodiscard]] double compute_stationarity_scaling(const Model& model, const Multipliers& multipliers) const;
       [[nodiscard]] double compute_complementarity_scaling(const Model& model, const Multipliers& multipliers) const;

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -113,8 +113,6 @@ namespace uno {
       this->reference_optimality_primals = current_iterate.primals;
       this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
-      // re-evaluate the progress measures at the current iterate
-      this->feasibility_inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
 
       current_iterate.set_number_variables(this->feasibility_problem.number_variables);
       this->initial_point.resize(this->feasibility_problem.number_variables);
@@ -127,6 +125,8 @@ namespace uno {
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
       this->feasibility_inequality_handling_method->set_elastic_variable_values(this->feasibility_problem, current_iterate,
          current_evaluations);
+      // re-evaluate the progress measures at the current iterate
+      this->feasibility_inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
 
       DEBUG2 << "Current iterate:\n" << current_iterate << '\n';
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -7,13 +7,8 @@
 #include "ingredients/globalization_strategies/GlobalizationStrategy.hpp"
 #include "ingredients/globalization_strategies/GlobalizationStrategyFactory.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
-#include "ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp"
 #include "ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp"
 #include "ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.hpp"
-#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
-#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategyFactory.hpp"
-#include "ingredients/subproblem/Subproblem.hpp"
-#include "ingredients/subproblem_solvers/SubproblemSolverFactory.hpp"
 #include "linear_algebra/View.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
@@ -35,8 +30,6 @@ namespace uno {
          original_problem(model),
          // relax the linear constraints in the l1 relaxed problem only if we are using a trust-region constraint
          feasibility_problem(model, 0., this->constraint_violation_coefficient, use_trust_region),
-         inertia_correction_strategy(InertiaCorrectionStrategyFactory::create(options)),
-         feasibility_inertia_correction_strategy(InertiaCorrectionStrategyFactory::create(options)),
          globalization_strategy(GlobalizationStrategyFactory::create(model, options)),
          feasibility_globalization_strategy(options),
          linear_feasibility_tolerance(options.get_double("primal_tolerance")),
@@ -45,43 +38,27 @@ namespace uno {
 
    FeasibilityRestoration::~FeasibilityRestoration() = default;
 
-   void FeasibilityRestoration::initialize(Statistics& statistics, const Model& model, Iterate& initial_iterate,
-         bool uses_trust_region, EvaluationCache& evaluation_cache, Options& options) {
+   void FeasibilityRestoration::initialize(Statistics& statistics, Iterate& initial_iterate, bool uses_trust_region,
+         EvaluationCache& evaluation_cache, Options& options) {
       this->initial_point.resize(this->original_problem.number_variables);
       this->reference_optimality_primals.resize(this->original_problem.number_variables);
+      this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
 
       // reformulation of the original problem and the feasibility problem
       this->inequality_handling_method = InequalityHandlingMethodFactory::create(this->original_problem, uses_trust_region,
-         options);
+         1., options);
       this->feasibility_inequality_handling_method = InequalityHandlingMethodFactory::create(this->feasibility_problem,
-         uses_trust_region, options);
-      this->reformulated_problem = this->inequality_handling_method->reformulate(this->original_problem, this->parameterization);
-      initial_iterate.set_number_variables(this->reformulated_problem->number_variables);
-      this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
-      this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
-      this->reformulated_feasibility_problem = this->feasibility_inequality_handling_method->reformulate(this->feasibility_problem, this->parameterization);
-
-      // creation of the Hessian models and the subproblem solvers
-      std::tie(this->hessian_model, this->subproblem_solver) = HessianSubproblemSolverJointFactory::create(model,
-         *this->reformulated_problem, initial_iterate, *this->inertia_correction_strategy, uses_trust_region, 1., options);
-      std::tie(this->feasibility_hessian_model, this->feasibility_subproblem_solver) = HessianSubproblemSolverJointFactory::create(model,
-         *this->reformulated_feasibility_problem, initial_iterate, *this->feasibility_inertia_correction_strategy, uses_trust_region,
-         0., options);
+         uses_trust_region, 0., options);
 
       // initial iterate
-      this->reformulated_problem->generate_initial_iterate(initial_iterate, evaluation_cache.current_evaluations);
-      this->evaluate_progress_measures(*this->reformulated_problem, initial_iterate, evaluation_cache.current_evaluations);
+      this->inequality_handling_method->evaluate_progress_measures(initial_iterate, evaluation_cache.current_evaluations);
       this->compute_residuals(this->original_problem, initial_iterate, evaluation_cache.current_evaluations);
       this->globalization_strategy->initialize(statistics, initial_iterate);
       this->feasibility_globalization_strategy.initialize(statistics, initial_iterate);
 
       // statistics
-      this->inertia_correction_strategy->initialize_statistics(statistics);
       this->inequality_handling_method->initialize_statistics(statistics);
-      this->feasibility_inertia_correction_strategy->initialize_statistics(statistics);
       this->feasibility_inequality_handling_method->initialize_statistics(statistics);
-      this->hessian_model->initialize_statistics(statistics);
-      this->feasibility_hessian_model->initialize_statistics(statistics);
       statistics.add_column("Phase", Statistics::int_width - 1, 3);
       statistics.set("Phase", "OPT");
    }
@@ -93,17 +70,16 @@ namespace uno {
       if (this->current_phase == Phase::OPTIMALITY) {
          DEBUG << "Solving the optimality subproblem\n";
          statistics.set("Phase", "OPT");
-         const Subproblem subproblem(*this->reformulated_problem, current_iterate, *this->hessian_model, *this->inertia_correction_strategy);
          this->initial_point.fill(0.);
-         Direction& optimality_direction = this->solve_subproblem(statistics, subproblem, *this->subproblem_solver,
-            this->original_problem, *this->inequality_handling_method, *this->globalization_strategy, current_iterate,
-            trust_region_radius, current_evaluations, warmstart_information);
+         Direction& optimality_direction = this->solve_subproblem(statistics, *this->inequality_handling_method,
+            *this->globalization_strategy, current_iterate, trust_region_radius, current_evaluations, warmstart_information);
          if (optimality_direction.status == SubproblemStatus::INFEASIBLE) {
             // switch to the feasibility problem, starting from the current direction
             statistics.set("Status", std::string("infeasible"));
             DEBUG << "/!\\ The subproblem is infeasible\n";
             this->initial_point = view(optimality_direction.primals, 0, this->original_problem.number_variables);
-            this->switch_to_feasibility_problem(statistics, current_iterate, optimality_direction, current_evaluations, warmstart_information);
+            this->switch_to_feasibility_problem(statistics, current_iterate, optimality_direction, current_evaluations,
+               warmstart_information);
          }
          else {
             warmstart_information.no_changes();
@@ -115,11 +91,9 @@ namespace uno {
       DEBUG << "Solving the feasibility subproblem\n";
       statistics.set("Phase", "FEAS");
       // note: failure of regularization should not happen here, since the feasibility Jacobian has full rank
-      const Subproblem feasibility_subproblem(*this->reformulated_feasibility_problem, current_iterate, *this->feasibility_hessian_model,
-         *this->feasibility_inertia_correction_strategy);
-      Direction& feasibility_direction = this->solve_subproblem(statistics, feasibility_subproblem, *this->feasibility_subproblem_solver,
-         this->feasibility_problem, *this->feasibility_inequality_handling_method, this->feasibility_globalization_strategy,
-         current_iterate, trust_region_radius, current_evaluations, warmstart_information);
+      Direction& feasibility_direction = this->solve_subproblem(statistics, *this->feasibility_inequality_handling_method,
+         this->feasibility_globalization_strategy, current_iterate, trust_region_radius, current_evaluations,
+         warmstart_information);
       return feasibility_direction;
    }
 
@@ -149,7 +123,6 @@ namespace uno {
       this->other_phase_multipliers.upper_bounds.resize(this->feasibility_problem.number_variables);
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
 
-      // TODO pass the parameterization
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
       this->feasibility_inequality_handling_method->set_elastic_variable_values(this->feasibility_problem, current_iterate,
          current_evaluations);
@@ -162,41 +135,35 @@ namespace uno {
 
    bool FeasibilityRestoration::has_second_order_corrections() const {
       if (this->current_phase == Phase::OPTIMALITY) {
-         return this->subproblem_solver->has_second_order_corrections();
+         return this->inequality_handling_method->has_second_order_corrections();
       }
       else {
-         return this->feasibility_subproblem_solver->has_second_order_corrections();
+         return this->feasibility_inequality_handling_method->has_second_order_corrections();
       }
    }
 
    const Direction& FeasibilityRestoration::compute_second_order_correction(Iterate& current_iterate, const Vector<double>& constraints_SOC) {
       if (this->current_phase == Phase::OPTIMALITY) {
-         const Subproblem subproblem(*this->reformulated_problem, current_iterate, *this->hessian_model, *this->inertia_correction_strategy);
-         return this->subproblem_solver->compute_second_order_correction(subproblem, constraints_SOC);
+         return this->inequality_handling_method->compute_second_order_correction(current_iterate, constraints_SOC);
       }
       else {
-         const Subproblem feasibility_subproblem(*this->reformulated_feasibility_problem, current_iterate, *this->feasibility_hessian_model,
-            *this->feasibility_inertia_correction_strategy);
-         return this->feasibility_subproblem_solver->compute_second_order_correction(feasibility_subproblem, constraints_SOC);
+         return this->feasibility_inequality_handling_method->compute_second_order_correction(current_iterate, constraints_SOC);
       }
    }
 
-   Direction& FeasibilityRestoration::solve_subproblem(Statistics& statistics, const Subproblem& subproblem,
-         SubproblemSolver& subproblem_solver, const OptimizationProblem& problem, InequalityHandlingMethod& inequality_handling_method,
-         GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius, Evaluations& current_evaluations,
-         const WarmstartInformation& warmstart_information) {
-      // update the parameterization
-      const bool parameterization_updated = inequality_handling_method.update_parameterization(statistics, problem,
-         current_iterate, this->parameterization);
+   Direction& FeasibilityRestoration::solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
+         GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,
+         Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
       // if the problem definition changed, reset the globalization strategy and recompute the current auxiliary measure
-      if (parameterization_updated) {
+      if (inequality_handling_method.update_parameterization(statistics, current_iterate)) {
          globalization_strategy.reset();
-         subproblem.problem.set_auxiliary_measure(current_iterate);
+         this->inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations); // TODO
       }
-      Direction& direction = subproblem_solver.solve(statistics, subproblem, trust_region_radius, this->initial_point,
+
+      Direction& direction = inequality_handling_method.solve(statistics, current_iterate, trust_region_radius, this->initial_point,
          current_evaluations, warmstart_information);
       ++this->number_subproblems_solved;
-      direction.norm = norm_inf(view(direction.primals, 0, subproblem.problem.get_number_original_variables()));
+      direction.norm = norm_inf(direction.primals); // TODO norm_inf(view(direction.primals, 0, problem.get_number_original_variables()));
       this->initial_point.fill(0.);
       DEBUG3 << direction << '\n';
       return direction;
@@ -240,25 +207,20 @@ namespace uno {
       bool accept_iterate = false;
       // determine acceptability, depending on the current phase
       if (this->current_phase == Phase::OPTIMALITY) {
-         const Subproblem subproblem(*this->reformulated_problem, current_iterate, *this->hessian_model,
-            *this->inertia_correction_strategy);
-         accept_iterate = ConstraintRelaxationStrategy::is_iterate_acceptable(statistics, *this->globalization_strategy,
-            subproblem, this->subproblem_solver->get_workspace(), current_iterate, trial_iterate, direction, step_length,
-            current_evaluations, trial_evaluations);
+         accept_iterate = this->inequality_handling_method->is_iterate_acceptable(statistics, *this->globalization_strategy,
+            current_iterate, trial_iterate, direction, step_length, current_evaluations, trial_evaluations);
          if (uses_trust_region || accept_iterate) {
-            this->hessian_model->notify_trial_iterate(statistics, current_iterate, trial_iterate, current_evaluations,
+            this->inequality_handling_method->notify_trial_iterate(statistics, current_iterate, trial_iterate, current_evaluations,
                trial_evaluations);
          }
       }
       else {
-         const Subproblem feasibility_subproblem(*this->reformulated_feasibility_problem, current_iterate, *this->feasibility_hessian_model,
-            *this->feasibility_inertia_correction_strategy);
-         accept_iterate = ConstraintRelaxationStrategy::is_iterate_acceptable(statistics, this->feasibility_globalization_strategy,
-            feasibility_subproblem, this->feasibility_subproblem_solver->get_workspace(), current_iterate, trial_iterate,
-            direction, step_length, current_evaluations, trial_evaluations);
+         accept_iterate = this->feasibility_inequality_handling_method->is_iterate_acceptable(statistics,
+            this->feasibility_globalization_strategy, current_iterate, trial_iterate, direction, step_length, current_evaluations,
+            trial_evaluations);
          if (uses_trust_region || accept_iterate) {
-            this->feasibility_hessian_model->notify_trial_iterate(statistics, current_iterate, trial_iterate, current_evaluations,
-               trial_evaluations);
+            this->feasibility_inequality_handling_method->notify_trial_iterate(statistics, current_iterate, trial_iterate,
+               current_evaluations, trial_evaluations);
          }
       }
 
@@ -296,9 +258,6 @@ namespace uno {
    }
 
    std::string FeasibilityRestoration::get_name() const {
-      const std::string hessian_model_name = (this->hessian_model != nullptr) ? this->hessian_model->name : "unknown";
-      return this->globalization_strategy->get_name() + " restoration " + this->inequality_handling_method->get_name() +
-         " with " + hessian_model_name + " Hessian and " + this->inertia_correction_strategy->get_name() +
-         " inertia correction";
+      return this->globalization_strategy->get_name() + " restoration " + this->inequality_handling_method->get_name();
    }
 } // namespace

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -158,7 +158,7 @@ namespace uno {
       // if the problem definition changed, reset the globalization strategy and recompute the current auxiliary measure
       if (inequality_handling_method.update_parameterization(statistics, current_iterate)) {
          globalization_strategy.reset();
-         inequality_handling_method.evaluate_progress_measures(current_iterate, current_evaluations); // TODO
+         inequality_handling_method.evaluate_progress_measures(current_iterate, current_evaluations); // TODO auxiliary
       }
 
       Direction& direction = inequality_handling_method.solve(statistics, current_iterate, trust_region_radius, this->initial_point,

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -113,6 +113,8 @@ namespace uno {
       this->reference_optimality_primals = current_iterate.primals;
       this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
+      // re-evaluate the progress measures at the current iterate
+      this->feasibility_inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
 
       current_iterate.set_number_variables(this->feasibility_problem.number_variables);
       this->initial_point.resize(this->feasibility_problem.number_variables);
@@ -156,13 +158,12 @@ namespace uno {
       // if the problem definition changed, reset the globalization strategy and recompute the current auxiliary measure
       if (inequality_handling_method.update_parameterization(statistics, current_iterate)) {
          globalization_strategy.reset();
-         this->inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations); // TODO
+         inequality_handling_method.evaluate_progress_measures(current_iterate, current_evaluations); // TODO
       }
 
       Direction& direction = inequality_handling_method.solve(statistics, current_iterate, trust_region_radius, this->initial_point,
          current_evaluations, warmstart_information);
       ++this->number_subproblems_solved;
-      direction.norm = norm_inf(direction.primals); // TODO norm_inf(view(direction.primals, 0, problem.get_number_original_variables()));
       this->initial_point.fill(0.);
       DEBUG3 << direction << '\n';
       return direction;
@@ -224,8 +225,8 @@ namespace uno {
       }
 
       // possibly go from restoration phase to optimality phase
-      if (this->current_phase == Phase::FEASIBILITY_RESTORATION && accept_iterate &&
-            this->can_switch_to_optimality_phase(model, trial_iterate, direction, step_length, current_evaluations)) {
+      if (this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(model, trial_iterate,
+            direction, step_length, current_evaluations)) {
          this->switch_back_to_optimality_phase(current_iterate, trial_iterate);
          // set a cold start in the subproblem solver
          warmstart_information.whole_problem_changed();

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -225,8 +225,8 @@ namespace uno {
       }
 
       // possibly go from restoration phase to optimality phase
-      if (this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(model, trial_iterate,
-            direction, step_length, current_evaluations)) {
+      if (accept_iterate && this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(model,
+            trial_iterate, direction, step_length, current_evaluations)) {
          this->switch_back_to_optimality_phase(current_iterate, trial_iterate);
          // set a cold start in the subproblem solver
          warmstart_information.whole_problem_changed();

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -224,8 +224,8 @@ namespace uno {
       }
 
       // possibly go from restoration phase to optimality phase
-      if (this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(model, trial_iterate,
-            direction, step_length, current_evaluations)) {
+      if (this->current_phase == Phase::FEASIBILITY_RESTORATION && accept_iterate &&
+            this->can_switch_to_optimality_phase(model, trial_iterate, direction, step_length, current_evaluations)) {
          this->switch_back_to_optimality_phase(current_iterate, trial_iterate);
          // set a cold start in the subproblem solver
          warmstart_information.whole_problem_changed();

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -51,6 +51,7 @@ namespace uno {
          uses_trust_region, 0., options);
 
       // initial iterate
+      this->inequality_handling_method->generate_initial_iterate(initial_iterate, evaluation_cache.current_evaluations);
       this->inequality_handling_method->evaluate_progress_measures(initial_iterate, evaluation_cache.current_evaluations);
       this->compute_residuals(this->original_problem, initial_iterate, evaluation_cache.current_evaluations);
       this->globalization_strategy->initialize(statistics, initial_iterate);
@@ -78,8 +79,7 @@ namespace uno {
             statistics.set("Status", std::string("infeasible"));
             DEBUG << "/!\\ The subproblem is infeasible\n";
             this->initial_point = view(optimality_direction.primals, 0, this->original_problem.number_variables);
-            this->switch_to_feasibility_problem(statistics, current_iterate, optimality_direction, current_evaluations,
-               warmstart_information);
+            this->switch_to_feasibility_problem(statistics, current_iterate, current_evaluations, warmstart_information);
          }
          else {
             warmstart_information.no_changes();
@@ -103,7 +103,7 @@ namespace uno {
 
    // precondition: this->current_phase == Phase::OPTIMALITY
    void FeasibilityRestoration::switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate,
-         Direction& direction, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
+         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
       DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
@@ -115,7 +115,6 @@ namespace uno {
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
 
       current_iterate.set_number_variables(this->feasibility_problem.number_variables);
-      direction.set_dimensions(this->feasibility_problem.number_variables, this->feasibility_problem.number_constraints);
       this->initial_point.resize(this->feasibility_problem.number_variables);
       // swap the iterate's multipliers and the feasibility multipliers maintained by the class
       this->other_phase_multipliers.constraints.resize(this->feasibility_problem.number_constraints);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -34,8 +34,8 @@ namespace uno {
       Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
-      void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Direction& direction,
-         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
+      void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
+         WarmstartInformation& warmstart_information) override;
 
       // second-order corrections
       [[nodiscard]] bool has_second_order_corrections() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -10,7 +10,6 @@
 #include "ingredients/globalization_strategies/MeritFunction.hpp"
 #include "ingredients/globalization_strategies/ProgressMeasures.hpp"
 #include "linear_algebra/Vector.hpp"
-#include "optimization/Parameterization.hpp"
 
 namespace uno {
    // forward declaration

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -27,7 +27,7 @@ namespace uno {
       FeasibilityRestoration(const Model& model, bool use_trust_region, Options& options);
       ~FeasibilityRestoration() override;
 
-      void initialize(Statistics& statistics, const Model& model, Iterate& initial_iterate, bool uses_trust_region,
+      void initialize(Statistics& statistics, Iterate& initial_iterate, bool uses_trust_region,
          EvaluationCache& evaluation_cache, Options& options) override;
 
       // direction computation
@@ -54,20 +54,10 @@ namespace uno {
       const double constraint_violation_coefficient;
       const OptimizationProblem original_problem;
       l1RelaxedProblem feasibility_problem;
-      std::unique_ptr<HessianModel> hessian_model;
-      std::unique_ptr<HessianModel> feasibility_hessian_model;
-      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy;
-      std::unique_ptr<InertiaCorrectionStrategy> feasibility_inertia_correction_strategy;
       std::unique_ptr<InequalityHandlingMethod> inequality_handling_method;
       std::unique_ptr<InequalityHandlingMethod> feasibility_inequality_handling_method;
       std::unique_ptr<GlobalizationStrategy> globalization_strategy;
       MeritFunction feasibility_globalization_strategy;
-
-      std::unique_ptr<OptimizationProblem> reformulated_problem{};
-      std::unique_ptr<OptimizationProblem> reformulated_feasibility_problem{};
-      std::unique_ptr<SubproblemSolver> subproblem_solver{};
-      std::unique_ptr<SubproblemSolver> feasibility_subproblem_solver{};
-      Parameterization parameterization;
       Vector<double> initial_point;
 
       // the class maintains multipliers for the other phase (feasibility multipliers if we are in the optimality phase,
@@ -78,8 +68,7 @@ namespace uno {
       ProgressMeasures reference_optimality_progress{};
       Vector<double> reference_optimality_primals{};
 
-      Direction& solve_subproblem(Statistics& statistics, const Subproblem& subproblem, SubproblemSolver& subproblem_solver,
-         const OptimizationProblem& problem, InequalityHandlingMethod& inequality_handling_method,
+      Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information);
       void switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate);

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -54,7 +54,7 @@ namespace uno {
       // if the problem definition changed, reset the globalization strategy and recompute the current auxiliary measure
       if (parameterization_updated) {
          this->globalization_strategy.reset();
-         this->inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations); // TODO
+         this->inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations); // TODO auxiliary
       }
 
       this->initial_point.fill(0.);

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -37,6 +37,7 @@ namespace uno {
       //initial_iterate.set_number_variables(this->reformulated_problem->number_variables);
 
       // initial iterate
+      this->inequality_handling_method->generate_initial_iterate(initial_iterate, evaluation_cache.current_evaluations);
       this->inequality_handling_method->evaluate_progress_measures(initial_iterate, evaluation_cache.current_evaluations);
       this->compute_residuals(this->original_problem, initial_iterate, evaluation_cache.current_evaluations);
       this->globalization_strategy.initialize(statistics, initial_iterate);
@@ -70,7 +71,7 @@ namespace uno {
    }
 
    void NoRelaxation::switch_to_feasibility_problem(Statistics& /*statistics*/, Iterate& /*current_iterate*/,
-         Direction& /*direction*/, Evaluations& /*current_evaluations*/, WarmstartInformation& /*warmstart_information*/) {
+         Evaluations& /*current_evaluations*/, WarmstartInformation& /*warmstart_information*/) {
       throw std::runtime_error("Switching to the feasibility problem should not happen");
    }
 

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -4,13 +4,9 @@
 #include <memory>
 #include "NoRelaxation.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
-#include "ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp"
 #include "ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp"
 #include "ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.hpp"
-#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
-#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategyFactory.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
-#include "ingredients/subproblem_solvers/SubproblemSolverFactory.hpp"
 #include "linear_algebra/View.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/EvaluationCache.hpp"
@@ -26,53 +22,43 @@ namespace uno {
    NoRelaxation::NoRelaxation(const Model& model, Options& options):
          ConstraintRelaxationStrategy(options),
          original_problem(model),
-         inertia_correction_strategy(InertiaCorrectionStrategyFactory::create(options)),
          globalization_strategy(options) {
    }
 
    NoRelaxation::~NoRelaxation() = default;
 
-   void NoRelaxation::initialize(Statistics& statistics, const Model& model, Iterate& initial_iterate,
-         bool uses_trust_region, EvaluationCache& evaluation_cache, Options& options) {
+   void NoRelaxation::initialize(Statistics& statistics, Iterate& initial_iterate, bool uses_trust_region,
+         EvaluationCache& evaluation_cache, Options& options) {
       this->initial_point.resize(this->original_problem.number_variables);
 
       // reformulation of the original problem
       this->inequality_handling_method = InequalityHandlingMethodFactory::create(this->original_problem, uses_trust_region,
-         options);
-      this->reformulated_problem = this->inequality_handling_method->reformulate(this->original_problem, this->parameterization);
-      initial_iterate.set_number_variables(this->reformulated_problem->number_variables);
-
-      // creation of the Hessian model and the subproblem solver
-      std::tie(this->hessian_model, this->subproblem_solver) = HessianSubproblemSolverJointFactory::create(model, *this->reformulated_problem,
-         initial_iterate, *this->inertia_correction_strategy, uses_trust_region, 1., options);
+         1., options);
+      //initial_iterate.set_number_variables(this->reformulated_problem->number_variables);
 
       // initial iterate
-      this->reformulated_problem->generate_initial_iterate(initial_iterate, evaluation_cache.current_evaluations);
-      this->evaluate_progress_measures(*this->reformulated_problem, initial_iterate, evaluation_cache.current_evaluations);
+      this->inequality_handling_method->evaluate_progress_measures(initial_iterate, evaluation_cache.current_evaluations);
       this->compute_residuals(this->original_problem, initial_iterate, evaluation_cache.current_evaluations);
       this->globalization_strategy.initialize(statistics, initial_iterate);
 
       // statistics
-      this->inertia_correction_strategy->initialize_statistics(statistics);
       this->inequality_handling_method->initialize_statistics(statistics);
-      this->hessian_model->initialize_statistics(statistics);
    }
 
    Direction& NoRelaxation::compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
          double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
       DEBUG << "Solving the subproblem\n";
       const bool parameterization_updated = this->inequality_handling_method->update_parameterization(statistics,
-         this->original_problem, current_iterate, this->parameterization);
-      const Subproblem subproblem(*this->reformulated_problem, current_iterate, *this->hessian_model,
-         *this->inertia_correction_strategy);
+         current_iterate);
       // if the problem definition changed, reset the globalization strategy and recompute the current auxiliary measure
       if (parameterization_updated) {
          this->globalization_strategy.reset();
-         subproblem.problem.set_auxiliary_measure(current_iterate);
+         this->inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations); // TODO
       }
+
       this->initial_point.fill(0.);
-      Direction& direction = this->subproblem_solver->solve(statistics, subproblem, trust_region_radius, this->initial_point,
-         current_evaluations, warmstart_information);
+      Direction& direction = this->inequality_handling_method->solve(statistics, current_iterate, trust_region_radius,
+         this->initial_point, current_evaluations, warmstart_information);
       direction.norm = norm_inf(view(direction.primals, 0, this->original_problem.get_number_original_variables()));
       DEBUG3 << direction << '\n';
       warmstart_information.no_changes();
@@ -89,23 +75,19 @@ namespace uno {
    }
 
    bool NoRelaxation::has_second_order_corrections() const {
-      return this->subproblem_solver->has_second_order_corrections();
+      return this->inequality_handling_method->has_second_order_corrections();
    }
 
    const Direction& NoRelaxation::compute_second_order_correction(Iterate& current_iterate, const Vector<double>& constraints_SOC) {
-      const Subproblem subproblem(*this->reformulated_problem, current_iterate, *this->hessian_model, *this->inertia_correction_strategy);
-      return this->subproblem_solver->compute_second_order_correction(subproblem, constraints_SOC);
+      return this->inequality_handling_method->compute_second_order_correction(current_iterate, constraints_SOC);
    }
 
    bool NoRelaxation::is_iterate_acceptable(Statistics& statistics, const Model& /*model*/, Iterate& current_iterate,
          Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region,
          Evaluations& current_evaluations, Evaluations& trial_evaluations, WarmstartInformation& warmstart_information,
          UserCallbacks& user_callbacks) {
-      const Subproblem subproblem(*this->reformulated_problem, current_iterate, *this->hessian_model,
-         *this->inertia_correction_strategy);
-      const bool accept_iterate = ConstraintRelaxationStrategy::is_iterate_acceptable(statistics, this->globalization_strategy,
-         subproblem, this->subproblem_solver->get_workspace(), current_iterate, trial_iterate, direction, step_length,
-         current_evaluations, trial_evaluations);
+      const bool accept_iterate = this->inequality_handling_method->is_iterate_acceptable(statistics, this->globalization_strategy,
+         current_iterate, trial_iterate, direction, step_length, current_evaluations, trial_evaluations);
       this->compute_residuals(this->original_problem, trial_iterate, trial_evaluations);
       trial_iterate.status = this->check_termination(this->original_problem, trial_iterate, trial_evaluations);
       if (accept_iterate) {
@@ -114,7 +96,7 @@ namespace uno {
             trial_iterate.residuals.stationarity, trial_iterate.residuals.complementarity);
       }
       if (uses_trust_region || accept_iterate) {
-         this->hessian_model->notify_trial_iterate(statistics, current_iterate, trial_iterate, current_evaluations,
+         this->inequality_handling_method->notify_trial_iterate(statistics, current_iterate, trial_iterate, current_evaluations,
             trial_evaluations);
       }
       warmstart_information.no_changes();
@@ -122,8 +104,6 @@ namespace uno {
    }
 
    std::string NoRelaxation::get_name() const {
-      const std::string hessian_model_name = (this->hessian_model != nullptr) ? this->hessian_model->name : "unknown";
-      return this->globalization_strategy.get_name() + " " + this->inequality_handling_method->get_name() + " with " +
-         hessian_model_name + " Hessian and " + this->inertia_correction_strategy->get_name() + " inertia correction";
+      return this->globalization_strategy.get_name() + " " + this->inequality_handling_method->get_name();
    }
 } // namespace

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -60,7 +60,6 @@ namespace uno {
       this->initial_point.fill(0.);
       Direction& direction = this->inequality_handling_method->solve(statistics, current_iterate, trust_region_radius,
          this->initial_point, current_evaluations, warmstart_information);
-      direction.norm = norm_inf(view(direction.primals, 0, this->original_problem.get_number_original_variables()));
       DEBUG3 << direction << '\n';
       warmstart_information.no_changes();
       return direction;

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -8,7 +8,6 @@
 #include "ConstraintRelaxationStrategy.hpp"
 #include "ingredients/globalization_strategies/MeritFunction.hpp"
 #include "optimization/OptimizationProblem.hpp"
-#include "optimization/Parameterization.hpp"
 
 namespace uno {
    // forward declarations

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -13,17 +13,14 @@
 namespace uno {
    // forward declarations
    class Direction;
-   class HessianModel;
    class InequalityHandlingMethod;
-   class InertiaCorrectionStrategy;
-   class SubproblemSolver;
 
    class NoRelaxation : public ConstraintRelaxationStrategy {
    public:
       NoRelaxation(const Model& model, Options& options);
       ~NoRelaxation() override;
 
-      void initialize(Statistics& statistics, const Model& model, Iterate& initial_iterate, bool uses_trust_region,
+      void initialize(Statistics& statistics, Iterate& initial_iterate, bool uses_trust_region,
          EvaluationCache& evaluation_cache, Options& options) override;
 
       // direction computation
@@ -48,12 +45,7 @@ namespace uno {
    private:
       const OptimizationProblem original_problem;
       std::unique_ptr<InequalityHandlingMethod> inequality_handling_method;
-      std::unique_ptr<HessianModel> hessian_model;
-      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy;
       MeritFunction globalization_strategy;
-      std::unique_ptr<OptimizationProblem> reformulated_problem{};
-      std::unique_ptr<SubproblemSolver> subproblem_solver{};
-      Parameterization parameterization;
       Vector<double> initial_point;
    };
 } // namespace

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -27,8 +27,8 @@ namespace uno {
       Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
          double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
-      void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Direction& direction,
-         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
+      void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
+         WarmstartInformation& warmstart_information) override;
 
       // second-order corrections
       [[nodiscard]] bool has_second_order_corrections() const override;

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -64,7 +64,7 @@ namespace uno {
       // if the inertia correction failed, switch to solving the feasibility problem
       catch (const UnstableInertiaCorrection&) {
          this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate,
-               evaluation_cache.current_evaluations, warmstart_information);
+            evaluation_cache.current_evaluations, warmstart_information);
       }
 
       // solve the feasibility problem

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -57,14 +57,14 @@ namespace uno {
             if (this->constraint_relaxation_strategy->solving_feasibility_problem() || !model.is_constrained()) {
                throw std::runtime_error("The line search failed");
             }
-            this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate, direction,
+            this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate,
                evaluation_cache.current_evaluations, warmstart_information);
          }
       }
       // if the inertia correction failed, switch to solving the feasibility problem
       catch (const UnstableInertiaCorrection&) {
-         // TODO this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate, direction,
-         //   evaluation_cache.current_evaluations, warmstart_information);
+         this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate,
+               evaluation_cache.current_evaluations, warmstart_information);
       }
 
       // solve the feasibility problem

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -30,7 +30,7 @@ namespace uno {
 
    void BacktrackingLineSearch::initialize(Statistics& statistics, const Model& model, Iterate& current_iterate,
          EvaluationCache& evaluation_cache, Options& options) {
-      this->constraint_relaxation_strategy->initialize(statistics, model, current_iterate, false, evaluation_cache, options);
+      this->constraint_relaxation_strategy->initialize(statistics, current_iterate, false, evaluation_cache, options);
       statistics.add_column("Minor", Statistics::int_width, 3);
       statistics.add_column("Steplength", Statistics::double_width + 1, 2);
       GlobalizationMechanism::set_primal_statistics(statistics, model, current_iterate, evaluation_cache.current_evaluations);

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -34,7 +34,7 @@ namespace uno {
 
    void TrustRegionStrategy::initialize(Statistics& statistics, const Model& model, Iterate& current_iterate,
          EvaluationCache& evaluation_cache, Options& options) {
-      this->constraint_relaxation_strategy->initialize(statistics, model, current_iterate, true, evaluation_cache, options);
+      this->constraint_relaxation_strategy->initialize(statistics, current_iterate, true, evaluation_cache, options);
       statistics.add_column("Minor", Statistics::int_width, 3);
       statistics.add_column("Radius", Statistics::double_width, 2);
       statistics.set("Radius", this->radius);

--- a/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.cpp
+++ b/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.cpp
@@ -19,17 +19,18 @@
 #include "tools/Logger.hpp"
 
 namespace uno {
-   std::pair<std::unique_ptr<HessianModel>, std::unique_ptr<SubproblemSolver>> HessianSubproblemSolverJointFactory::create(const Model& model,
-         const OptimizationProblem& problem, Iterate& current_iterate, InertiaCorrectionStrategy& inertia_correction_strategy,
-         bool uses_trust_region, double objective_multiplier, Options& options) {
+   std::tuple<std::unique_ptr<HessianModel>, Subproblem, std::unique_ptr<SubproblemSolver>> HessianSubproblemSolverJointFactory::create(const OptimizationProblem& problem,
+         InertiaCorrectionStrategy& inertia_correction_strategy, bool uses_trust_region, double objective_multiplier, Options& options) {
+      const Model& model = problem.model;
+
       // first look at the problem type. If it is an LP, pick zero Hessian model
       if (model.get_problem_type() == ProblemType::LINEAR) {
          // override user defined option
          options.set_string("hessian_model", "zero", true);
          auto hessian_model = std::make_unique<ZeroHessian>(model.number_variables);
-         auto subproblem_solver = SubproblemSolverFactory::create(problem, current_iterate, *hessian_model,
-            inertia_correction_strategy, uses_trust_region, options);
-         return {std::move(hessian_model), std::move(subproblem_solver)};
+         Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+         auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
+         return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
       }
 
       // then look at the option hessian_model
@@ -39,9 +40,9 @@ namespace uno {
       if (hessian_model_type == "exact") {
          if (model.has_hessian_matrix() || model.has_hessian_operator()) {
             auto hessian_model = std::make_unique<ExactHessian>(model);
-            auto subproblem_solver = SubproblemSolverFactory::create(problem, current_iterate, *hessian_model,
-               inertia_correction_strategy, uses_trust_region, options);
-            return {std::move(hessian_model), std::move(subproblem_solver)};
+            Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+            auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
+            return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
          }
          else {
             // no Hessian (matrix or operator) is available: pick a quasi-Newton Hessian (L-BFGS for line search, L-SR1
@@ -58,34 +59,34 @@ namespace uno {
          }
          if (0 < model.number_constraints || model.has_bound_constraints() || uses_trust_region) { // constrained
             auto hessian_model = std::make_unique<LBFGSHessian>(model, objective_multiplier, options);
-            auto subproblem_solver = SubproblemSolverFactory::create(problem, current_iterate, *hessian_model,
-               inertia_correction_strategy, uses_trust_region, options);
-            return {std::move(hessian_model), std::move(subproblem_solver)};
+            Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+            auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
+            return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
          }
          else { // unconstrained
             auto hessian_model = std::make_unique<InverseLBFGSHessian>(model, options);
-            auto subproblem_solver = SubproblemSolverFactory::create(problem, current_iterate, *hessian_model,
-               inertia_correction_strategy, uses_trust_region, options);
-            return {std::move(hessian_model), std::move(subproblem_solver)};
+            Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+            auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
+            return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
          }
       }
       else if (hessian_model_type == "LSR1") {
          auto hessian_model = std::make_unique<LSR1Hessian>(model, objective_multiplier, options);
-         auto subproblem_solver = SubproblemSolverFactory::create(problem, current_iterate, *hessian_model,
-            inertia_correction_strategy, uses_trust_region, options);
-         return {std::move(hessian_model), std::move(subproblem_solver)};
+         Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+         auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
+         return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
       }
       else if (hessian_model_type == "identity") {
          auto hessian_model = std::make_unique<IdentityHessian>(model.number_variables);
-         auto subproblem_solver = SubproblemSolverFactory::create(problem, current_iterate, *hessian_model,
-            inertia_correction_strategy, uses_trust_region, options);
-         return {std::move(hessian_model), std::move(subproblem_solver)};
+         Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+         auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
+         return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
       }
       else if (hessian_model_type == "zero") {
          auto hessian_model = std::make_unique<ZeroHessian>(model.number_variables);
-         auto subproblem_solver = SubproblemSolverFactory::create(problem, current_iterate, *hessian_model,
-            inertia_correction_strategy, uses_trust_region, options);
-         return {std::move(hessian_model), std::move(subproblem_solver)};
+         Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+         auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
+         return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
       }
       throw std::invalid_argument("Hessian model " + hessian_model_type + " does not exist");
    }

--- a/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.cpp
+++ b/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.cpp
@@ -12,6 +12,8 @@
 #include "quasi_newton/direct/LSR1Hessian.hpp"
 #include "IdentityHessian.hpp"
 #include "ZeroHessian.hpp"
+#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
+#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategyFactory.hpp"
 #include "ingredients/subproblem_solvers/SubproblemSolver.hpp"
 #include "ingredients/subproblem_solvers/SubproblemSolverFactory.hpp"
 #include "model/Model.hpp"
@@ -19,18 +21,19 @@
 #include "tools/Logger.hpp"
 
 namespace uno {
-   std::tuple<std::unique_ptr<HessianModel>, Subproblem, std::unique_ptr<SubproblemSolver>> HessianSubproblemSolverJointFactory::create(const OptimizationProblem& problem,
-         InertiaCorrectionStrategy& inertia_correction_strategy, bool uses_trust_region, double objective_multiplier, Options& options) {
+   Ingredients HessianSubproblemSolverJointFactory::create(const OptimizationProblem& problem, bool uses_trust_region,
+         double objective_multiplier, Options& options) {
       const Model& model = problem.model;
+      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy = InertiaCorrectionStrategyFactory::create(options);
 
       // first look at the problem type. If it is an LP, pick zero Hessian model
       if (model.get_problem_type() == ProblemType::LINEAR) {
          // override user defined option
          options.set_string("hessian_model", "zero", true);
          auto hessian_model = std::make_unique<ZeroHessian>(model.number_variables);
-         Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+         Subproblem subproblem{problem, *hessian_model, *inertia_correction_strategy};
          auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
-         return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
+         return {std::move(inertia_correction_strategy), std::move(hessian_model), std::move(subproblem_solver)};
       }
 
       // then look at the option hessian_model
@@ -40,9 +43,9 @@ namespace uno {
       if (hessian_model_type == "exact") {
          if (model.has_hessian_matrix() || model.has_hessian_operator()) {
             auto hessian_model = std::make_unique<ExactHessian>(model);
-            Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+            Subproblem subproblem{problem, *hessian_model, *inertia_correction_strategy};
             auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
-            return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
+            return {std::move(inertia_correction_strategy), std::move(hessian_model), std::move(subproblem_solver)};
          }
          else {
             // no Hessian (matrix or operator) is available: pick a quasi-Newton Hessian (L-BFGS for line search, L-SR1
@@ -59,34 +62,34 @@ namespace uno {
          }
          if (0 < model.number_constraints || model.has_bound_constraints() || uses_trust_region) { // constrained
             auto hessian_model = std::make_unique<LBFGSHessian>(model, objective_multiplier, options);
-            Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+            Subproblem subproblem{problem, *hessian_model, *inertia_correction_strategy};
             auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
-            return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
+            return {std::move(inertia_correction_strategy), std::move(hessian_model), std::move(subproblem_solver)};
          }
          else { // unconstrained
             auto hessian_model = std::make_unique<InverseLBFGSHessian>(model, options);
-            Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+            Subproblem subproblem{problem, *hessian_model, *inertia_correction_strategy};
             auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
-            return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
+            return {std::move(inertia_correction_strategy), std::move(hessian_model), std::move(subproblem_solver)};
          }
       }
       else if (hessian_model_type == "LSR1") {
          auto hessian_model = std::make_unique<LSR1Hessian>(model, objective_multiplier, options);
-         Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+         Subproblem subproblem{problem, *hessian_model, *inertia_correction_strategy};
          auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
-         return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
+         return {std::move(inertia_correction_strategy), std::move(hessian_model), std::move(subproblem_solver)};
       }
       else if (hessian_model_type == "identity") {
          auto hessian_model = std::make_unique<IdentityHessian>(model.number_variables);
-         Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+         Subproblem subproblem{problem, *hessian_model, *inertia_correction_strategy};
          auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
-         return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
+         return {std::move(inertia_correction_strategy), std::move(hessian_model), std::move(subproblem_solver)};
       }
       else if (hessian_model_type == "zero") {
          auto hessian_model = std::make_unique<ZeroHessian>(model.number_variables);
-         Subproblem subproblem{problem, *hessian_model, inertia_correction_strategy};
+         Subproblem subproblem{problem, *hessian_model, *inertia_correction_strategy};
          auto subproblem_solver = SubproblemSolverFactory::create(*hessian_model, subproblem, uses_trust_region, options);
-         return {std::move(hessian_model), subproblem, std::move(subproblem_solver)};
+         return {std::move(inertia_correction_strategy), std::move(hessian_model), std::move(subproblem_solver)};
       }
       throw std::invalid_argument("Hessian model " + hessian_model_type + " does not exist");
    }

--- a/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.cpp
+++ b/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.cpp
@@ -14,7 +14,6 @@
 #include "ZeroHessian.hpp"
 #include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
 #include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategyFactory.hpp"
-#include "ingredients/subproblem_solvers/SubproblemSolver.hpp"
 #include "ingredients/subproblem_solvers/SubproblemSolverFactory.hpp"
 #include "model/Model.hpp"
 #include "options/Options.hpp"

--- a/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp
+++ b/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp
@@ -6,24 +6,22 @@
 
 #include <array>
 #include <memory>
-#include <utility>
+#include <tuple>
+#include "ingredients/subproblem/Subproblem.hpp"
 
 namespace uno {
    // forward declarations
    class HessianModel;
    class InertiaCorrectionStrategy;
-   class Iterate;
-   class Model;
    class OptimizationProblem;
    class Options;
    class SubproblemSolver;
 
    class HessianSubproblemSolverJointFactory {
    public:
-      // joint factory of Hessian models and subproblem solvers
-      static std::pair<std::unique_ptr<HessianModel>, std::unique_ptr<SubproblemSolver>> create(const Model& model,
-         const OptimizationProblem& problem, Iterate& current_iterate, InertiaCorrectionStrategy& inertia_correction_strategy,
-         bool uses_trust_region, double objective_multiplier, Options& options);
+      // joint factory of Hessian models, subproblem, and subproblem solvers
+      static std::tuple<std::unique_ptr<HessianModel>, Subproblem, std::unique_ptr<SubproblemSolver>> create(const OptimizationProblem& problem,
+         InertiaCorrectionStrategy& inertia_correction_strategy, bool uses_trust_region, double objective_multiplier, Options& options);
 
       constexpr static std::array available_strategies{"exact", "LFBGS", "LSR1", "identity", "zero"};
    };

--- a/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp
+++ b/uno/ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp
@@ -7,7 +7,6 @@
 #include <array>
 #include <memory>
 #include <tuple>
-#include "ingredients/subproblem/Subproblem.hpp"
 
 namespace uno {
    // forward declarations
@@ -17,11 +16,16 @@ namespace uno {
    class Options;
    class SubproblemSolver;
 
+   using Ingredients = std::tuple<std::unique_ptr<InertiaCorrectionStrategy>,
+                                  std::unique_ptr<HessianModel>,
+                                  std::unique_ptr<SubproblemSolver>
+                                 >;
+
    class HessianSubproblemSolverJointFactory {
    public:
-      // joint factory of Hessian models, subproblem, and subproblem solvers
-      static std::tuple<std::unique_ptr<HessianModel>, Subproblem, std::unique_ptr<SubproblemSolver>> create(const OptimizationProblem& problem,
-         InertiaCorrectionStrategy& inertia_correction_strategy, bool uses_trust_region, double objective_multiplier, Options& options);
+      // joint factory of inertia correction strategy, Hessian models, and subproblem solver
+      static Ingredients create(const OptimizationProblem& problem, bool uses_trust_region, double objective_multiplier,
+         Options& options);
 
       constexpr static std::array available_strategies{"exact", "LFBGS", "LSR1", "identity", "zero"};
    };

--- a/uno/ingredients/hessian_models/quasi_newton/QuasiNewtonHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/QuasiNewtonHessian.cpp
@@ -3,7 +3,6 @@
 
 #include "QuasiNewtonHessian.hpp"
 #include "model/Model.hpp"
-#include "optimization/EvaluationCache.hpp"
 #include "optimization/Iterate.hpp"
 #include "options/Options.hpp"
 #include "symbolic/Range.hpp"

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
@@ -7,18 +7,32 @@
 #include "optimization/Direction.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
+#include "options/Options.hpp"
 #include "tools/Logger.hpp"
 #include "tools/Statistics.hpp"
 
 namespace uno {
+   InequalityHandlingMethod::InequalityHandlingMethod(const OptimizationProblem& problem, const Options& options):
+         problem(problem), progress_norm(norm_from_string(options.get_string("progress_norm"))) {
+   }
+
+   // protected member functions
+
+   void InequalityHandlingMethod::evaluate_progress_measures(const OptimizationProblem& problem, Iterate& iterate,
+         Evaluations& evaluations) const {
+      problem.set_infeasibility_measure(iterate, evaluations, this->progress_norm);
+      problem.set_objective_measure(iterate, evaluations);
+      problem.set_auxiliary_measure(iterate);
+   }
+
    bool InequalityHandlingMethod::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          const Subproblem& subproblem, const SolverWorkspace& solver_workspace, Iterate& current_iterate, Iterate& trial_iterate,
          const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
-      this->problem.postprocess_iterate(trial_iterate);
+      subproblem.problem.postprocess_iterate(trial_iterate);
       const double objective_multiplier = subproblem.problem.get_objective_multiplier();
 
       // evaluate progress measures
-      this->evaluate_progress_measures(trial_iterate, trial_evaluations);
+      evaluate_progress_measures(subproblem.problem, trial_iterate, trial_evaluations);
       trial_iterate.objective_multiplier = objective_multiplier;
 
       bool accept_iterate = false;
@@ -30,9 +44,8 @@ namespace uno {
       }
       else {
          // determine acceptance wrt the globalization strategy
-         Norm progress_norm = Norm::L1;
          const ProgressMeasures predicted_reductions = subproblem.compute_predicted_reductions(current_iterate, direction,
-            step_length, progress_norm, current_evaluations, solver_workspace);
+            step_length, this->progress_norm, current_evaluations, solver_workspace);
          accept_iterate = globalization_strategy.is_iterate_acceptable(statistics, current_iterate.progress, trial_iterate.progress,
             predicted_reductions, objective_multiplier);
          // check that the derivatives exist at the accepted trial iterate (an exception is thrown upon evaluation failure)
@@ -42,12 +55,5 @@ namespace uno {
          }
       }
       return accept_iterate;
-   }
-
-   void InequalityHandlingMethod::evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const {
-      Norm progress_norm = Norm::L1;
-      this->problem.set_infeasibility_measure(iterate, evaluations, progress_norm);
-      this->problem.set_objective_measure(iterate, evaluations);
-      this->problem.set_auxiliary_measure(iterate);
    }
 } // namespace

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#include "InequalityHandlingMethod.hpp"
+#include "ingredients/globalization_strategies/GlobalizationStrategy.hpp"
+#include "ingredients/subproblem/Subproblem.hpp"
+#include "optimization/Direction.hpp"
+#include "optimization/Evaluations.hpp"
+#include "optimization/Iterate.hpp"
+#include "tools/Logger.hpp"
+#include "tools/Statistics.hpp"
+
+namespace uno {
+   bool InequalityHandlingMethod::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
+         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, Iterate& current_iterate, Iterate& trial_iterate,
+         const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
+      this->problem.postprocess_iterate(trial_iterate);
+      const double objective_multiplier = subproblem.problem.get_objective_multiplier();
+
+      // evaluate progress measures
+      this->evaluate_progress_measures(trial_iterate, trial_evaluations);
+      trial_iterate.objective_multiplier = objective_multiplier;
+
+      bool accept_iterate = false;
+      if (direction.norm == 0.) {
+         DEBUG << "Zero step acceptable\n";
+         trial_evaluations.objective = this->problem.model.evaluate_objective(trial_iterate.primals);
+         accept_iterate = true;
+         statistics.set("Status", "0 primal step");
+      }
+      else {
+         // determine acceptance wrt the globalization strategy
+         Norm progress_norm = Norm::L1;
+         const ProgressMeasures predicted_reductions = subproblem.compute_predicted_reductions(current_iterate, direction,
+            step_length, progress_norm, current_evaluations, solver_workspace);
+         accept_iterate = globalization_strategy.is_iterate_acceptable(statistics, current_iterate.progress, trial_iterate.progress,
+            predicted_reductions, objective_multiplier);
+         // check that the derivatives exist at the accepted trial iterate (an exception is thrown upon evaluation failure)
+         if (accept_iterate) {
+            trial_evaluations.evaluate_objective_gradient(this->problem.model, trial_iterate.primals);
+            trial_evaluations.evaluate_jacobian(this->problem.model, trial_iterate.primals);
+         }
+      }
+      return accept_iterate;
+   }
+
+   void InequalityHandlingMethod::evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const {
+      Norm progress_norm = Norm::L1;
+      this->problem.set_infeasibility_measure(iterate, evaluations, progress_norm);
+      this->problem.set_objective_measure(iterate, evaluations);
+      this->problem.set_auxiliary_measure(iterate);
+   }
+} // namespace

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
@@ -26,7 +26,7 @@ namespace uno {
    }
 
    bool InequalityHandlingMethod::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, Iterate& current_iterate, Iterate& trial_iterate,
+         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, const Iterate& current_iterate, Iterate& trial_iterate,
          const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
       subproblem.problem.postprocess_iterate(trial_iterate);
       const double objective_multiplier = subproblem.problem.get_objective_multiplier();

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include "linear_algebra/Norm.hpp"
 
 namespace uno {
    // forward declarations
@@ -15,7 +16,7 @@ namespace uno {
    class Iterate;
    class l1RelaxedProblem;
    class OptimizationProblem;
-   class Parameterization;
+   class Options;
    class Statistics;
    class SolverWorkspace;
    class Subproblem;
@@ -25,9 +26,10 @@ namespace uno {
    
    class InequalityHandlingMethod {
    public:
-      InequalityHandlingMethod(const OptimizationProblem& problem): problem(problem) { }
+      InequalityHandlingMethod(const OptimizationProblem& problem, const Options& options);
       virtual ~InequalityHandlingMethod() = default;
 
+      virtual void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const = 0;
       virtual void initialize_statistics(Statistics& statistics) = 0;
       [[nodiscard]] virtual bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) = 0;
       [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
@@ -41,7 +43,7 @@ namespace uno {
       [[nodiscard]] virtual const Direction& compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) = 0;
 
-      void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const;
+      virtual void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const = 0;
       [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) const = 0;
@@ -52,7 +54,9 @@ namespace uno {
 
    protected:
       const OptimizationProblem& problem;
+      const Norm progress_norm;
 
+      void evaluate_progress_measures(const OptimizationProblem& problem, Iterate& iterate, Evaluations& evaluations) const;
       bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          const Subproblem& subproblem, const SolverWorkspace& solver_workspace, Iterate& current_iterate, Iterate& trial_iterate,
          const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const;

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -58,7 +58,7 @@ namespace uno {
 
       void evaluate_progress_measures(const OptimizationProblem& problem, Iterate& iterate, Evaluations& evaluations) const;
       bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, Iterate& current_iterate, Iterate& trial_iterate,
+         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, const Iterate& current_iterate, Iterate& trial_iterate,
          const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const;
    };
 } // namespace

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -9,29 +9,53 @@
 
 namespace uno {
    // forward declarations
+   class Direction;
    class Evaluations;
+   class GlobalizationStrategy;
    class Iterate;
    class l1RelaxedProblem;
    class OptimizationProblem;
    class Parameterization;
    class Statistics;
+   class SolverWorkspace;
+   class Subproblem;
+   template <typename T>
+   class Vector;
+   class WarmstartInformation;
    
    class InequalityHandlingMethod {
    public:
-      InequalityHandlingMethod() = default;
+      InequalityHandlingMethod(const OptimizationProblem& problem): problem(problem) { }
       virtual ~InequalityHandlingMethod() = default;
 
       virtual void initialize_statistics(Statistics& statistics) = 0;
-      [[nodiscard]] virtual std::unique_ptr<OptimizationProblem> reformulate(const OptimizationProblem& problem,
-         Parameterization& parameterization) = 0;
-      [[nodiscard]] virtual bool update_parameterization(Statistics& statistics, const OptimizationProblem& problem,
-         const Iterate& current_iterate, Parameterization& parameterization) = 0;
+      [[nodiscard]] virtual bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) = 0;
+      [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
+         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) = 0;
 
       virtual void initialize_feasibility_problem(Iterate& current_iterate) = 0;
       virtual void set_elastic_variable_values(const l1RelaxedProblem& problem, Iterate& current_iterate, Evaluations& evaluations) = 0;
       [[nodiscard]] virtual double proximal_coefficient() const = 0;
 
+      [[nodiscard]] virtual bool has_second_order_corrections() const = 0;
+      [[nodiscard]] virtual const Direction& compute_second_order_correction(const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) = 0;
+
+      void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const;
+      [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
+         Evaluations& current_evaluations, Evaluations& trial_evaluations) const = 0;
+      virtual void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
+         Evaluations& current_evaluations, Evaluations& trial_evaluations) = 0;
+
       [[nodiscard]] virtual std::string get_name() const = 0;
+
+   protected:
+      const OptimizationProblem& problem;
+
+      bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
+         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, Iterate& current_iterate, Iterate& trial_iterate,
+         const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const;
    };
 } // namespace
 

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.cpp
@@ -41,7 +41,8 @@ namespace uno {
       else if (inequality_handling_method == "interior_point") {
          const std::string barrier_function = options.get_string("barrier_function");
          if (barrier_function == "log") {
-            return std::make_unique<InteriorPointMethod<PrimalDualInteriorPointProblem>>(problem, options);
+            return std::make_unique<InteriorPointMethod<PrimalDualInteriorPointProblem>>(problem, uses_trust_region,
+               objective_multiplier, options);
          }
          else {
             throw std::invalid_argument("The barrier function " + barrier_function + " is not supported");

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.cpp
@@ -14,17 +14,19 @@
 
 namespace uno {
    std::unique_ptr<InequalityHandlingMethod> InequalityHandlingMethodFactory::create(const OptimizationProblem& problem,
-         bool uses_trust_region, const Options& options) {
+         bool uses_trust_region, double objective_multiplier, Options& options) {
       // figure out whether there are inequality constraints altogether
       if (!problem.has_inequality_constraints() && !problem.has_bound_constraints() && !uses_trust_region) {
          // no reformulation
          if (0 < problem.number_constraints) {
             INFO << "The problem has no inequalities, picking a pure SQP method\n";
-            return std::make_unique<NoInequalityReformulation>("pure SQP method");
+            return std::make_unique<NoInequalityReformulation>("pure SQP method", problem, uses_trust_region,
+               objective_multiplier, options);
          }
          else {
             INFO << "The problem has no constraints, picking a pure Newton method\n";
-            return std::make_unique<NoInequalityReformulation>("pure Newton method");
+            return std::make_unique<NoInequalityReformulation>("pure Newton method", problem, uses_trust_region,
+               objective_multiplier, options);
          }
       }
       // from now on, the problem has inequalities
@@ -32,13 +34,14 @@ namespace uno {
       // inequality-constrained methods
       if (inequality_handling_method == "inequality_constrained") {
          // no inequality reformulation: let the subproblem solver handle them
-         return std::make_unique<NoInequalityReformulation>("inequality-constrained SQP method");
+         return std::make_unique<NoInequalityReformulation>("inequality-constrained SQP method", problem, uses_trust_region,
+            objective_multiplier, options);
       }
       // interior-point method
       else if (inequality_handling_method == "interior_point") {
          const std::string barrier_function = options.get_string("barrier_function");
          if (barrier_function == "log") {
-            return std::make_unique<InteriorPointMethod<PrimalDualInteriorPointProblem>>(options);
+            return std::make_unique<InteriorPointMethod<PrimalDualInteriorPointProblem>>(problem, options);
          }
          else {
             throw std::invalid_argument("The barrier function " + barrier_function + " is not supported");

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.hpp
@@ -16,7 +16,7 @@ namespace uno {
    class InequalityHandlingMethodFactory {
       public:
          static std::unique_ptr<InequalityHandlingMethod> create(const OptimizationProblem& problem, bool uses_trust_region,
-            const Options& options);
+            double objective_multiplier, Options& options);
 
          static std::vector<std::string> available_strategies();
    };

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -5,34 +5,21 @@
 #include "optimization/Iterate.hpp"
 #include "ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
-#include "ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp"
 #include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
-#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategyFactory.hpp"
 #include "ingredients/subproblem_solvers/SubproblemSolver.hpp"
 
 namespace uno {
    NoInequalityReformulation::NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
-      bool uses_trust_region, double objective_multiplier, Options& options):
-            NoInequalityReformulation(std::move(name), problem, InertiaCorrectionStrategyFactory::create(options),
-               uses_trust_region, objective_multiplier, options) {
+         bool uses_trust_region, double objective_multiplier, Options& options):
+      InequalityHandlingMethod(problem, options), name(std::move(name)) {
+      // create the ingredients
+      std::tie(this->inertia_correction_strategy, this->hessian_model, this->subproblem_solver) =
+         HessianSubproblemSolverJointFactory::create(this->problem, uses_trust_region, objective_multiplier, options);
+      this->subproblem = std::make_unique<Subproblem>(this->problem, *this->hessian_model, *this->inertia_correction_strategy);
    }
 
-   NoInequalityReformulation::NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
-      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy, bool uses_trust_region, double objective_multiplier,
-      Options& options):
-         NoInequalityReformulation(std::move(name), problem, std::move(inertia_correction_strategy),
-            HessianSubproblemSolverJointFactory::create(problem, *inertia_correction_strategy, uses_trust_region,
-            objective_multiplier, options)) {
-   }
-
-   NoInequalityReformulation::NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
-      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy,
-      std::tuple<std::unique_ptr<HessianModel>, Subproblem, std::unique_ptr<SubproblemSolver>> ingredients):
-         InequalityHandlingMethod(problem), name(std::move(name)),
-         inertia_correction_strategy(std::move(inertia_correction_strategy)),
-         hessian_model(std::move(std::get<0>(ingredients))),
-         subproblem(std::move(std::get<1>(ingredients))),
-         subproblem_solver(std::move(std::get<2>(ingredients))) {
+   void NoInequalityReformulation::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
+      this->problem.generate_initial_iterate(initial_iterate, evaluations);
    }
 
    void NoInequalityReformulation::initialize_statistics(Statistics& statistics) {
@@ -47,7 +34,7 @@ namespace uno {
 
    Direction& NoInequalityReformulation::solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
          const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
-      return this->subproblem_solver->solve(statistics, this->subproblem, current_iterate, trust_region_radius, initial_point,
+      return this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius, initial_point,
          current_evaluations, warmstart_information);
    }
 
@@ -76,13 +63,17 @@ namespace uno {
 
    const Direction& NoInequalityReformulation::compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) {
-      return this->subproblem_solver->compute_second_order_correction(this->subproblem, current_iterate, constraints_SOC);
+      return this->subproblem_solver->compute_second_order_correction(*this->subproblem, current_iterate, constraints_SOC);
+   }
+
+   void NoInequalityReformulation::evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const {
+      InequalityHandlingMethod::evaluate_progress_measures(this->problem, iterate, evaluations);
    }
 
    bool NoInequalityReformulation::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
-      return InequalityHandlingMethod::is_iterate_acceptable(statistics, globalization_strategy, this->subproblem,
+      return InequalityHandlingMethod::is_iterate_acceptable(statistics, globalization_strategy, *this->subproblem,
          this->subproblem_solver->get_workspace(), current_iterate, trial_iterate, direction, step_length, current_evaluations,
          trial_evaluations);
    }

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -4,24 +4,51 @@
 #include "NoInequalityReformulation.hpp"
 #include "optimization/Iterate.hpp"
 #include "ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp"
+#include "ingredients/hessian_models/HessianModel.hpp"
+#include "ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp"
+#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
+#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategyFactory.hpp"
+#include "ingredients/subproblem_solvers/SubproblemSolver.hpp"
 
 namespace uno {
-   NoInequalityReformulation::NoInequalityReformulation(std::string name): name(std::move(name)) {
+   NoInequalityReformulation::NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
+      bool uses_trust_region, double objective_multiplier, Options& options):
+            NoInequalityReformulation(std::move(name), problem, InertiaCorrectionStrategyFactory::create(options),
+               uses_trust_region, objective_multiplier, options) {
    }
 
-   void NoInequalityReformulation::initialize_statistics(Statistics& /*statistics*/) {
-      // do nothing
+   NoInequalityReformulation::NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
+      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy, bool uses_trust_region, double objective_multiplier,
+      Options& options):
+         NoInequalityReformulation(std::move(name), problem, std::move(inertia_correction_strategy),
+            HessianSubproblemSolverJointFactory::create(problem, *inertia_correction_strategy, uses_trust_region,
+            objective_multiplier, options)) {
    }
 
-   std::unique_ptr<OptimizationProblem> NoInequalityReformulation::reformulate(const OptimizationProblem& problem,
-         Parameterization& /*parameterization*/) {
-      return problem.clone(); // the problem is not reformulated, simply make a copy
+   NoInequalityReformulation::NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
+      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy,
+      std::tuple<std::unique_ptr<HessianModel>, Subproblem, std::unique_ptr<SubproblemSolver>> ingredients):
+         InequalityHandlingMethod(problem), name(std::move(name)),
+         inertia_correction_strategy(std::move(inertia_correction_strategy)),
+         hessian_model(std::move(std::get<0>(ingredients))),
+         subproblem(std::move(std::get<1>(ingredients))),
+         subproblem_solver(std::move(std::get<2>(ingredients))) {
    }
 
-   bool NoInequalityReformulation::update_parameterization(Statistics& /*statistics*/, const OptimizationProblem& /*problem*/,
-         const Iterate& /*current_iterate*/, Parameterization& /*parameterization*/) {
+   void NoInequalityReformulation::initialize_statistics(Statistics& statistics) {
+      this->hessian_model->initialize_statistics(statistics);
+      this->inertia_correction_strategy->initialize_statistics(statistics);
+   }
+
+   bool NoInequalityReformulation::update_parameterization(Statistics& /*statistics*/, const Iterate& /*current_iterate*/) {
       // the parameterization is not updated
       return false;
+   }
+
+   Direction& NoInequalityReformulation::solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
+         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
+      return this->subproblem_solver->solve(statistics, this->subproblem, current_iterate, trust_region_radius, initial_point,
+         current_evaluations, warmstart_information);
    }
 
    void NoInequalityReformulation::initialize_feasibility_problem(Iterate& /*current_iterate*/) {
@@ -43,7 +70,30 @@ namespace uno {
       return 0.;
    }
 
+   bool NoInequalityReformulation::has_second_order_corrections() const {
+      return this->subproblem_solver->has_second_order_corrections();
+   }
+
+   const Direction& NoInequalityReformulation::compute_second_order_correction(const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) {
+      return this->subproblem_solver->compute_second_order_correction(this->subproblem, current_iterate, constraints_SOC);
+   }
+
+   bool NoInequalityReformulation::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
+         Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
+      return InequalityHandlingMethod::is_iterate_acceptable(statistics, globalization_strategy, this->subproblem,
+         this->subproblem_solver->get_workspace(), current_iterate, trial_iterate, direction, step_length, current_evaluations,
+         trial_evaluations);
+   }
+
+   void NoInequalityReformulation::notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate,
+         const Iterate& trial_iterate, Evaluations& current_evaluations, Evaluations& trial_evaluations) {
+      this->hessian_model->notify_trial_iterate(statistics, current_iterate, trial_iterate, current_evaluations, trial_evaluations);
+   }
+
    std::string NoInequalityReformulation::get_name() const {
-      return this->name;
+      return this->name + " with " + this->hessian_model->name + " Hessian and " + this->inertia_correction_strategy->get_name()
+         + " inertia correction";
    }
 } // namespace

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -16,6 +16,7 @@ namespace uno {
       std::tie(this->inertia_correction_strategy, this->hessian_model, this->subproblem_solver) =
          HessianSubproblemSolverJointFactory::create(this->problem, uses_trust_region, objective_multiplier, options);
       this->subproblem = std::make_unique<Subproblem>(this->problem, *this->hessian_model, *this->inertia_correction_strategy);
+      this->subproblem_solver->initialize_memory(*this->subproblem);
    }
 
    void NoInequalityReformulation::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -7,6 +7,7 @@
 #include "ingredients/hessian_models/HessianModel.hpp"
 #include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
 #include "ingredients/subproblem_solvers/SubproblemSolver.hpp"
+#include "optimization/Direction.hpp"
 
 namespace uno {
    NoInequalityReformulation::NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
@@ -35,8 +36,10 @@ namespace uno {
 
    Direction& NoInequalityReformulation::solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
          const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
-      return this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius, initial_point,
-         current_evaluations, warmstart_information);
+      Direction& direction = this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius,
+         initial_point, current_evaluations, warmstart_information);
+      direction.norm = norm_inf(view(direction.primals, 0, this->problem.get_number_original_variables()));
+      return direction;
    }
 
    void NoInequalityReformulation::initialize_feasibility_problem(Iterate& /*current_iterate*/) {

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <string>
-#include <tuple>
 #include "InequalityHandlingMethod.hpp"
 #include "ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <tuple>
 #include "InequalityHandlingMethod.hpp"
+#include "ingredients/hessian_models/HessianSubproblemSolverJointFactory.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 
 namespace uno {
@@ -23,6 +24,7 @@ namespace uno {
          double objective_multiplier, Options& options);
       ~NoInequalityReformulation() override = default;
 
+      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
       void initialize_statistics(Statistics& statistics) override;
       [[nodiscard]] bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) override;
       [[nodiscard]] Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
@@ -36,6 +38,7 @@ namespace uno {
       [[nodiscard]] const Direction& compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) override;
 
+      void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) const override;
@@ -48,15 +51,8 @@ namespace uno {
       const std::string name;
       std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy;
       std::unique_ptr<HessianModel> hessian_model;
-      Subproblem subproblem;
       std::unique_ptr<SubproblemSolver> subproblem_solver;
-
-      NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
-         std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy, bool uses_trust_region, double objective_multiplier,
-         Options& options);
-      NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
-         std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy,
-         std::tuple<std::unique_ptr<HessianModel>, Subproblem, std::unique_ptr<SubproblemSolver>> ingredients);
+      std::unique_ptr<Subproblem> subproblem;
    };
 } // namespace
 

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
@@ -6,28 +6,57 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include "InequalityHandlingMethod.hpp"
+#include "ingredients/subproblem/Subproblem.hpp"
 
 namespace uno {
+   // forward declaration
+   class HessianModel;
+   class InertiaCorrectionStrategy;
+   class Options;
+   class SubproblemSolver;
+
    class NoInequalityReformulation : public InequalityHandlingMethod {
    public:
-      explicit NoInequalityReformulation(std::string name);
+      NoInequalityReformulation(std::string name, const OptimizationProblem& problem, bool uses_trust_region,
+         double objective_multiplier, Options& options);
       ~NoInequalityReformulation() override = default;
 
       void initialize_statistics(Statistics& statistics) override;
-      [[nodiscard]] std::unique_ptr<OptimizationProblem> reformulate(const OptimizationProblem& problem,
-         Parameterization& parameterization) override;
-      [[nodiscard]] bool update_parameterization(Statistics& statistics, const OptimizationProblem& problem,
-         const Iterate& current_iterate, Parameterization& parameterization) override;
+      [[nodiscard]] bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) override;
+      [[nodiscard]] Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
+         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
 
       void initialize_feasibility_problem(Iterate& current_iterate) override;
       void set_elastic_variable_values(const l1RelaxedProblem& problem, Iterate& current_iterate, Evaluations& evaluations) override;
       [[nodiscard]] double proximal_coefficient() const override;
 
+      [[nodiscard]] bool has_second_order_corrections() const override;
+      [[nodiscard]] const Direction& compute_second_order_correction(const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) override;
+
+      [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
+         Evaluations& current_evaluations, Evaluations& trial_evaluations) const override;
+      void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
+         Evaluations& current_evaluations, Evaluations& trial_evaluations) override;
+
       [[nodiscard]] std::string get_name() const override;
 
    protected:
       const std::string name;
+      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy;
+      std::unique_ptr<HessianModel> hessian_model;
+      Subproblem subproblem;
+      std::unique_ptr<SubproblemSolver> subproblem_solver;
+
+      NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
+         std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy, bool uses_trust_region, double objective_multiplier,
+         Options& options);
+      NoInequalityReformulation(std::string name, const OptimizationProblem& problem,
+         std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy,
+         std::tuple<std::unique_ptr<HessianModel>, Subproblem, std::unique_ptr<SubproblemSolver>> ingredients);
    };
 } // namespace
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -131,8 +131,10 @@ namespace uno {
    Direction& InteriorPointMethod<BarrierProblem>::solve(Statistics& statistics, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
-      return this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius, initial_point,
-         current_evaluations, warmstart_information);
+      Direction& direction = this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius,
+         initial_point, current_evaluations, warmstart_information);
+      direction.norm = norm_inf(view(direction.primals, 0, this->barrier_problem.get_number_original_variables()));
+      return direction;
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -98,6 +98,7 @@ namespace uno {
       std::tie(this->inertia_correction_strategy, this->hessian_model, this->subproblem_solver) =
          HessianSubproblemSolverJointFactory::create(this->barrier_problem, uses_trust_region, objective_multiplier, options);
       this->subproblem = std::make_unique<Subproblem>(this->barrier_problem, *this->hessian_model, *this->inertia_correction_strategy);
+      this->subproblem_solver->initialize_memory(*this->subproblem);
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -12,7 +12,6 @@
 #include "ingredients/hessian_models/HessianModel.hpp"
 #include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
-#include "ingredients/subproblem_solvers/DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "ingredients/subproblem_solvers/EQPSolver.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/OptimizationProblem.hpp"

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -25,8 +25,9 @@ namespace uno {
    template <typename BarrierProblem>
    class InteriorPointMethod : public InequalityHandlingMethod {
    public:
-      InteriorPointMethod(const OptimizationProblem& problem, const Options& options);
+      InteriorPointMethod(const OptimizationProblem& problem, bool uses_trust_region, double objective_multiplier, Options& options);
 
+      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
       void initialize_statistics(Statistics& statistics) override;
       [[nodiscard]] bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) override;
       [[nodiscard]] Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
@@ -40,6 +41,7 @@ namespace uno {
       [[nodiscard]] const Direction& compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) override;
 
+      void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
         Evaluations& current_evaluations, Evaluations& trial_evaluations) const override;
@@ -49,16 +51,17 @@ namespace uno {
       [[nodiscard]] std::string get_name() const override;
 
    protected:
-      BarrierParameterUpdateStrategy<BarrierProblem> barrier_parameter_update_strategy;
       double previous_barrier_parameter;
       const InteriorPointParameters parameters;
-      Parameterization parameterization;
 
+      Parameterization parameterization;
       BarrierProblem barrier_problem;
+      BarrierParameterUpdateStrategy<BarrierProblem> barrier_parameter_update_strategy;
+
       std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy;
       std::unique_ptr<HessianModel> hessian_model;
-      Subproblem subproblem;
-      EQPSolver EQP_solver;
+      std::unique_ptr<SubproblemSolver> subproblem_solver;
+      std::unique_ptr<Subproblem> subproblem;
 
       const double least_square_multiplier_max_norm;
       const double l1_constraint_violation_coefficient; // (rho in Section 3.3.1 in IPOPT paper)
@@ -72,9 +75,9 @@ namespace uno {
    // class template implementation
 
    template <typename BarrierProblem>
-   InteriorPointMethod<BarrierProblem>::InteriorPointMethod(const OptimizationProblem& problem, const Options& options):
-         InequalityHandlingMethod(problem),
-         barrier_parameter_update_strategy(options),
+   InteriorPointMethod<BarrierProblem>::InteriorPointMethod(const OptimizationProblem& problem, bool uses_trust_region,
+      double objective_multiplier, Options& options):
+         InequalityHandlingMethod(problem, options),
          previous_barrier_parameter(options.get_double("barrier_initial_parameter")),
          parameters({
                options.get_double("barrier_tau_min"),
@@ -87,10 +90,19 @@ namespace uno {
                options.get_double("barrier_default_multiplier")
          }),
          barrier_problem(problem, this->parameters, this->parameterization),
-         subproblem(this->barrier_problem, *this->hessian_model, *this->inertia_correction_strategy),
-         EQP_solver(options),
+         barrier_parameter_update_strategy(options),
          least_square_multiplier_max_norm(options.get_double("least_square_multiplier_max_norm")),
          l1_constraint_violation_coefficient(options.get_double("l1_constraint_violation_coefficient")) {
+      this->parameterization.set("barrier_parameter", this->barrier_parameter());
+      // create the ingredients
+      std::tie(this->inertia_correction_strategy, this->hessian_model, this->subproblem_solver) =
+         HessianSubproblemSolverJointFactory::create(this->barrier_problem, uses_trust_region, objective_multiplier, options);
+      this->subproblem = std::make_unique<Subproblem>(this->barrier_problem, *this->hessian_model, *this->inertia_correction_strategy);
+   }
+
+   template <typename BarrierProblem>
+   void InteriorPointMethod<BarrierProblem>::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
+      this->barrier_problem.generate_initial_iterate(initial_iterate, evaluations);
    }
 
    template <typename BarrierProblem>
@@ -119,7 +131,7 @@ namespace uno {
    Direction& InteriorPointMethod<BarrierProblem>::solve(Statistics& statistics, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
-      return this->EQP_solver.solve(statistics, this->subproblem, current_iterate, trust_region_radius, initial_point,
+      return this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius, initial_point,
          current_evaluations, warmstart_information);
    }
 
@@ -186,21 +198,26 @@ namespace uno {
 
    template <typename BarrierProblem>
    bool InteriorPointMethod<BarrierProblem>::has_second_order_corrections() const {
-      return this->EQP_solver.has_second_order_corrections();
+      return this->subproblem_solver->has_second_order_corrections();
    }
 
    template <typename BarrierProblem>
    const Direction& InteriorPointMethod<BarrierProblem>::compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) {
-      return this->EQP_solver.compute_second_order_correction(this->subproblem, current_iterate, constraints_SOC);
+      return this->subproblem_solver->compute_second_order_correction(*this->subproblem, current_iterate, constraints_SOC);
+   }
+
+   template <typename BarrierProblem>
+   void InteriorPointMethod<BarrierProblem>::evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const {
+      InequalityHandlingMethod::evaluate_progress_measures(this->barrier_problem, iterate, evaluations);
    }
 
    template <typename BarrierProblem>
    bool InteriorPointMethod<BarrierProblem>::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
          Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
-      return InequalityHandlingMethod::is_iterate_acceptable(statistics, globalization_strategy, this->subproblem,
-         this->EQP_solver.get_workspace(), current_iterate, trial_iterate, direction, step_length, current_evaluations,
+      return InequalityHandlingMethod::is_iterate_acceptable(statistics, globalization_strategy, *this->subproblem,
+         this->subproblem_solver->get_workspace(), current_iterate, trial_iterate, direction, step_length, current_evaluations,
          trial_evaluations);
    }
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -9,6 +9,11 @@
 #include "BarrierParameterUpdateStrategy.hpp"
 #include "InteriorPointParameters.hpp"
 #include "ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp"
+#include "ingredients/hessian_models/HessianModel.hpp"
+#include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
+#include "ingredients/subproblem/Subproblem.hpp"
+#include "ingredients/subproblem_solvers/DirectSymmetricIndefiniteLinearSolver.hpp"
+#include "ingredients/subproblem_solvers/EQPSolver.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/OptimizationProblem.hpp"
 #include "optimization/Parameterization.hpp"
@@ -20,17 +25,26 @@ namespace uno {
    template <typename BarrierProblem>
    class InteriorPointMethod : public InequalityHandlingMethod {
    public:
-      explicit InteriorPointMethod(const Options& options);
+      InteriorPointMethod(const OptimizationProblem& problem, const Options& options);
 
       void initialize_statistics(Statistics& statistics) override;
-      [[nodiscard]] std::unique_ptr<OptimizationProblem> reformulate(const OptimizationProblem& problem,
-         Parameterization& parameterization) override;
-      [[nodiscard]] bool update_parameterization(Statistics& statistics, const OptimizationProblem& problem,
-         const Iterate& current_iterate, Parameterization& parameterization) override;
+      [[nodiscard]] bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) override;
+      [[nodiscard]] Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
+         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
 
       void initialize_feasibility_problem(Iterate& current_iterate) override;
       void set_elastic_variable_values(const l1RelaxedProblem& feasibility_problem, Iterate& iterate, Evaluations& evaluations) override;
       [[nodiscard]] double proximal_coefficient() const override;
+
+      [[nodiscard]] bool has_second_order_corrections() const override;
+      [[nodiscard]] const Direction& compute_second_order_correction(const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) override;
+
+      [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
+        Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
+        Evaluations& current_evaluations, Evaluations& trial_evaluations) const override;
+      void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
+         Evaluations& current_evaluations, Evaluations& trial_evaluations) override;
 
       [[nodiscard]] std::string get_name() const override;
 
@@ -38,6 +52,14 @@ namespace uno {
       BarrierParameterUpdateStrategy<BarrierProblem> barrier_parameter_update_strategy;
       double previous_barrier_parameter;
       const InteriorPointParameters parameters;
+      Parameterization parameterization;
+
+      BarrierProblem barrier_problem;
+      std::unique_ptr<InertiaCorrectionStrategy> inertia_correction_strategy;
+      std::unique_ptr<HessianModel> hessian_model;
+      Subproblem subproblem;
+      EQPSolver EQP_solver;
+
       const double least_square_multiplier_max_norm;
       const double l1_constraint_violation_coefficient; // (rho in Section 3.3.1 in IPOPT paper)
 
@@ -50,8 +72,8 @@ namespace uno {
    // class template implementation
 
    template <typename BarrierProblem>
-   InteriorPointMethod<BarrierProblem>::InteriorPointMethod(const Options& options):
-         InequalityHandlingMethod(),
+   InteriorPointMethod<BarrierProblem>::InteriorPointMethod(const OptimizationProblem& problem, const Options& options):
+         InequalityHandlingMethod(problem),
          barrier_parameter_update_strategy(options),
          previous_barrier_parameter(options.get_double("barrier_initial_parameter")),
          parameters({
@@ -64,42 +86,41 @@ namespace uno {
                options.get_double("barrier_damping_factor"),
                options.get_double("barrier_default_multiplier")
          }),
+         barrier_problem(problem, this->parameters, this->parameterization),
+         subproblem(this->barrier_problem, *this->hessian_model, *this->inertia_correction_strategy),
+         EQP_solver(options),
          least_square_multiplier_max_norm(options.get_double("least_square_multiplier_max_norm")),
          l1_constraint_violation_coefficient(options.get_double("l1_constraint_violation_coefficient")) {
    }
 
    template <typename BarrierProblem>
    void InteriorPointMethod<BarrierProblem>::initialize_statistics(Statistics& statistics) {
+      this->hessian_model->initialize_statistics(statistics);
+      this->inertia_correction_strategy->initialize_statistics(statistics);
       statistics.add_column("Barrier", Statistics::double_width, 2);
    }
 
    template <typename BarrierProblem>
-   std::unique_ptr<OptimizationProblem> InteriorPointMethod<BarrierProblem>::reformulate(const OptimizationProblem& problem,
-         Parameterization& parameterization) {
-      if (!problem.get_inequality_constraints().empty()) {
-         throw std::runtime_error("The problem has inequality constraints. Create an instance of HomogeneousEqualityConstrainedModel");
-      }
-      if (!problem.get_fixed_variables().empty()) {
-         throw std::runtime_error("The problem has fixed variables. Move them to the set of general constraints.");
-      }
-      parameterization.set("barrier_parameter", this->barrier_parameter());
-      return std::make_unique<BarrierProblem>(problem, this->parameters, parameterization);
-   }
-
-   template <typename BarrierProblem>
-   bool InteriorPointMethod<BarrierProblem>::update_parameterization(Statistics& statistics, const OptimizationProblem& problem,
-         const Iterate& current_iterate, Parameterization& parameterization) {
+   bool InteriorPointMethod<BarrierProblem>::update_parameterization(Statistics& statistics, const Iterate& current_iterate) {
       bool update = false;
       // possibly update the barrier parameter
       if (!this->first_feasibility_iteration) {
-         update = this->barrier_parameter_update_strategy.update_barrier_parameter(problem, current_iterate, current_iterate.residuals);
+         update = this->barrier_parameter_update_strategy.update_barrier_parameter(this->problem, current_iterate, current_iterate.residuals);
       }
       else {
          this->first_feasibility_iteration = false;
       }
-      parameterization.set("barrier_parameter", this->barrier_parameter());
+      this->parameterization.set("barrier_parameter", this->barrier_parameter());
       statistics.set("Barrier", this->barrier_parameter());
       return update;
+   }
+
+   template <typename BarrierProblem>
+   Direction& InteriorPointMethod<BarrierProblem>::solve(Statistics& statistics, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
+         const WarmstartInformation& warmstart_information) {
+      return this->EQP_solver.solve(statistics, this->subproblem, current_iterate, trust_region_radius, initial_point,
+         current_evaluations, warmstart_information);
    }
 
    template <typename BarrierProblem>
@@ -163,6 +184,32 @@ namespace uno {
       return std::sqrt(this->barrier_parameter());
    }
 
+   template <typename BarrierProblem>
+   bool InteriorPointMethod<BarrierProblem>::has_second_order_corrections() const {
+      return this->EQP_solver.has_second_order_corrections();
+   }
+
+   template <typename BarrierProblem>
+   const Direction& InteriorPointMethod<BarrierProblem>::compute_second_order_correction(const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) {
+      return this->EQP_solver.compute_second_order_correction(this->subproblem, current_iterate, constraints_SOC);
+   }
+
+   template <typename BarrierProblem>
+   bool InteriorPointMethod<BarrierProblem>::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
+         Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
+      return InequalityHandlingMethod::is_iterate_acceptable(statistics, globalization_strategy, this->subproblem,
+         this->EQP_solver.get_workspace(), current_iterate, trial_iterate, direction, step_length, current_evaluations,
+         trial_evaluations);
+   }
+
+   template <typename BarrierProblem>
+   void InteriorPointMethod<BarrierProblem>::notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate,
+         const Iterate& trial_iterate, Evaluations& current_evaluations, Evaluations& trial_evaluations) {
+      this->hessian_model->notify_trial_iterate(statistics, current_iterate, trial_iterate, current_evaluations, trial_evaluations);
+   }
+
    // protected member functions
 
    template <typename BarrierProblem>
@@ -186,7 +233,8 @@ namespace uno {
 
    template <typename BarrierProblem>
    std::string InteriorPointMethod<BarrierProblem>::get_name() const {
-      return "primal-dual interior-point method";
+      return "primal-dual interior-point method with " + this->hessian_model->name + " Hessian and "
+         + this->inertia_correction_strategy->get_name() + " inertia correction";
    }
 } // namespace
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -55,8 +55,10 @@ namespace uno {
       // set the slack variables (if any)
       if (!this->model.get_slacks().is_empty()) {
          evaluations.evaluate_constraints(this->model, initial_iterate.primals);
+         std::cout << "CONSTRAINTS: " << evaluations.constraints << '\n';
          // set the slacks to the constraint values
          for (const auto [constraint_index, slack_index]: this->model.get_slacks()) {
+            std::cout << "Slack index " << slack_index << " associated with constraint " << constraint_index << '\n';
             initial_iterate.primals[slack_index] = this->push_variable_to_interior(evaluations.constraints[constraint_index],
                variables_lower_bounds[slack_index], variables_upper_bounds[slack_index]);
          }

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -55,10 +55,8 @@ namespace uno {
       // set the slack variables (if any)
       if (!this->model.get_slacks().is_empty()) {
          evaluations.evaluate_constraints(this->model, initial_iterate.primals);
-         std::cout << "CONSTRAINTS: " << evaluations.constraints << '\n';
          // set the slacks to the constraint values
          for (const auto [constraint_index, slack_index]: this->model.get_slacks()) {
-            std::cout << "Slack index " << slack_index << " associated with constraint " << constraint_index << '\n';
             initial_iterate.primals[slack_index] = this->push_variable_to_interior(evaluations.constraints[constraint_index],
                variables_lower_bounds[slack_index], variables_upper_bounds[slack_index]);
          }

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -18,10 +18,10 @@
 #include "tools/Logger.hpp"
 
 namespace uno {
-   Subproblem::Subproblem(const OptimizationProblem& problem, Iterate& current_iterate, HessianModel& hessian_model,
+   Subproblem::Subproblem(const OptimizationProblem& problem, HessianModel& hessian_model,
       InertiaCorrectionStrategy& inertia_correction_strategy):
          number_variables(problem.number_variables), number_constraints(problem.number_constraints),
-         problem(problem), current_iterate(current_iterate), hessian_model(hessian_model),
+         problem(problem), hessian_model(hessian_model),
          inertia_correction_strategy(inertia_correction_strategy) {
    }
 
@@ -79,14 +79,14 @@ namespace uno {
       }
    }
 
-   void Subproblem::evaluate_jacobian(View<double> jacobian_values, Evaluations& evaluations) const {
-      this->problem.evaluate_jacobian(this->current_iterate.primals, jacobian_values, evaluations);
+   void Subproblem::evaluate_jacobian(const Iterate& current_iterate, View<double> jacobian_values, Evaluations& evaluations) const {
+      this->problem.evaluate_jacobian(current_iterate.primals, jacobian_values, evaluations);
    }
 
-   void Subproblem::evaluate_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const {
+   void Subproblem::evaluate_lagrangian_hessian(Statistics& statistics, const Iterate& current_iterate, View<double> hessian_values) const {
       // evaluate the Lagrangian Hessian of the problem at the current primal-dual point
-      this->problem.evaluate_lagrangian_hessian(statistics, this->hessian_model, this->current_iterate.primals,
-         this->current_iterate.multipliers, hessian_values);
+      this->problem.evaluate_lagrangian_hessian(statistics, this->hessian_model, current_iterate.primals,
+         current_iterate.multipliers, hessian_values);
    }
 
    void Subproblem::regularize_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const {
@@ -101,9 +101,9 @@ namespace uno {
       }
    }
 
-   void Subproblem::compute_hessian_vector_product(const double* x, const double* vector, double* result) const {
+   void Subproblem::compute_hessian_vector_product(const Iterate& current_iterate, const double* x, const double* vector, double* result) const {
       // unregularized Hessian-vector product
-      this->problem.compute_hessian_vector_product(this->hessian_model, x, vector, this->current_iterate.multipliers, result);
+      this->problem.compute_hessian_vector_product(this->hessian_model, x, vector, current_iterate.multipliers, result);
 
       // contribution of the regularization strategy
       const double regularization_factor = this->inertia_correction_strategy.get_primal_regularization_factor();
@@ -132,19 +132,19 @@ namespace uno {
       }
    }
 
-   void Subproblem::assemble_augmented_rhs(Evaluations& evaluations, Vector<double>& rhs) const {
+   void Subproblem::assemble_augmented_rhs(const Iterate& current_iterate, Evaluations& evaluations, Vector<double>& rhs) const {
       rhs.fill(0.);
 
       // -Jacobian^T-multipliers product
-      this->problem.compute_jacobian_transposed_vector_product(this->current_iterate.multipliers.constraints.data(),
+      this->problem.compute_jacobian_transposed_vector_product(current_iterate.multipliers.constraints.data(),
          rhs.data(), evaluations);
       rhs.scale(-1.);
 
       // objective gradient
-      this->problem.evaluate_objective_gradient(this->current_iterate, rhs.data(), evaluations);
+      this->problem.evaluate_objective_gradient(current_iterate, rhs.data(), evaluations);
 
       // constraints
-      this->problem.evaluate_constraints(this->current_iterate, rhs.data() + this->number_variables, evaluations);
+      this->problem.evaluate_constraints(current_iterate, rhs.data() + this->number_variables, evaluations);
       // shift the bound (lb == ub)
       for (size_t constraint_index: Range(this->problem.number_constraints)) {
          rhs[this->number_variables + constraint_index] -= this->problem.get_constraints_lower_bounds()[constraint_index];
@@ -155,25 +155,25 @@ namespace uno {
       DEBUG2 << "RHS: "; print_vector(DEBUG2, view(rhs, 0, this->number_variables + this->number_constraints)); DEBUG << '\n';
    }
 
-   void Subproblem::assemble_primal_dual_direction(const Vector<double>& solution, Direction& direction) const {
-      this->problem.assemble_primal_dual_direction(this->current_iterate, solution, direction);
+   void Subproblem::assemble_primal_dual_direction(const Iterate& current_iterate, const Vector<double>& solution, Direction& direction) const {
+      this->problem.assemble_primal_dual_direction(current_iterate, solution, direction);
    }
 
-   void Subproblem::set_variables_bounds(std::vector<double>& subproblem_variables_lower_bounds,
+   void Subproblem::set_variables_bounds(const Iterate& current_iterate, std::vector<double>& subproblem_variables_lower_bounds,
          std::vector<double>& subproblem_variables_upper_bounds, double trust_region_radius) const {
       const auto& variables_lower_bounds = this->problem.get_variables_lower_bounds();
       const auto& variables_upper_bounds = this->problem.get_variables_upper_bounds();
       // bounds of original variables intersected with trust region
       for (size_t variable_index: Range(this->problem.get_number_original_variables())) {
          subproblem_variables_lower_bounds[variable_index] = std::max(-trust_region_radius,
-            variables_lower_bounds[variable_index] - this->current_iterate.primals[variable_index]);
+            variables_lower_bounds[variable_index] - current_iterate.primals[variable_index]);
          subproblem_variables_upper_bounds[variable_index] = std::min(trust_region_radius,
-            variables_upper_bounds[variable_index] - this->current_iterate.primals[variable_index]);
+            variables_upper_bounds[variable_index] - current_iterate.primals[variable_index]);
       }
       // bounds of additional variables (no trust region!)
       for (size_t variable_index: Range(this->problem.get_number_original_variables(), this->problem.number_variables)) {
-         subproblem_variables_lower_bounds[variable_index] = variables_lower_bounds[variable_index] - this->current_iterate.primals[variable_index];
-         subproblem_variables_upper_bounds[variable_index] = variables_upper_bounds[variable_index] - this->current_iterate.primals[variable_index];
+         subproblem_variables_lower_bounds[variable_index] = variables_lower_bounds[variable_index] - current_iterate.primals[variable_index];
+         subproblem_variables_upper_bounds[variable_index] = variables_upper_bounds[variable_index] - current_iterate.primals[variable_index];
       }
    }
 
@@ -266,11 +266,11 @@ namespace uno {
    }
 
    // local models of progress measures
-   double Subproblem::compute_predicted_infeasibility_reduction(const Model& model, const Vector<double>& primal_direction,
-         double step_length, Norm norm, Evaluations& current_evaluations) const {
+   double Subproblem::compute_predicted_infeasibility_reduction(const Model& model, const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const {
       // predicted infeasibility reduction: "‖c(x)‖ - ‖c(x) + ∇c(x)^T (αd)‖"
-      current_evaluations.evaluate_constraints(model, this->current_iterate.primals);
-      current_evaluations.evaluate_jacobian(model, this->current_iterate.primals);
+      current_evaluations.evaluate_constraints(model, current_iterate.primals);
+      current_evaluations.evaluate_jacobian(model, current_iterate.primals);
 
       const double current_constraint_violation = model.constraint_violation(current_evaluations.constraints, norm);
       // TODO preallocate
@@ -281,27 +281,29 @@ namespace uno {
       return current_constraint_violation - trial_linearized_constraint_violation;
    }
 
-   std::function<double(double)> Subproblem::compute_predicted_objective_reduction(const Vector<double>& primal_direction,
-         double step_length, const Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const {
+   std::function<double(double)> Subproblem::compute_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, const Evaluations& current_evaluations,
+         const SolverWorkspace& solver_workspace) const {
       // predicted objective reduction: "-∇f(x)^T (αd) - α^2/2 d^T H d"
       const double directional_derivative = dot(view(primal_direction, 0, this->problem.model.number_variables), current_evaluations.objective_gradient);
       // if the regularized Hessian is positive definite (as it usually is in line-search methods), we can compute the
       // predicted reduction with only first-order information (the directional derivative)
       const bool is_regularized_hessian_positive_definite = this->hessian_model.is_positive_definite() || this->performs_primal_regularization();
       const double quadratic_term = is_regularized_hessian_positive_definite ? 0. :
-         solver_workspace.compute_hessian_quadratic_form(*this, primal_direction);
+         solver_workspace.compute_hessian_quadratic_form(*this, current_iterate, primal_direction);
       return [=](double objective_multiplier) {
          return step_length * (-objective_multiplier*directional_derivative) - step_length*step_length/2. * quadratic_term;
       };
    }
 
-   ProgressMeasures Subproblem::compute_predicted_reductions(const Direction& direction, double step_length, Norm norm,
-         Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const {
+   ProgressMeasures Subproblem::compute_predicted_reductions(const Iterate& current_iterate, const Direction& direction,
+         double step_length, Norm norm, Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const {
       return {
-         this->compute_predicted_infeasibility_reduction(this->problem.model, direction.primals, step_length, norm,
-            current_evaluations),
-         this->compute_predicted_objective_reduction(direction.primals, step_length, current_evaluations, solver_workspace),
-         this->problem.compute_predicted_auxiliary_reduction(this->current_iterate, direction.primals, step_length)
+         this->compute_predicted_infeasibility_reduction(this->problem.model, current_iterate, direction.primals, step_length,
+            norm, current_evaluations),
+         this->compute_predicted_objective_reduction(current_iterate, direction.primals, step_length, current_evaluations,
+            solver_workspace),
+         this->problem.compute_predicted_auxiliary_reduction(current_iterate, direction.primals, step_length)
       };
    }
 } // namespace

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -27,8 +27,7 @@ namespace uno {
    public:
       const size_t number_variables, number_constraints;
 
-      Subproblem(const OptimizationProblem& problem, Iterate& current_iterate, HessianModel& hessian_model,
-         InertiaCorrectionStrategy& inertia_correction_strategy);
+      Subproblem(const OptimizationProblem& problem, HessianModel& hessian_model, InertiaCorrectionStrategy& inertia_correction_strategy);
 
       // sparsity patterns
       void compute_jacobian_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int row_offset, uno_int column_offset,
@@ -36,22 +35,22 @@ namespace uno {
       void compute_regularized_hessian_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int solver_indexing) const;
       void compute_regularized_augmented_matrix_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int solver_indexing) const;
 
-      void evaluate_jacobian(View<double> jacobian_values, Evaluations& evaluations) const;
+      void evaluate_jacobian(const Iterate& current_iterate, View<double> jacobian_values, Evaluations& evaluations) const;
 
       // regularized Hessian
-      void evaluate_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const;
+      void evaluate_lagrangian_hessian(Statistics& statistics, const Iterate& current_iterate, View<double> hessian_values) const;
       void regularize_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const;
-      void compute_hessian_vector_product(const double* x, const double* vector, double* result) const;
+      void compute_hessian_vector_product(const Iterate& current_iterate, const double* x, const double* vector, double* result) const;
 
       // augmented system
       void regularize_augmented_matrix(Statistics& statistics, View<double> primal_inertia_correction_block,
          View<double> dual_inertia_correction_block, double dual_regularization_parameter,
          DirectSymmetricIndefiniteLinearSolver<double>& linear_solver) const;
-      void assemble_augmented_rhs(Evaluations& evaluations, Vector<double>& rhs) const;
-      void assemble_primal_dual_direction(const Vector<double>& solution, Direction& direction) const;
+      void assemble_augmented_rhs(const Iterate& current_iterate, Evaluations& evaluations, Vector<double>& rhs) const;
+      void assemble_primal_dual_direction(const Iterate& current_iterate, const Vector<double>& solution, Direction& direction) const;
 
       // variables bounds
-      void set_variables_bounds(std::vector<double>& variables_lower_bounds, std::vector<double>& variables_upper_bounds,
+      void set_variables_bounds(const Iterate& current_iterate, std::vector<double>& variables_lower_bounds, std::vector<double>& variables_upper_bounds,
          double trust_region_radius) const;
 
       // constraints bounds
@@ -81,15 +80,15 @@ namespace uno {
       [[nodiscard]] double dual_regularization_factor() const;
 
       // local models of progress measures
-      [[nodiscard]] double compute_predicted_infeasibility_reduction(const Model& model, const Vector<double>& primal_direction,
-         double step_length, Norm norm, Evaluations& current_evaluations) const;
-      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction(const Vector<double>& primal_direction,
-         double step_length, const Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const;
-      [[nodiscard]] ProgressMeasures compute_predicted_reductions(const Direction& direction, double step_length, Norm norm,
-         Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const;
+      [[nodiscard]] double compute_predicted_infeasibility_reduction(const Model& model, const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const;
+      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, const Evaluations& current_evaluations,
+         const SolverWorkspace& solver_workspace) const;
+      [[nodiscard]] ProgressMeasures compute_predicted_reductions(const Iterate& current_iterate, const Direction& direction,
+         double step_length, Norm norm, Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const;
 
       const OptimizationProblem& problem;
-      Iterate& current_iterate;
 
    protected:
       HessianModel& hessian_model;
@@ -102,12 +101,6 @@ namespace uno {
          Vector<double>& constraints) const {
       view(constraints_lower_bounds, 0, this->number_constraints) = this->problem.get_constraints_lower_bounds() - constraints;
       view(constraints_upper_bounds, 0, this->number_constraints) = this->problem.get_constraints_upper_bounds() - constraints;
-      /*
-      for (size_t constraint_index: Range(this->problem.number_constraints)) {
-         constraints_lower_bounds[constraint_index] = this->problem.constraint_lower_bound(constraint_index) - constraints[constraint_index];
-         constraints_upper_bounds[constraint_index] = this->problem.constraint_upper_bound(constraint_index) - constraints[constraint_index];
-      }
-      */
    }
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include <algorithm>
+#include <iostream>
 #include <numeric>
 #include <stdexcept>
 #include "BQPDQuadraticProgram.hpp"
@@ -62,19 +63,20 @@ namespace uno {
       if (allocate_explicit_hessian) {
          this->hessian_row_indices.resize(number_hessian_nonzeros);
          this->hessian_column_indices.resize(number_hessian_nonzeros);
+         std::cout << "ALLOCATING " << number_hessian_nonzeros << " FOR THE HESSIAN\n";
          this->hessian_values.resize(number_hessian_nonzeros);
       }
    }
 
-   void BQPDQuadraticProgram::fill(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
+   void BQPDQuadraticProgram::fill(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
       // evaluate objective gradient + constraint Jacobian (packed into workspace.gradients)
-      this->evaluate_functions(subproblem.problem, subproblem.current_iterate, current_evaluations,
+      this->evaluate_functions(subproblem.problem, current_iterate, current_evaluations,
          warmstart_information);
 
       // variable bounds
       if (warmstart_information.trust_region_changed) {
-         subproblem.set_variables_bounds(this->lower_bounds, this->upper_bounds, trust_region_radius);
+         subproblem.set_variables_bounds(current_iterate, this->lower_bounds, this->upper_bounds, trust_region_radius);
       }
       // constraint bounds
       if (warmstart_information.constraint_bounds_changed || warmstart_information.new_iterate) {
@@ -100,20 +102,16 @@ namespace uno {
          }
          // evaluate + regularize the explicit Hessian once per iterate
          if (this->hessian_evaluation_required) {
-            subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.view());
+            subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_values.view());
             subproblem.regularize_lagrangian_hessian(statistics, this->hessian_values.view());
             this->hessian_evaluation_required = false;
          }
          this->hessian_operator = nullptr;
       }
       else {
-         // matrix-free Hessian-vector product evaluated at the current iterate. The Subproblem outlives
-         // this build()/solve() pair (it is owned by the caller for the duration of the solve), so
-         // capturing it by pointer is safe; the operator is rebuilt on every build().
-         const Subproblem* subproblem_pointer = &subproblem;
-         this->hessian_operator = [subproblem_pointer](const double* vector, double* result) {
-            subproblem_pointer->compute_hessian_vector_product(subproblem_pointer->current_iterate.primals.data(),
-               vector, result);
+         // matrix-free Hessian-vector product evaluated at the current iterate
+         this->hessian_operator = [&current_iterate, &subproblem](const double* vector, double* result) {
+            subproblem.compute_hessian_vector_product(current_iterate, current_iterate.primals.data(), vector, result);
          };
       }
    }
@@ -212,11 +210,12 @@ namespace uno {
       this->hessian_evaluation_required = false;
    }
 
-   double BQPDQuadraticProgram::compute_hessian_quadratic_form(const Subproblem& subproblem, const Vector<double>& vector) const {
+   double BQPDQuadraticProgram::compute_hessian_quadratic_form(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& vector) const {
       if (subproblem.has_hessian_operator()) { // linear operator
          // TODO compute the quadratic form directly without temporary result
          // compute Hv
-         subproblem.compute_hessian_vector_product(subproblem.current_iterate.primals.data(), vector.data(),
+         subproblem.compute_hessian_vector_product(current_iterate, current_iterate.primals.data(), vector.data(),
             this->hessian_vector_product.data());
          // compute the dot product <v, Hv>
          return dot(view(vector, 0, subproblem.number_variables), this->hessian_vector_product);

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
@@ -63,7 +63,6 @@ namespace uno {
       if (allocate_explicit_hessian) {
          this->hessian_row_indices.resize(number_hessian_nonzeros);
          this->hessian_column_indices.resize(number_hessian_nonzeros);
-         std::cout << "ALLOCATING " << number_hessian_nonzeros << " FOR THE HESSIAN\n";
          this->hessian_values.resize(number_hessian_nonzeros);
       }
    }

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.hpp
@@ -29,7 +29,7 @@ namespace uno {
       BQPDQuadraticProgram() = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void fill(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
+      void fill(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
       // data-driven build: dense objective gradient + COO constraint Jacobian + COO Lagrangian Hessian
       // (one triangle; empty for an LP). Converts COO to BQPD's weak-CSR layout internally.
@@ -54,7 +54,8 @@ namespace uno {
          const Vector<double>& jacobian_values, const Vector<uno_int>& hessian_row_indices,
          const Vector<uno_int>& hessian_column_indices, const Vector<double>& hessian_values);
 
-      [[nodiscard]] double compute_hessian_quadratic_form(const Subproblem& subproblem, const Vector<double>& vector) const override;
+      [[nodiscard]] double compute_hessian_quadratic_form(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& vector) const override;
 
       void evaluate_functions(const OptimizationProblem& problem, const Iterate& current_iterate, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information);

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
@@ -5,7 +5,6 @@
 #include "BoxLPSolver.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "optimization/Direction.hpp"
-#include "tools/Logger.hpp"
 
 namespace uno {
    void BoxLPSolver::initialize_memory(const Subproblem& subproblem) {

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
@@ -15,8 +15,8 @@ namespace uno {
       this->workspace.objective_gradient.resize(subproblem.number_variables);
    }
 
-   Direction& BoxLPSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
+   Direction& BoxLPSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& /*warmstart_information*/) {
       if (0 < subproblem.number_constraints) {
          throw std::runtime_error("BoxLPSolver cannot solve problems with general constraints");
@@ -24,11 +24,11 @@ namespace uno {
       this->direction.reset();
       // compute the objective gradient
       this->workspace.objective_gradient.fill(0.);
-      subproblem.problem.evaluate_objective_gradient(subproblem.current_iterate, this->workspace.objective_gradient.data(),
+      subproblem.problem.evaluate_objective_gradient(current_iterate, this->workspace.objective_gradient.data(),
         current_evaluations);
 
       // compute the variables bounds
-      subproblem.set_variables_bounds(this->variable_lower_bounds, this->variable_upper_bounds, trust_region_radius);
+      subproblem.set_variables_bounds(current_iterate, this->variable_lower_bounds, this->variable_upper_bounds, trust_region_radius);
 
       // move the variables to one of their bounds
       this->direction.subproblem_objective = 0.;
@@ -60,11 +60,12 @@ namespace uno {
       return false;
    }
 
-   const Direction& BoxLPSolver::compute_second_order_correction(const Subproblem& /*subproblem*/, const Vector<double>& /*constraints_SOC*/) {
+   const Direction& BoxLPSolver::compute_second_order_correction(const Subproblem& /*subproblem*/, const Iterate& /*current_iterate*/,
+         const Vector<double>& /*constraints_SOC*/) {
       throw std::runtime_error("No SOC implemented in BoxLPSolver");
    }
 
-   SolverWorkspace& BoxLPSolver::get_workspace() {
+   const SolverWorkspace& BoxLPSolver::get_workspace() const {
       return this->workspace;
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
@@ -15,7 +15,8 @@ namespace uno {
    public:
       BoxLPSolverWorkspace() = default;
 
-      [[nodiscard]] double compute_hessian_quadratic_form(const Subproblem& /*subproblem*/, const Vector<double>& /*vector*/) const override {
+      [[nodiscard]] double compute_hessian_quadratic_form(const Subproblem& /*subproblem*/, const Iterate& /*current_iterate*/,
+            const Vector<double>& /*vector*/) const override {
          return 0.;
       }
 
@@ -29,13 +30,15 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
+      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
+         const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] bool has_second_order_corrections() const override;
-      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Vector<double>& constraints_SOC) override;
+      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) override;
 
-      [[nodiscard]] SolverWorkspace& get_workspace() override;
+      [[nodiscard]] const SolverWorkspace& get_workspace() const override;
 
    protected:
       Direction direction;

--- a/uno/ingredients/subproblem_solvers/COOLinearSystem.cpp
+++ b/uno/ingredients/subproblem_solvers/COOLinearSystem.cpp
@@ -43,7 +43,7 @@ namespace uno {
       this->solution.resize(this->dimension);
    }
 
-   double COOLinearSystem::compute_hessian_quadratic_form(const Subproblem& /*subproblem*/,
+   double COOLinearSystem::compute_hessian_quadratic_form(const Subproblem& /*subproblem*/, const Iterate& /*current_iterate*/,
          const Vector<double>& /*vector*/) const {
       return 0.;
    }

--- a/uno/ingredients/subproblem_solvers/COOLinearSystem.hpp
+++ b/uno/ingredients/subproblem_solvers/COOLinearSystem.hpp
@@ -17,7 +17,8 @@ namespace uno {
       void initialize_hessian(const Subproblem& subproblem) override;
       void initialize_augmented_system(const Subproblem& subproblem) override;
 
-      [[nodiscard]] double compute_hessian_quadratic_form(const Subproblem& subproblem, const Vector<double>& vector) const override;
+      [[nodiscard]] double compute_hessian_quadratic_form(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& vector) const override;
 
       // symmetric matrix (Hessian or augmented system)
       std::vector<uno_int> matrix_row_indices{};

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -30,8 +30,8 @@ namespace uno {
       this->linear_solver->initialize_memory();
    }
 
-   Direction& EQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
+   Direction& EQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
       if (is_finite(trust_region_radius)) {
          throw std::runtime_error("The direct linear solver does not support a trust region");
@@ -53,8 +53,8 @@ namespace uno {
          View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
          View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
 
-         subproblem.evaluate_lagrangian_hessian(statistics, hessian);
-         subproblem.evaluate_jacobian(jacobian, current_evaluations);
+         subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, hessian);
+         subproblem.evaluate_jacobian(current_iterate, jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all
          if (!this->analysis_performed) {
@@ -68,7 +68,7 @@ namespace uno {
             subproblem.dual_regularization_factor(), *this->linear_solver);
 
          // assemble the RHS
-         subproblem.assemble_augmented_rhs(current_evaluations, linear_system.rhs);
+         subproblem.assemble_augmented_rhs(current_iterate, current_evaluations, linear_system.rhs);
       }
 
       // solve the linear system
@@ -78,7 +78,7 @@ namespace uno {
       }
       else {
          // assemble the full primal-dual direction
-         subproblem.assemble_primal_dual_direction(linear_system.solution, this->direction);
+         subproblem.assemble_primal_dual_direction(current_iterate, linear_system.solution, this->direction);
       }
       return this->direction;
    }
@@ -88,7 +88,8 @@ namespace uno {
    }
 
    // precondition: the constraints have been evaluated at the trial iterate in trial_evaluations
-   const Direction& EQPSolver::compute_second_order_correction(const Subproblem& subproblem, const Vector<double>& constraints_SOC) {
+   const Direction& EQPSolver::compute_second_order_correction(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) {
       // initialize upon the first time
       if (!this->SOC_initialized) {
          this->direction_SOC = Direction(subproblem.number_variables, subproblem.number_constraints);
@@ -115,11 +116,11 @@ namespace uno {
          this->direction_SOC.status = SubproblemStatus::INFEASIBLE;
       }
       // assemble the full primal-dual direction
-      subproblem.assemble_primal_dual_direction(linear_system.solution, this->direction_SOC);
+      subproblem.assemble_primal_dual_direction(current_iterate, linear_system.solution, this->direction_SOC);
       return this->direction_SOC;
    }
 
-   SolverWorkspace& EQPSolver::get_workspace() {
+   const SolverWorkspace& EQPSolver::get_workspace() const {
       return this->linear_solver->get_linear_system();
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/EQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.hpp
@@ -21,13 +21,15 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
+      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
+         const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] bool has_second_order_corrections() const override;
-      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Vector<double>& constraints_SOC) override;
+      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) override;
 
-      [[nodiscard]] SolverWorkspace& get_workspace() override;
+      [[nodiscard]] const SolverWorkspace& get_workspace() const override;
 
    protected:
       Direction direction;

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
@@ -34,14 +34,14 @@ namespace uno {
       this->compute_hessian_sparsity(subproblem);
    }
 
-   void HiGHSQuadraticProgram::fill(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
+   void HiGHSQuadraticProgram::fill(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
       // evaluate the functions and derivatives into the HiGHS model
-      this->evaluate_functions(statistics, subproblem, current_evaluations, warmstart_information);
+      this->evaluate_functions(statistics, subproblem, current_iterate, current_evaluations, warmstart_information);
 
       // variable bounds
       if (warmstart_information.trust_region_changed) {
-         subproblem.set_variables_bounds(this->model.lp_.col_lower_, this->model.lp_.col_upper_, trust_region_radius);
+         subproblem.set_variables_bounds(current_iterate, this->model.lp_.col_lower_, this->model.lp_.col_upper_, trust_region_radius);
       }
       // constraint bounds
       if (warmstart_information.constraint_bounds_changed || warmstart_information.new_iterate) {
@@ -89,7 +89,8 @@ namespace uno {
       }
    }
 
-   double HiGHSQuadraticProgram::compute_hessian_quadratic_form(const Subproblem& /*subproblem*/, const Vector<double>& vector) const {
+   double HiGHSQuadraticProgram::compute_hessian_quadratic_form(const Subproblem& /*subproblem*/, const Iterate& /*current_iterate*/,
+         const Vector<double>& vector) const {
       double quadratic_product = 0.;
       const size_t number_hessian_nonzeros = this->hessian_values.size();
       for (size_t nonzero_index: Range(number_hessian_nonzeros)) {
@@ -177,19 +178,18 @@ namespace uno {
       }
    }
 
-   void HiGHSQuadraticProgram::evaluate_functions(Statistics& statistics, const Subproblem& subproblem,
+   void HiGHSQuadraticProgram::evaluate_functions(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
       // evaluate the functions based on warmstart information
       if (warmstart_information.new_iterate) {
          for (size_t index: Range(subproblem.number_variables)) {
             this->model.lp_.col_cost_[index] = 0.;
          }
-         subproblem.problem.evaluate_objective_gradient(subproblem.current_iterate, this->model.lp_.col_cost_.data(),
-            current_evaluations);
-         subproblem.problem.evaluate_constraints(subproblem.current_iterate, this->constraints.data(), current_evaluations);
-         this->evaluate_jacobian(subproblem.problem, subproblem.current_iterate.primals, current_evaluations);
+         subproblem.problem.evaluate_objective_gradient(current_iterate, this->model.lp_.col_cost_.data(), current_evaluations);
+         subproblem.problem.evaluate_constraints(current_iterate, this->constraints.data(), current_evaluations);
+         this->evaluate_jacobian(subproblem.problem, current_iterate.primals, current_evaluations);
          // evaluate the Hessian and regularize it
-         subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.view());
+         subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_values.view());
          // copy the Hessian with permutation into this->model.hessian_.value_
          this->scatter_hessian_values();
          View hessian(this->model.hessian_.value_.data(), subproblem.number_regularized_hessian_nonzeros());

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.hpp
@@ -24,7 +24,7 @@ namespace uno {
       HiGHSQuadraticProgram() = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void fill(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
+      void fill(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
       // data-driven build: dense objective gradient + COO constraint Jacobian + COO Lagrangian Hessian
       // (one triangle; empty for an LP). Converts COO to HiGHS' CSC layout internally.
@@ -35,7 +35,8 @@ namespace uno {
          const Vector<double>& hessian_values,
          const std::vector<double>& variables_lower_bounds, const std::vector<double>& variables_upper_bounds,
          const std::vector<double>& constraints_lower_bounds, const std::vector<double>& constraints_upper_bounds) override;
-      [[nodiscard]] double compute_hessian_quadratic_form(const Subproblem& subproblem, const Vector<double>& vector) const override;
+      [[nodiscard]] double compute_hessian_quadratic_form(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& vector) const override;
 
       HighsModel model;
       Vector<double> constraints{};
@@ -62,8 +63,8 @@ namespace uno {
          const Vector<double>& jacobian_values, const Vector<uno_int>& hessian_row_indices,
          const Vector<uno_int>& hessian_column_indices, const Vector<double>& hessian_values);
 
-      void evaluate_functions(Statistics& statistics, const Subproblem& subproblem, Evaluations& current_evaluations,
-         const WarmstartInformation& warmstart_information);
+      void evaluate_functions(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         Evaluations& current_evaluations, const WarmstartInformation& warmstart_information);
       void evaluate_jacobian(const OptimizationProblem& problem, const Vector<double>& primals, Evaluations& evaluations);
 
       // build HiGHS' CSC Jacobian/Hessian from the COO arrays already stored in the *_row/column_indices members

--- a/uno/ingredients/subproblem_solvers/IQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.cpp
@@ -21,19 +21,19 @@ namespace uno {
       this->qp_solver->initialize_memory(subproblem);
    }
 
-   Direction& IQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& initial_point, Evaluations& current_evaluations,
+   Direction& IQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
       this->direction.reset();
       // build the QuadraticProgram from the Subproblem at the current iterate
       QuadraticProgram& quadratic_program = this->qp_solver->get_quadratic_program();
-      quadratic_program.fill(statistics, subproblem, trust_region_radius, current_evaluations, warmstart_information);
+      quadratic_program.fill(statistics, subproblem, current_iterate, trust_region_radius, current_evaluations, warmstart_information);
 
       // solve the QP
       this->qp_solver->solve(statistics, initial_point, this->direction, warmstart_information);
 
       // compute the dual direction
-      compute_dual_direction(subproblem, this->direction.multipliers);
+      compute_dual_direction(subproblem, current_iterate, this->direction.multipliers);
       return this->direction;
    }
 
@@ -41,11 +41,12 @@ namespace uno {
       return false;
    }
 
-   const Direction& IQPSolver::compute_second_order_correction(const Subproblem& /*subproblem*/, const Vector<double>& /*constraints_SOC*/) {
+   const Direction& IQPSolver::compute_second_order_correction(const Subproblem& /*subproblem*/, const Iterate& /*current_iterate*/,
+         const Vector<double>& /*constraints_SOC*/) {
       throw std::runtime_error("No SOC implemented in IQPSolver");
    }
 
-   SolverWorkspace& IQPSolver::get_workspace() {
+   SolverWorkspace& IQPSolver::get_workspace() const {
       return this->qp_solver->get_workspace();
    }
 
@@ -53,12 +54,12 @@ namespace uno {
 
    // because of the way we form LPs/QPs, we get the new *multipliers* back from the solver. To get the dual
    // displacements/direction, we need to subtract the current multipliers
-   void IQPSolver::compute_dual_direction(const Subproblem& subproblem, Multipliers& direction_multipliers) {
+   void IQPSolver::compute_dual_direction(const Subproblem& subproblem, const Iterate& current_iterate, Multipliers& direction_multipliers) {
       view(direction_multipliers.constraints, 0, subproblem.number_constraints) -=
-         view(subproblem.current_iterate.multipliers.constraints, 0, subproblem.number_constraints);
+         view(current_iterate.multipliers.constraints, 0, subproblem.number_constraints);
       view(direction_multipliers.lower_bounds, 0, subproblem.number_variables) -=
-         view(subproblem.current_iterate.multipliers.lower_bounds, 0, subproblem.number_variables);
+         view(current_iterate.multipliers.lower_bounds, 0, subproblem.number_variables);
       view(direction_multipliers.upper_bounds, 0, subproblem.number_variables) -=
-         view(subproblem.current_iterate.multipliers.upper_bounds, 0, subproblem.number_variables);
+         view(current_iterate.multipliers.upper_bounds, 0, subproblem.number_variables);
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/IQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.cpp
@@ -7,7 +7,6 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Iterate.hpp"
-#include "tools/Logger.hpp"
 
 namespace uno {
    IQPSolver::IQPSolver(std::unique_ptr<LPSolver> qp_solver):

--- a/uno/ingredients/subproblem_solvers/IQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.hpp
@@ -27,19 +27,21 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
+      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
+         const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] bool has_second_order_corrections() const override;
-      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Vector<double>& constraints_SOC) override;
+      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) override;
 
-      [[nodiscard]] SolverWorkspace& get_workspace() override;
+      [[nodiscard]] SolverWorkspace& get_workspace() const override;
 
    private:
       Direction direction;
       std::unique_ptr<LPSolver> qp_solver;
 
-      static void compute_dual_direction(const Subproblem& subproblem, Multipliers& direction_multipliers);
+      static void compute_dual_direction(const Subproblem& subproblem, const Iterate& current_iterate, Multipliers& direction_multipliers);
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
@@ -20,17 +20,18 @@ namespace uno {
       this->rhs.resize(subproblem.number_variables);
    }
 
-   Direction& InverseNewtonSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, [[maybe_unused]] double trust_region_radius,
-         const Vector<double>& /*initial_point*/, Evaluations& current_evaluations, const WarmstartInformation& /*warmstart_information*/) {
+   Direction& InverseNewtonSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
+         [[maybe_unused]] double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
+         const WarmstartInformation& /*warmstart_information*/) {
       assert(is_infinite(trust_region_radius));
       this->direction.reset();
 
       // store -gradient in this->rhs
-      current_evaluations.evaluate_objective_gradient(subproblem.problem.model, subproblem.current_iterate.primals);
+      current_evaluations.evaluate_objective_gradient(subproblem.problem.model, current_iterate.primals);
       this->rhs = -current_evaluations.objective_gradient;
 
       // compute the Newton step d = -H⁻¹ g
-      this->hessian_model.compute_inverse_hessian_vector_product(subproblem.current_iterate.primals.data(),
+      this->hessian_model.compute_inverse_hessian_vector_product(current_iterate.primals.data(),
          this->rhs.data(), this->direction.primals.data());
       return this->direction;
    }
@@ -40,11 +41,11 @@ namespace uno {
    }
 
    const Direction& InverseNewtonSolver::compute_second_order_correction(const Subproblem& /*subproblem*/,
-         const Vector<double>& /*constraints_SOC*/) {
+         const Iterate& /*current_iterate*/, const Vector<double>& /*constraints_SOC*/) {
       throw std::runtime_error("No SOC implemented in InverseNewtonSolver");
    }
 
-   SolverWorkspace& InverseNewtonSolver::get_workspace() {
+   const SolverWorkspace& InverseNewtonSolver::get_workspace() const {
       return this->workspace;
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
@@ -14,7 +14,8 @@ namespace uno {
    public:
       NewtonWorkspace() = default;
 
-      double compute_hessian_quadratic_form(const Subproblem& /*subproblem*/, const Vector<double>& /*vector*/) const override {
+      double compute_hessian_quadratic_form(const Subproblem& /*subproblem*/, const Iterate& /*current_iterate*/,
+            const Vector<double>& /*vector*/) const override {
          // no explicit Hessian. Since the (inverse) Hessian model is positive definite, the predicted reduction can
          // be kept first order
          return 0.;
@@ -31,13 +32,15 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
+      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
+         const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] bool has_second_order_corrections() const override;
-      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Vector<double>& constraints_SOC) override;
+      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) override;
 
-      [[nodiscard]] SolverWorkspace& get_workspace() override;
+      [[nodiscard]] const SolverWorkspace& get_workspace() const override;
 
    protected:
       Direction direction;

--- a/uno/ingredients/subproblem_solvers/QuadraticProgram.hpp
+++ b/uno/ingredients/subproblem_solvers/QuadraticProgram.hpp
@@ -11,6 +11,7 @@
 namespace uno {
    // forward declarations
    class Evaluations;
+   class Iterate;
    class SolverWorkspace;
    class Statistics;
    class Subproblem;
@@ -45,8 +46,8 @@ namespace uno {
       virtual void initialize_memory(const Subproblem& subproblem) = 0;
 
       // populate from a Subproblem at the current iterate (storage allocated by initialize_memory)
-      virtual void fill(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) = 0;
+      virtual void fill(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) = 0;
 
       // populate directly from data: dense objective gradient, COO constraint Jacobian (row = constraint,
       // column = variable), COO Lagrangian Hessian (one triangle; empty for an LP), and concatenable

--- a/uno/ingredients/subproblem_solvers/SolverWorkspace.hpp
+++ b/uno/ingredients/subproblem_solvers/SolverWorkspace.hpp
@@ -6,6 +6,7 @@
 
 namespace uno {
    // forward declarations
+   class Iterate;
    class Subproblem;
    template <typename ElementType>
    class Vector;
@@ -15,7 +16,8 @@ namespace uno {
       SolverWorkspace() = default;
       virtual ~SolverWorkspace() = default;
 
-      [[nodiscard]] virtual double compute_hessian_quadratic_form(const Subproblem& subproblem, const Vector<double>& vector) const = 0;
+      [[nodiscard]] virtual double compute_hessian_quadratic_form(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& vector) const = 0;
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
@@ -8,6 +8,7 @@ namespace uno {
    // forward declarations
    class Direction;
    class Evaluations;
+   class Iterate;
    class Multipliers;
    class Statistics;
    class SolverWorkspace;
@@ -23,14 +24,15 @@ namespace uno {
 
       virtual void initialize_memory(const Subproblem& subproblem) = 0;
 
-      [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& initial_point, Evaluations& current_evaluations,
+      [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) = 0;
 
       [[nodiscard]] virtual bool has_second_order_corrections() const = 0;
-      virtual const Direction& compute_second_order_correction(const Subproblem& subproblem, const Vector<double>& constraints_SOC) = 0;
+      virtual const Direction& compute_second_order_correction(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) = 0;
 
-      [[nodiscard]] virtual SolverWorkspace& get_workspace() = 0;
+      [[nodiscard]] virtual const SolverWorkspace& get_workspace() const = 0;
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/SubproblemSolverFactory.hpp
+++ b/uno/ingredients/subproblem_solvers/SubproblemSolverFactory.hpp
@@ -19,26 +19,20 @@
 
 namespace uno {
    // forward declarations
-   class InertiaCorrectionStrategy;
    class InverseLBFGSHessian;
    class DirectQuasiNewtonHessian;
    class Options;
-   class Subproblem;
 
    class SubproblemSolverFactory {
    public:
       template <typename HessianType>
-      static std::unique_ptr<SubproblemSolver> create(const OptimizationProblem& problem, Iterate& current_iterate,
-         HessianType& hessian_model, InertiaCorrectionStrategy& inertia_correction_strategy,
+      static std::unique_ptr<SubproblemSolver> create(HessianType& hessian_model, const Subproblem& subproblem,
          bool uses_trust_region, const Options& options);
    };
 
    template <typename HessianType>
-   std::unique_ptr<SubproblemSolver> SubproblemSolverFactory::create(const OptimizationProblem& problem,
-         Iterate& current_iterate, HessianType& hessian_model, InertiaCorrectionStrategy& inertia_correction_strategy,
+   std::unique_ptr<SubproblemSolver> SubproblemSolverFactory::create(HessianType& hessian_model, const Subproblem& subproblem,
          bool uses_trust_region, const Options& options) {
-      const Subproblem subproblem(problem, current_iterate, hessian_model, inertia_correction_strategy);
-
       // if no curvature, allocate LP solver
       if (!subproblem.has_curvature()) {
          if (subproblem.number_constraints == 0) {

--- a/uno/ingredients/subproblem_solvers/SubproblemSolverFactory.hpp
+++ b/uno/ingredients/subproblem_solvers/SubproblemSolverFactory.hpp
@@ -37,15 +37,11 @@ namespace uno {
       if (!subproblem.has_curvature()) {
          if (subproblem.number_constraints == 0) {
             DEBUG << "No curvature and only bound constraints in the subproblem, allocating a box LP solver\n";
-            auto subproblem_solver = std::make_unique<BoxLPSolver>();
-            subproblem_solver->initialize_memory(subproblem);
-            return subproblem_solver;
+            return std::make_unique<BoxLPSolver>();
          }
          else {
             DEBUG << "No curvature in the subproblem, allocating an LP solver\n";
-            auto subproblem_solver = std::make_unique<IQPSolver>(LPSolverFactory::create(options));
-            subproblem_solver->initialize_memory(subproblem);
-            return subproblem_solver;
+            return std::make_unique<IQPSolver>(LPSolverFactory::create(options));
          }
       }
       // if no inequality constraint and no trust region, allocate EQP solver
@@ -53,31 +49,23 @@ namespace uno {
          if constexpr (std::is_same_v<HessianType, InverseLBFGSHessian>) { // unconstrained
             DEBUG << "No constraints in the subproblem, allocating a Newton solver with inverse quasi-Newton Hessian\n";
             // the hessian_model we pass has type QuasiNewtonHessian
-            auto subproblem_solver = std::make_unique<InverseNewtonSolver>(hessian_model);
-            subproblem_solver->initialize_memory(subproblem);
-            return subproblem_solver;
+            return std::make_unique<InverseNewtonSolver>(hessian_model);
          }
          else if constexpr (std::is_base_of_v<DirectQuasiNewtonHessian, HessianType>) { // equality-constrained
             DEBUG << "No inequality constraints in the subproblem, allocating an EQP solver with quasi-Newton Hessian\n";
             // the hessian_model we pass has type QuasiNewtonHessian
-            auto subproblem_solver = std::make_unique<WoodburyEQPSolver>(hessian_model, options);
-            subproblem_solver->initialize_memory(subproblem);
-            return subproblem_solver;
+            return std::make_unique<WoodburyEQPSolver>(hessian_model, options);
          }
          else {
             DEBUG << "No inequality constraints in the subproblem, allocating an EQP solver\n";
-            auto subproblem_solver = std::make_unique<EQPSolver>(options);
-            subproblem_solver->initialize_memory(subproblem);
-            return subproblem_solver;
+            return std::make_unique<EQPSolver>(options);
          }
       }
       // otherwise, allocate QP solver
       else {
          DEBUG << "Curvature in the subproblem, allocating a QP solver\n";
          // wrap the (Subproblem-agnostic) QP backend in an IQPSolver that builds its QuadraticProgram
-         auto subproblem_solver = std::make_unique<IQPSolver>(QPSolverFactory::create(options));
-         subproblem_solver->initialize_memory(subproblem);
-         return subproblem_solver;
+         return std::make_unique<IQPSolver>(QPSolverFactory::create(options));
       }
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -31,8 +31,8 @@ namespace uno {
       this->linear_solver->initialize_memory();
    }
 
-   Direction& WoodburyEQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
+   Direction& WoodburyEQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
       if (is_finite(trust_region_radius)) {
          throw std::runtime_error("The direct linear solver does not support a trust region");
@@ -54,8 +54,8 @@ namespace uno {
          View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
          View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
 
-         subproblem.evaluate_lagrangian_hessian(statistics, hessian);
-         subproblem.evaluate_jacobian(jacobian, current_evaluations);
+         subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, hessian);
+         subproblem.evaluate_jacobian(current_iterate, jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all
          if (!this->analysis_performed) {
@@ -69,7 +69,7 @@ namespace uno {
             subproblem.dual_regularization_factor(), *this->linear_solver);
 
          // assemble the RHS
-         subproblem.assemble_augmented_rhs(current_evaluations, linear_system.rhs);
+         subproblem.assemble_augmented_rhs(current_iterate, current_evaluations, linear_system.rhs);
       }
 
       // solve the linear system with only the diagonal part and store the result in solution_diagonal_part
@@ -83,7 +83,7 @@ namespace uno {
          this->compute_low_rank_correction(subproblem, solution_diagonal_part);
 
          // assemble the full primal-dual direction
-         subproblem.assemble_primal_dual_direction(solution_diagonal_part, this->direction);
+         subproblem.assemble_primal_dual_direction(current_iterate, solution_diagonal_part, this->direction);
       }
       return this->direction;
    }
@@ -93,11 +93,11 @@ namespace uno {
    }
 
    const Direction& WoodburyEQPSolver::compute_second_order_correction(const Subproblem& /*subproblem*/,
-         const Vector<double>& /*constraints_SOC*/) {
+         const Iterate& /*current_iterate*/, const Vector<double>& /*constraints_SOC*/) {
       throw std::runtime_error("No SOC implemented in WoodburyEQPSolver");
    }
 
-   SolverWorkspace& WoodburyEQPSolver::get_workspace() {
+   const SolverWorkspace& WoodburyEQPSolver::get_workspace() const {
       return this->linear_solver->get_linear_system();
    }
 

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
@@ -37,13 +37,15 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, double trust_region_radius,
-         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
+      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
+         const WarmstartInformation& warmstart_information) override;
 
       [[nodiscard]] bool has_second_order_corrections() const override;
-      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Vector<double>& constraints_SOC) override;
+      const Direction& compute_second_order_correction(const Subproblem& subproblem, const Iterate& current_iterate,
+         const Vector<double>& constraints_SOC) override;
 
-      [[nodiscard]] SolverWorkspace& get_workspace() override;
+      [[nodiscard]] const SolverWorkspace& get_workspace() const override;
 
    protected:
       Direction direction;

--- a/uno/model/HomogeneousEqualityConstrainedModel.cpp
+++ b/uno/model/HomogeneousEqualityConstrainedModel.cpp
@@ -4,7 +4,6 @@
 #include "HomogeneousEqualityConstrainedModel.hpp"
 #include "linear_algebra/View.hpp"
 #include "optimization/Iterate.hpp"
-#include "symbolic/Range.hpp"
 
 namespace uno {
    // Transform the problem into an equality-constrained problem with constraints c(x) = 0. This implies:


### PR DESCRIPTION
- moved `Subproblem` and `SubproblemSolver` to `InequalityHandlingMethod`
- to compute a direction, we traverse both the `ConstraintRelaxationStrategy` and the `InequalityHandlingMethod`
- this allows the `InequalityHandlingMethod` to compute several steps (e.g., like SLP-EQP)