### PR TITLE
[UnoSolver.jl] Update README.md

### DIFF
--- a/interfaces/Julia/README.md
+++ b/interfaces/Julia/README.md
@@ -158,7 +158,8 @@ set_attribute(model, "LP_solver", "HiGHS")
 
 ## BLAS and LAPACK demuxer
 
-`Uno_jll.jl` is compiled with [libblastrampoline](https://github.com/JuliaLinearAlgebra/libblastrampoline) (LBT), a library that can switch between BLAS and LAPACK backends at runtime, such as OpenBLAS, Intel MKL, and Apple Accelerate.
+`Uno_jll.jl` is compiled with [libblastrampoline](https://github.com/JuliaLinearAlgebra/libblastrampoline) (LBT), a library that can switch between BLAS and LAPACK backends at runtime, such as Intel MKL (Intel CPUs), AOCL (AMD CPUs), and Apple Accelerate (Apple Silicon).
+Because Uno and the linear solvers heavily rely on BLAS and LAPACK routines, using an optimized backend for a particular platform can improve the performance.
 The default BLAS and LAPACK backend used in the Julia interface `UnoSolver.jl` is [OpenBLAS](https://github.com/OpenMathLib/OpenBLAS).
 
 ### Display backends
@@ -191,6 +192,16 @@ switch to MKL by adding `using MKL` to your code:
 ```julia
 using MKL
 using UnoSolver
+```
+
+### AOCL
+
+If you have [AOCL.jl](https://github.com/JuliaLinearAlgebra/AOCL.jl) installed,
+switch to AOCL by adding `using AOCL` to your code:
+
+```julia
+using AOCL
+using Ipopt
 ```
 
 ### AppleAccelerate

--- a/interfaces/Julia/README.md
+++ b/interfaces/Julia/README.md
@@ -201,7 +201,7 @@ switch to AOCL by adding `using AOCL` to your code:
 
 ```julia
 using AOCL
-using Ipopt
+using UnoSolver
 ```
 
 ### AppleAccelerate


### PR DESCRIPTION
The "BLAS and LAPACK" section lists MKL, AOCL and Apple Accelerate as alternative backends but doesn't say which platform each one targets. This adds a short hint so users can quickly pick the backend suited to their CPU.

`AOCL.jl` was registered this morning: https://github.com/JuliaLinearAlgebra/AOCL.jl