### PR TITLE
Replace raw pointers with views for KKT blocks

### DIFF
--- a/interfaces/AMPL/AMPLModel.cpp
+++ b/interfaces/AMPL/AMPLModel.cpp
@@ -211,9 +211,9 @@ namespace uno {
    //this->asl->i.x_known = 0;
 
    void AMPLModel::evaluate_lagrangian_hessian(const Vector<double>& /*x*/, double objective_multiplier, const Vector<double>& multipliers,
-         double* hessian_values) const {
+         View<double> hessian_values) const {
       objective_multiplier *= this->optimization_sense;
-      this->asl->p.Sphes(this->asl, nullptr, hessian_values, -1, &objective_multiplier, const_cast<double*>(multipliers.data()));
+      this->asl->p.Sphes(this->asl, nullptr, hessian_values.data(), -1, &objective_multiplier, const_cast<double*>(multipliers.data()));
       ++this->number_model_evaluations.hessian;
    }
 

--- a/interfaces/AMPL/AMPLModel.hpp
+++ b/interfaces/AMPL/AMPLModel.hpp
@@ -52,7 +52,7 @@ namespace uno {
       // numerical evaluations of Jacobian and Hessian
       void evaluate_jacobian(const Vector<double>& x, double* jacobian_values) const override;
       void evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier, const Vector<double>& multipliers,
-         double* hessian_values) const override;
+         View<double> hessian_values) const override;
 
       // linear operators for Jacobian-, Jacobian^T-, and Hessian-vector products
       void compute_jacobian_vector_product(const double* x, const double* vector, double* result) const override;

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -159,7 +159,7 @@ public:
    }
 
    void evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier, const Vector<double>& multipliers,
-         double* hessian_values) const override {
+         View<double> hessian_values) const override {
       if (this->user_model.lagrangian_hessian != nullptr) {
          objective_multiplier *= this->optimization_sense;
          // if the model has a different sign convention for the Lagrangian than Uno, flip the signs of the multipliers
@@ -169,7 +169,7 @@ public:
          const uno_int number_hessian_nonzeros = static_cast<uno_int>(this->number_hessian_nonzeros());
          const uno_int return_code = this->user_model.lagrangian_hessian(this->user_model.number_variables,
             this->user_model.number_constraints, number_hessian_nonzeros, x.data(), objective_multiplier,
-            multipliers.data(), hessian_values, this->user_model.user_data);
+            multipliers.data(), hessian_values.data(), this->user_model.user_data);
          // flip the signs of the multipliers back
          if (this->user_model.lagrangian_sign_convention == UNO_MULTIPLIER_POSITIVE) {
             const_cast<Vector<double>&>(multipliers).scale(-1.);

--- a/interfaces/Python/cpp_classes/PythonModel.cpp
+++ b/interfaces/Python/cpp_classes/PythonModel.cpp
@@ -5,7 +5,7 @@
 #include <pybind11/numpy.h>
 #include <functional>
 #include "PythonModel.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/EvaluationErrors.hpp"
 #include "symbolic/Concatenation.hpp"
 #include "Uno.hpp"

--- a/interfaces/Python/cpp_classes/PythonModel.cpp
+++ b/interfaces/Python/cpp_classes/PythonModel.cpp
@@ -148,7 +148,7 @@ namespace uno {
    }
 
    void PythonModel::evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier, const Vector<double>& multipliers,
-         double* hessian_values) const {
+         View<double> hessian_values) const {
       if (this->user_model.lagrangian_hessian.has_value()) {
          objective_multiplier *= this->optimization_sense;
          // if the model has a different sign convention for the Lagrangian than Uno, flip the signs of the multipliers
@@ -157,7 +157,7 @@ namespace uno {
          }
          const auto x_py = to_const_array(x.data(), this->number_variables);
          const auto multipliers_py = to_const_array(multipliers.data(), this->number_constraints);
-         auto hessian_py = to_array(hessian_values, this->number_hessian_nonzeros());
+         auto hessian_py = to_array(hessian_values.data(), this->number_hessian_nonzeros());
 
          // evaluate Lagrangian Hessian
          try {

--- a/interfaces/Python/cpp_classes/PythonModel.hpp
+++ b/interfaces/Python/cpp_classes/PythonModel.hpp
@@ -42,7 +42,7 @@ namespace uno {
       // numerical evaluations of Jacobian and Hessian
       void evaluate_jacobian(const Vector<double>& x, double* jacobian_values) const override;
       void evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier, const Vector<double>& multipliers,
-         double* hessian_values) const override;
+         View<double> hessian_values) const override;
 
       // linear operators for Jacobian-, Jacobian^T-, and Hessian-vector products
       void compute_jacobian_vector_product(const double* x, const double* vector, double* result) const override;

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -4,7 +4,7 @@
 #include "ConstraintRelaxationStrategy.hpp"
 #include "ingredients/globalization_strategies/GlobalizationStrategy.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/EvaluationCache.hpp"

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -14,7 +14,7 @@
 #include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategyFactory.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "ingredients/subproblem_solvers/SubproblemSolverFactory.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/EvaluationCache.hpp"

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -11,7 +11,7 @@
 #include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategyFactory.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "ingredients/subproblem_solvers/SubproblemSolverFactory.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/EvaluationCache.hpp"
 #include "optimization/Iterate.hpp"

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -153,7 +153,7 @@ namespace uno {
       }
    }
 
-   void l1RelaxedProblem::evaluate_jacobian(const Vector<double>& primals, double* jacobian_values, Evaluations& evaluations) const {
+   void l1RelaxedProblem::evaluate_jacobian(const Vector<double>& primals, View<double> jacobian_values, Evaluations& evaluations) const {
       evaluations.evaluate_jacobian(this->model, primals);
       for (size_t nonzeros_index: Range(this->model.number_jacobian_nonzeros())) {
          jacobian_values[nonzeros_index] = evaluations.jacobian_values[nonzeros_index];
@@ -216,7 +216,7 @@ namespace uno {
    }
 
    void l1RelaxedProblem::evaluate_lagrangian_hessian(Statistics& statistics, HessianModel& hessian_model, const Vector<double>& primal_variables,
-         const Multipliers& multipliers, double* hessian_values) const {
+         const Multipliers& multipliers, View<double> hessian_values) const {
       hessian_model.evaluate_hessian(statistics, primal_variables, this->get_objective_multiplier(),
          multipliers.constraints, hessian_values);
 
@@ -225,7 +225,7 @@ namespace uno {
       size_t nonzero_index = number_hessian_nonzeros;
       if (this->proximal_center != nullptr) {
          if (this->proximal_coefficient == 0.) {
-            view(hessian_values, number_hessian_nonzeros, number_hessian_nonzeros + this->model.number_variables).fill(0.);
+            view(hessian_values.data(), number_hessian_nonzeros, number_hessian_nonzeros + this->model.number_variables).fill(0.);
          }
          else {
             for (size_t variable_index: Range(this->model.number_variables)) {

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -3,7 +3,7 @@
 
 #include "l1RelaxedProblem.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "model/Model.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -37,11 +37,11 @@ namespace uno {
       // numerical evaluations of constraints, objective gradient, Jacobian and Hessian
       void evaluate_constraints(const Iterate& iterate, double* constraints, Evaluations& evaluations) const override;
       void evaluate_objective_gradient(const Iterate& iterate, double* objective_gradient, Evaluations& evaluations) const override;
-      void evaluate_jacobian(const Vector<double>& primals, double* jacobian_values, Evaluations& evaluations) const override;
+      void evaluate_jacobian(const Vector<double>& primals, View<double> jacobian_values, Evaluations& evaluations) const override;
       void evaluate_lagrangian_gradient(const Iterate& iterate, Evaluations& evaluations,
          Vector<double>& lagrangian_gradient) const override;
       void evaluate_lagrangian_hessian(Statistics& statistics, HessianModel& hessian_model, const Vector<double>& primal_variables,
-         const Multipliers& multipliers, double* hessian_values) const override;
+         const Multipliers& multipliers, View<double> hessian_values) const override;
 
       // linear operators
       void compute_jacobian_vector_product(const double* vector, double* result, const Evaluations& evaluations) const override;

--- a/uno/ingredients/hessian_models/ExactHessian.cpp
+++ b/uno/ingredients/hessian_models/ExactHessian.cpp
@@ -41,7 +41,7 @@ namespace uno {
    }
 
    void ExactHessian::evaluate_hessian(Statistics& /*statistics*/, const Vector<double>& primal_variables,
-         double objective_multiplier, const Vector<double>& constraint_multipliers, double* hessian_values) {
+         double objective_multiplier, const Vector<double>& constraint_multipliers, View<double> hessian_values) {
       this->model.evaluate_lagrangian_hessian(primal_variables, objective_multiplier, constraint_multipliers, hessian_values);
       ++this->evaluation_count;
    }

--- a/uno/ingredients/hessian_models/ExactHessian.hpp
+++ b/uno/ingredients/hessian_models/ExactHessian.hpp
@@ -26,7 +26,7 @@ namespace uno {
       void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) override;
       void evaluate_hessian(Statistics& statistics, const Vector<double>& primal_variables, double objective_multiplier,
-         const Vector<double>& constraint_multipliers, double* hessian_values) override;
+         const Vector<double>& constraint_multipliers, View<double> hessian_values) override;
       void compute_hessian_vector_product(const double* x, const double* vector, double objective_multiplier,
          const Vector<double>& constraint_multipliers, double* result) override;
 

--- a/uno/ingredients/hessian_models/HessianModel.hpp
+++ b/uno/ingredients/hessian_models/HessianModel.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include "../interfaces/C/uno_int.h"
+#include "linear_algebra/View.hpp"
 
 namespace uno {
    // forward declarations
@@ -36,7 +37,7 @@ namespace uno {
       virtual void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) = 0;
       virtual void evaluate_hessian(Statistics& statistics, const Vector<double>& primal_variables,
-         double objective_multiplier, const Vector<double>& constraint_multipliers, double* hessian_values) = 0;
+         double objective_multiplier, const Vector<double>& constraint_multipliers, View<double> hessian_values) = 0;
       virtual void compute_hessian_vector_product(const double* x, const double* vector, double objective_multiplier,
          const Vector<double>& constraint_multipliers, double* result) = 0;
    };

--- a/uno/ingredients/hessian_models/IdentityHessian.cpp
+++ b/uno/ingredients/hessian_models/IdentityHessian.cpp
@@ -45,7 +45,7 @@ namespace uno {
    }
 
    void IdentityHessian::evaluate_hessian(Statistics& /*statistics*/, const Vector<double>& /*primal_variables*/,
-         double /*objective_multiplier*/, const Vector<double>& /*constraint_multipliers*/, double* hessian_values) {
+         double /*objective_multiplier*/, const Vector<double>& /*constraint_multipliers*/, View<double> hessian_values) {
       DEBUG << "Setting identity Hessian\n";
       for (size_t variable_index: Range(this->number_variables)) {
          hessian_values[variable_index] = 1.;

--- a/uno/ingredients/hessian_models/IdentityHessian.hpp
+++ b/uno/ingredients/hessian_models/IdentityHessian.hpp
@@ -22,7 +22,7 @@ namespace uno {
       void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) override;
       void evaluate_hessian(Statistics& statistics, const Vector<double>& primal_variables,
-         double objective_multiplier, const Vector<double>& constraint_multipliers, double* hessian_values) override;
+         double objective_multiplier, const Vector<double>& constraint_multipliers, View<double> hessian_values) override;
       void compute_hessian_vector_product(const double* x, const double* vector, double objective_multiplier,
          const Vector<double>& constraint_multipliers, double* result) override;
 

--- a/uno/ingredients/hessian_models/ZeroHessian.cpp
+++ b/uno/ingredients/hessian_models/ZeroHessian.cpp
@@ -40,7 +40,7 @@ namespace uno {
    }
 
    void ZeroHessian::evaluate_hessian(Statistics& /*statistics*/, const Vector<double>& /*primal_variables*/,
-         double /*objective_multiplier*/, const Vector<double>& /*constraint_multipliers*/, double* /*hessian_values*/) {
+         double /*objective_multiplier*/, const Vector<double>& /*constraint_multipliers*/, View<double> /*hessian_values*/) {
       // do nothing
    }
 

--- a/uno/ingredients/hessian_models/ZeroHessian.hpp
+++ b/uno/ingredients/hessian_models/ZeroHessian.hpp
@@ -23,7 +23,7 @@ namespace uno {
       void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) override;
       void evaluate_hessian(Statistics& statistics, const Vector<double>& primal_variables, double objective_multiplier,
-         const Vector<double>& constraint_multipliers, double* hessian_values) override;
+         const Vector<double>& constraint_multipliers, View<double> hessian_values) override;
       void compute_hessian_vector_product(const double* x, const double* vector, double objective_multiplier,
          const Vector<double>& constraint_multipliers, double* result) override;
 

--- a/uno/ingredients/hessian_models/quasi_newton/direct/DirectQuasiNewtonHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/DirectQuasiNewtonHessian.cpp
@@ -43,7 +43,7 @@ namespace uno {
    // forms the diagonal part of the L-BFGS Hessian approximation
    // this can only be called by WoodburyEQPSolver
    void DirectQuasiNewtonHessian::evaluate_hessian(Statistics& /*statistics*/, const Vector<double>& /*primal_variables*/,
-         double /*objective_multiplier*/, const Vector<double>& /*constraint_multipliers*/, double* hessian_values) {
+         double /*objective_multiplier*/, const Vector<double>& /*constraint_multipliers*/, View<double> hessian_values) {
       // recompute the Hessian representation if the limited memory was updated
       if (this->hessian_recomputation_required) {
          this->recompute_hessian_representation();

--- a/uno/ingredients/hessian_models/quasi_newton/direct/DirectQuasiNewtonHessian.hpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/DirectQuasiNewtonHessian.hpp
@@ -24,7 +24,7 @@ namespace uno {
 
       // functions that can be called by WoodburyEQPSolver
       [[nodiscard]] virtual size_t get_correction_rank() const = 0;
-      [[nodiscard]] virtual VectorView<const double> get_correction_column(size_t column_index) const = 0;
+      [[nodiscard]] virtual View<const double> get_correction_column(size_t column_index) const = 0;
       [[nodiscard]] virtual double get_correction_column_scaling(size_t column_index) const = 0;
    };
 } // namespace

--- a/uno/ingredients/hessian_models/quasi_newton/direct/DirectQuasiNewtonHessian.hpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/DirectQuasiNewtonHessian.hpp
@@ -20,7 +20,7 @@ namespace uno {
       void compute_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int solver_indexing) const override;
 
       void evaluate_hessian(Statistics& statistics, const Vector<double>& primal_variables,
-         double objective_multiplier, const Vector<double>& constraint_multipliers, double* hessian_values) override;
+         double objective_multiplier, const Vector<double>& constraint_multipliers, View<double> hessian_values) override;
 
       // functions that can be called by WoodburyEQPSolver
       [[nodiscard]] virtual size_t get_correction_rank() const = 0;

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
@@ -6,7 +6,7 @@
 #include "model/Model.hpp"
 #include "options/Options.hpp"
 #include "linear_algebra/BLAS.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/Iterate.hpp"
 #include "symbolic/Inverse.hpp"
 #include "symbolic/Multiplication.hpp"
@@ -125,7 +125,7 @@ namespace uno {
    }
 
    // get a column of (U V)
-   VectorView<const double> LBFGSHessian::get_correction_column(size_t column_index) const {
+   View<const double> LBFGSHessian::get_correction_column(size_t column_index) const {
       if (column_index < this->number_entries_in_memory) {
          return this->U.column(column_index);
       }

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.hpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.hpp
@@ -34,7 +34,7 @@ namespace uno {
 
       // functions that can be called by WoodburyEQPSolver
       [[nodiscard]] size_t get_correction_rank() const override;
-      [[nodiscard]] VectorView<const double> get_correction_column(size_t column_index) const override;
+      [[nodiscard]] View<const double> get_correction_column(size_t column_index) const override;
       [[nodiscard]] double get_correction_column_scaling(size_t column_index) const override;
 
    protected:

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -86,7 +86,7 @@ namespace uno {
       return this->number_entries_in_memory;
    }
 
-   VectorView<const double> LSR1Hessian::get_correction_column(size_t column_index) const {
+   View<const double> LSR1Hessian::get_correction_column(size_t column_index) const {
       return this->U.column(column_index);
    }
 

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.hpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.hpp
@@ -29,7 +29,7 @@ namespace uno {
 
       // functions that can be called by WoodburyEQPSolver
       [[nodiscard]] size_t get_correction_rank() const override;
-      [[nodiscard]] VectorView<const double> get_correction_column(size_t column_index) const override;
+      [[nodiscard]] View<const double> get_correction_column(size_t column_index) const override;
       [[nodiscard]] double get_correction_column_scaling(size_t column_index) const override;
 
    protected:

--- a/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
@@ -76,7 +76,7 @@ namespace uno {
    }
 
    void InverseLBFGSHessian::evaluate_hessian(Statistics& /*statistics*/, const Vector<double>& /*primal_variables*/,
-         double /*objective_multiplier*/, const Vector<double>& /*constraint_multipliers*/, double* /*hessian_values*/) {
+         double /*objective_multiplier*/, const Vector<double>& /*constraint_multipliers*/, View<double> /*hessian_values*/) {
       throw std::runtime_error("InverseLBFGSHessian::evaluate_hessian should not be called.");
    }
 

--- a/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
@@ -6,7 +6,7 @@
 #include "model/Model.hpp"
 #include "options/Options.hpp"
 #include "linear_algebra/Vector.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/Iterate.hpp"
 #include "symbolic/Inverse.hpp"
 #include "symbolic/Multiplication.hpp"

--- a/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.hpp
+++ b/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.hpp
@@ -27,7 +27,7 @@ namespace uno {
          Evaluations& current_evaluations, Evaluations& trial_evaluations) override;
 
       void evaluate_hessian(Statistics& statistics, const Vector<double>& primal_variables,
-         double objective_multiplier, const Vector<double>& constraint_multipliers, double* hessian_values) override;
+         double objective_multiplier, const Vector<double>& constraint_multipliers, View<double> hessian_values) override;
       void compute_hessian_vector_product(const double* x, const double* vector, double objective_multiplier,
          const Vector<double>& constraint_multipliers, double* result) override;
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -5,7 +5,7 @@
 #include "../InteriorPointParameters.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
 #include "linear_algebra/SparseVector.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Evaluations.hpp"

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -171,7 +171,8 @@ namespace uno {
       }
    }
 
-   void PrimalDualInteriorPointProblem::evaluate_jacobian(const Vector<double>& primals, double* jacobian_values, Evaluations& evaluations) const {
+   void PrimalDualInteriorPointProblem::evaluate_jacobian(const Vector<double>& primals, View<double> jacobian_values,
+         Evaluations& evaluations) const {
       this->inner.evaluate_jacobian(primals, jacobian_values, evaluations);
    }
 
@@ -205,7 +206,7 @@ namespace uno {
    }
 
    void PrimalDualInteriorPointProblem::evaluate_lagrangian_hessian(Statistics& statistics, HessianModel& hessian_model, const Vector<double>& primal_variables,
-         const Multipliers& multipliers, double* hessian_values) const {
+         const Multipliers& multipliers, View<double> hessian_values) const {
       // original Lagrangian Hessian
       this->inner.evaluate_lagrangian_hessian(statistics, hessian_model, primal_variables, multipliers, hessian_values);
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.hpp
@@ -37,11 +37,11 @@ namespace uno {
       // numerical evaluations of constraints, objective gradient, Jacobian and Hessian
       void evaluate_constraints(const Iterate& iterate, double* constraints, Evaluations& evaluations) const override;
       void evaluate_objective_gradient(const Iterate& iterate, double* objective_gradient, Evaluations& evaluations) const override;
-      void evaluate_jacobian(const Vector<double>& primals, double* jacobian_values, Evaluations& evaluations) const override;
+      void evaluate_jacobian(const Vector<double>& primals, View<double> jacobian_values, Evaluations& evaluations) const override;
       void evaluate_lagrangian_gradient(const Iterate& iterate, Evaluations& evaluations,
          Vector<double>& lagrangian_gradient) const override;
       void evaluate_lagrangian_hessian(Statistics& statistics, HessianModel& hessian_model, const Vector<double>& primal_variables,
-         const Multipliers& multipliers, double* hessian_values) const override;
+         const Multipliers& multipliers, View<double> hessian_values) const override;
 
       // linear operators
       void compute_jacobian_vector_product(const double* vector, double* result, const Evaluations& evaluations) const override;

--- a/uno/ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp
+++ b/uno/ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp
@@ -5,6 +5,7 @@
 #define UNO_INERTIACORRECTIONSTRATEGY_H
 
 #include <string>
+#include "linear_algebra/View.hpp"
 
 namespace uno {
    // forward declarations
@@ -27,11 +28,11 @@ namespace uno {
       virtual void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
          DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* hessian_values) = 0;
       virtual void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
-         double dual_regularization_parameter, const Inertia& expected_inertia, double* primal_regularization_values,
-         double* dual_regularization_values) = 0;
+         double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block) = 0;
       virtual void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double dual_regularization_parameter, const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         double* primal_regularization_values, double* dual_regularization_values) = 0;
+        View<double> primal_inertia_correction_block, View<double> dual_inertia_correction_block) = 0;
 
       [[nodiscard]] virtual bool performs_primal_regularization() const = 0;
       [[nodiscard]] virtual bool performs_dual_regularization() const = 0;

--- a/uno/ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp
+++ b/uno/ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp
@@ -24,9 +24,9 @@ namespace uno {
       virtual void initialize_statistics(Statistics& statistics) = 0;
 
       virtual void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
-         double* hessian_values) = 0;
+         View<double> hessian_values) = 0;
       virtual void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
-         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* hessian_values) = 0;
+         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, View<double> hessian_values) = 0;
       virtual void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
          View<double> dual_inertia_correction_block) = 0;

--- a/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.cpp
@@ -21,20 +21,16 @@ namespace uno {
    }
 
    void NoInertiaCorrection::regularize_augmented_matrix(Statistics& /*statistics*/, const Subproblem& /*subproblem*/,
-         double /*dual_regularization_parameter*/, const Inertia& /*expected_inertia*/, double* /*primal_regularization_values*/,
-         double* /*dual_regularization_values*/) {
+         double /*dual_regularization_parameter*/, const Inertia& /*expected_inertia*/, View<double> /*primal_inertia_correction_block*/,
+         View<double> /*dual_inertia_correction_block*/) {
       // do nothing
    }
 
    void NoInertiaCorrection::regularize_augmented_matrix(Statistics& /*statistics*/, const Subproblem& subproblem,
          double /*dual_regularization_parameter*/, const Inertia& /*expected_inertia*/, DirectSymmetricIndefiniteLinearSolver<double>& /*linear_solver*/,
-         double* primal_regularization_values, double* dual_regularization_values) {
-      for (size_t index: Range(subproblem.get_primal_regularization_variables().size())) {
-         primal_regularization_values[index] = 0.;
-      }
-      for (size_t index: Range(subproblem.get_dual_regularization_constraints().size())) {
-         dual_regularization_values[index] = 0.;
-      }
+         View<double> primal_inertia_correction_block, View<double> dual_inertia_correction_block) {
+      primal_inertia_correction_block.fill(0.);
+      dual_inertia_correction_block.fill(0.);
    }
 
    [[nodiscard]] bool NoInertiaCorrection::performs_primal_regularization() const {

--- a/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.cpp
@@ -10,13 +10,13 @@ namespace uno {
    }
 
    void NoInertiaCorrection::regularize_hessian(Statistics& /*statistics*/, const Subproblem& /*subproblem*/,
-         const Inertia& /*expected_inertia*/, double* /*hessian_values*/) {
+         const Inertia& /*expected_inertia*/, View<double> /*hessian_values*/) {
       // do nothing
    }
 
    void NoInertiaCorrection::regularize_hessian(Statistics& /*statistics*/, const Subproblem& /*subproblem*/,
          const Inertia& /*expected_inertia*/, DirectSymmetricIndefiniteLinearSolver<double>& /*linear_solver*/,
-         double* /*hessian_values*/) {
+         View<double> /*hessian_values*/) {
       // do nothing
    }
 

--- a/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.hpp
@@ -18,11 +18,11 @@ namespace uno {
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
          DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* hessian_values) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
-         double dual_regularization_parameter, const Inertia& expected_inertia, double* primal_regularization_values,
-            double* dual_regularization_values) override;
+         double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem, double dual_regularization_parameter,
          const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         double* primal_regularization_values, double* dual_regularization_values) override;
+         View<double> primal_inertia_correction_block, View<double> dual_inertia_correction_block) override;
 
       [[nodiscard]] bool performs_primal_regularization() const override;
       [[nodiscard]] bool performs_dual_regularization() const override;

--- a/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.hpp
@@ -14,9 +14,9 @@ namespace uno {
       void initialize_statistics(Statistics& statistics) override;
 
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
-         double* hessian_values) override;
+         View<double> hessian_values) override;
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
-         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* hessian_values) override;
+         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, View<double> hessian_values) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
          View<double> dual_inertia_correction_block) override;

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
@@ -32,7 +32,7 @@ namespace uno {
    }
 
    void PrimalDualInertiaCorrection::regularize_hessian(Statistics& statistics, const Subproblem& subproblem,
-         const Inertia& expected_inertia, double* hessian_values) {
+         const Inertia& expected_inertia, View<double> hessian_values) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
          this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
@@ -45,7 +45,7 @@ namespace uno {
 
    void PrimalDualInertiaCorrection::regularize_hessian(Statistics& /*statistics*/, const Subproblem& /*subproblem*/,
          const Inertia& /*expected_inertia*/, DirectSymmetricIndefiniteLinearSolver<double>& /*linear_solver*/,
-         double* /*hessian_values*/) {
+         View<double> /*hessian_values*/) {
       // to regularize the Hessian only, call the function for the augmented matrix with no dual part
       // TODO fix
       throw std::runtime_error("PrimalDualInertiaCorrection::regularize_hessian not implemented yet");

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
@@ -53,8 +53,8 @@ namespace uno {
 
    // the augmented matrix has been factorized prior to calling this function
    void PrimalDualInertiaCorrection::regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
-         double dual_regularization_parameter, const Inertia& expected_inertia, double* primal_regularization_values,
-         double* dual_regularization_values) {
+         double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block) {
       if (this->optional_linear_solver == nullptr) {
          this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
          this->optional_linear_solver->get_linear_system().initialize_augmented_system(subproblem);
@@ -62,20 +62,17 @@ namespace uno {
          this->optional_linear_solver->do_symbolic_analysis();
       }
       this->regularize_augmented_matrix(statistics, subproblem, dual_regularization_parameter, expected_inertia,
-         *this->optional_linear_solver, primal_regularization_values, dual_regularization_values);
+         *this->optional_linear_solver, primal_inertia_correction_block, dual_inertia_correction_block);
    }
 
    void PrimalDualInertiaCorrection::regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double dual_regularization_parameter, const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         double* primal_regularization_values, double* dual_regularization_values) {
+         View<double> primal_inertia_correction_block, View<double> dual_inertia_correction_block) {
       this->primal_regularization = 0.;
       this->dual_regularization = 0.;
-      for (size_t index: Range(subproblem.get_primal_regularization_variables().size())) {
-         primal_regularization_values[index] = this->primal_regularization;
-      }
-      for (size_t index: Range(subproblem.get_dual_regularization_constraints().size())) {
-         dual_regularization_values[index] = -this->dual_regularization;
-      }
+      primal_inertia_correction_block.fill(this->primal_regularization);
+      dual_inertia_correction_block.fill(-this->dual_regularization);
+
       DEBUG2 << '\n';
       DEBUG << "Testing factorization with regularization factors (0, 0)\n";
       size_t number_attempts = 1;
@@ -108,12 +105,8 @@ namespace uno {
       }
 
       // regularize the augmented matrix
-      for (size_t index: Range(subproblem.get_primal_regularization_variables().size())) {
-         primal_regularization_values[index] = this->primal_regularization;
-      }
-      for (size_t index: Range(subproblem.get_dual_regularization_constraints().size())) {
-         dual_regularization_values[index] = -this->dual_regularization;
-      }
+      primal_inertia_correction_block.fill(this->primal_regularization);
+      dual_inertia_correction_block.fill(-this->dual_regularization);
 
       bool good_inertia = false;
       while (!good_inertia) {
@@ -143,12 +136,8 @@ namespace uno {
 
             if (this->primal_regularization <= this->regularization_failure_threshold) {
                // regularize the augmented matrix
-               for (size_t index: Range(subproblem.get_primal_regularization_variables().size())) {
-                  primal_regularization_values[index] = this->primal_regularization;
-               }
-               for (size_t index: Range(subproblem.get_dual_regularization_constraints().size())) {
-                  dual_regularization_values[index] = -this->dual_regularization;
-               }
+               primal_inertia_correction_block.fill(this->primal_regularization);
+               dual_inertia_correction_block.fill(-this->dual_regularization);
             }
             else {
                throw UnstableInertiaCorrection();

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.hpp
@@ -24,11 +24,11 @@ namespace uno {
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
          DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* hessian_values) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
-         double dual_regularization_parameter, const Inertia& expected_inertia, double* primal_regularization_values,
-         double* dual_regularization_values) override;
+         double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double dual_regularization_parameter, const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         double* primal_regularization_values, double* dual_regularization_values) override;
+         View<double> primal_inertia_correction_block, View<double> dual_inertia_correction_block) override;
 
       [[nodiscard]] bool performs_primal_regularization() const override;
       [[nodiscard]] bool performs_dual_regularization() const override;

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.hpp
@@ -20,9 +20,9 @@ namespace uno {
       void initialize_statistics(Statistics& statistics) override;
 
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
-         double* hessian_values) override;
+         View<double> hessian_values) override;
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
-         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* hessian_values) override;
+         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, View<double> hessian_values) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
          View<double> dual_inertia_correction_block) override;

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
@@ -87,8 +87,8 @@ namespace uno {
    }
 
    void PrimalInertiaCorrection::regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
-         double dual_regularization_parameter, const Inertia& expected_inertia, double* primal_regularization_values,
-         double* dual_regularization_values) {
+         double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
          this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
@@ -97,13 +97,14 @@ namespace uno {
          this->optional_linear_solver->do_symbolic_analysis();
       }
       this->regularize_augmented_matrix(statistics, subproblem, dual_regularization_parameter, expected_inertia,
-         *this->optional_linear_solver, primal_regularization_values, dual_regularization_values);
+         *this->optional_linear_solver, primal_inertia_correction_block, dual_inertia_correction_block);
    }
 
    void PrimalInertiaCorrection::regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double /*dual_regularization_parameter*/, const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         double* primal_regularization_values, double* /*dual_regularization_values*/) {
-      this->regularize_hessian(statistics, subproblem, expected_inertia, linear_solver, primal_regularization_values);
+         View<double> /*primal_inertia_correction_block*/, View<double> /*dual_inertia_correction_block*/) {
+      // this->regularize_hessian(statistics, subproblem, expected_inertia, linear_solver, primal_regularization_values);
+      throw std::runtime_error("NOT IMPLEMENTED YET");
    }
 
    bool PrimalInertiaCorrection::performs_primal_regularization() const {

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
@@ -27,7 +27,7 @@ namespace uno {
 
    // Nocedal and Wright, p51
    void PrimalInertiaCorrection::regularize_hessian(Statistics& statistics, const Subproblem& subproblem,
-         const Inertia& expected_inertia, double* hessian_values) {
+         const Inertia& expected_inertia, View<double> hessian_values) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
          this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
@@ -42,7 +42,7 @@ namespace uno {
          matrix[nonzero_index] = hessian_values[nonzero_index];
       }
       // figure out where to set the regularization terms in the linear system
-      double* primal_regularization_values = matrix + number_hessian_nonzeros;
+      View<double> primal_regularization_values(matrix + number_hessian_nonzeros, subproblem.number_primal_inertia_correction_nonzeros());
       // regularize the Hessian
       this->regularize_hessian(statistics, subproblem, expected_inertia, *this->optional_linear_solver, primal_regularization_values);
       // copy the regularization terms back into the Hessian
@@ -53,14 +53,12 @@ namespace uno {
 
    void PrimalInertiaCorrection::regularize_hessian(Statistics& statistics, const Subproblem& subproblem,
          const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         double* primal_regularization_values) {
+         View<double> primal_regularization_values) {
       this->regularization_factor = 0.;
       bool good_inertia = false;
       while (!good_inertia) {
          DEBUG << "Testing factorization with regularization factor " << this->regularization_factor << '\n';
-         for (size_t index: Range(subproblem.get_primal_regularization_variables().size())) {
-            primal_regularization_values[index] = this->regularization_factor;
-         }
+         primal_regularization_values.fill(this->regularization_factor);
          DEBUG << '\n';
 
          // perform factorization to get an estimate of the inertia
@@ -102,9 +100,8 @@ namespace uno {
 
    void PrimalInertiaCorrection::regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double /*dual_regularization_parameter*/, const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         View<double> /*primal_inertia_correction_block*/, View<double> /*dual_inertia_correction_block*/) {
-      // this->regularize_hessian(statistics, subproblem, expected_inertia, linear_solver, primal_regularization_values);
-      throw std::runtime_error("NOT IMPLEMENTED YET");
+         View<double> primal_inertia_correction_block, View<double> /*dual_inertia_correction_block*/) {
+      this->regularize_hessian(statistics, subproblem, expected_inertia, linear_solver, primal_inertia_correction_block);
    }
 
    bool PrimalInertiaCorrection::performs_primal_regularization() const {

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.hpp
@@ -25,11 +25,11 @@ namespace uno {
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
          DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* hessian_values) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
-         double dual_regularization_parameter, const Inertia& expected_inertia, double* primal_regularization_values,
-         double* dual_regularization_values) override;
+         double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double dual_regularization_parameter, const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         double* primal_regularization_values, double* dual_regularization_values) override;
+         View<double> primal_inertia_correction_block, View<double> dual_inertia_correction_block) override;
 
       [[nodiscard]] bool performs_primal_regularization() const override;
       [[nodiscard]] bool performs_dual_regularization() const override;

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.hpp
@@ -21,9 +21,9 @@ namespace uno {
       void initialize_statistics(Statistics& statistics) override;
 
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
-         double* hessian_values) override;
+         View<double> hessian_values) override;
       void regularize_hessian(Statistics& statistics, const Subproblem& subproblem, const Inertia& expected_inertia,
-         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, double* hessian_values) override;
+         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver, View<double> hessian_values) override;
       void regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
          View<double> dual_inertia_correction_block) override;

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -112,8 +112,9 @@ namespace uno {
       }
    }
 
-   void Subproblem::regularize_augmented_matrix(Statistics& statistics, double* augmented_matrix_values,
-         double dual_regularization_parameter, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver) const {
+   void Subproblem::regularize_augmented_matrix(Statistics& statistics, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block, double dual_regularization_parameter,
+         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver) const {
       if ((!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) ||
             this->inertia_correction_strategy.performs_dual_regularization()) {
          const Inertia expected_inertia = this->problem.get_inertia();
@@ -121,12 +122,8 @@ namespace uno {
                this->number_variables + this->number_constraints) {
             throw std::runtime_error("Mismatch in expected inertia");
          }
-
-         const size_t offset = this->number_hessian_nonzeros() + this->problem.number_jacobian_nonzeros();
-         double* primal_regularization_values = augmented_matrix_values + offset;
-         double* dual_regularization_values = augmented_matrix_values + offset + this->get_primal_regularization_variables().size();
          this->inertia_correction_strategy.regularize_augmented_matrix(statistics, *this, dual_regularization_parameter,
-            expected_inertia, linear_solver, primal_regularization_values, dual_regularization_values);
+            expected_inertia, linear_solver, primal_inertia_correction_block, dual_inertia_correction_block);
       }
       else {
          linear_solver.do_numerical_factorization(false);

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -7,7 +7,7 @@
 #include "ingredients/subproblem_solvers/DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "ingredients/subproblem_solvers/SolverWorkspace.hpp"
 #include "linear_algebra/Vector.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Evaluations.hpp"

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -51,15 +51,8 @@ namespace uno {
       // sparsity of original Lagrangian Hessian in the (1, 1) block
       this->problem.compute_hessian_sparsity(this->hessian_model, row_indices, column_indices, solver_indexing);
 
-      // copy Jacobian of general constraints into the (2, 1) block
+      // primal inertia correction (if applicable)
       size_t nonzero_index = this->number_hessian_nonzeros();
-      const uno_int row_offset = static_cast<uno_int>(this->problem.number_variables);
-      constexpr uno_int column_offset = 0;
-      this->problem.compute_jacobian_sparsity(row_indices + nonzero_index, column_indices + nonzero_index,
-         row_offset, column_offset, solver_indexing, MatrixOrder::COLUMN_MAJOR);
-
-      // regularize the augmented matrix only if required (diagonal regularization)
-      nonzero_index += this->problem.number_jacobian_nonzeros();
       if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
          for (size_t variable_index: this->get_primal_regularization_variables()) {
             row_indices[nonzero_index] = static_cast<uno_int>(variable_index) + solver_indexing;
@@ -67,6 +60,15 @@ namespace uno {
             ++nonzero_index;
          }
       }
+
+      // copy Jacobian of general constraints into the (2, 1) block
+      const uno_int row_offset = static_cast<uno_int>(this->problem.number_variables);
+      constexpr uno_int column_offset = 0;
+      this->problem.compute_jacobian_sparsity(row_indices + nonzero_index, column_indices + nonzero_index,
+         row_offset, column_offset, solver_indexing, MatrixOrder::COLUMN_MAJOR);
+
+      // dual inertia correction (if applicable)
+      nonzero_index += this->problem.number_jacobian_nonzeros();
       if (this->inertia_correction_strategy.performs_dual_regularization()) {
          for (size_t constraint_index: this->get_dual_regularization_constraints()) {
             const uno_int shifted_constraint_index = static_cast<uno_int>(this->number_variables + constraint_index);

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -87,7 +87,7 @@ namespace uno {
          this->current_iterate.multipliers, hessian_values);
    }
 
-   void Subproblem::regularize_lagrangian_hessian(Statistics& statistics, double* hessian_values) const {
+   void Subproblem::regularize_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const {
       // regularize the Hessian only if necessary
       if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
          const Inertia problem_inertia = this->problem.get_inertia();

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -35,7 +35,7 @@ namespace uno {
       this->problem.compute_hessian_sparsity(this->hessian_model, row_indices, column_indices, solver_indexing);
 
       // regularize the Hessian only if required (diagonal regularization)
-      if (!this->hessian_model.is_positive_definite() && this->inertia_correction_strategy.performs_primal_regularization()) {
+      if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
          size_t current_index = this->number_hessian_nonzeros();
          for (size_t variable_index: this->get_primal_regularization_variables()) {
             row_indices[current_index] = static_cast<uno_int>(variable_index) + solver_indexing;
@@ -60,7 +60,7 @@ namespace uno {
 
       // regularize the augmented matrix only if required (diagonal regularization)
       nonzero_index += this->problem.number_jacobian_nonzeros();
-      if (!this->hessian_model.is_positive_definite() && this->inertia_correction_strategy.performs_primal_regularization()) {
+      if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
          for (size_t variable_index: this->get_primal_regularization_variables()) {
             row_indices[nonzero_index] = static_cast<uno_int>(variable_index) + solver_indexing;
             column_indices[nonzero_index] = static_cast<uno_int>(variable_index) + solver_indexing;
@@ -77,11 +77,11 @@ namespace uno {
       }
    }
 
-   void Subproblem::evaluate_jacobian(double* jacobian_values, Evaluations& evaluations) const {
+   void Subproblem::evaluate_jacobian(View<double> jacobian_values, Evaluations& evaluations) const {
       this->problem.evaluate_jacobian(this->current_iterate.primals, jacobian_values, evaluations);
    }
 
-   void Subproblem::evaluate_lagrangian_hessian(Statistics& statistics, double* hessian_values) const {
+   void Subproblem::evaluate_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const {
       // evaluate the Lagrangian Hessian of the problem at the current primal-dual point
       this->problem.evaluate_lagrangian_hessian(statistics, this->hessian_model, this->current_iterate.primals,
          this->current_iterate.multipliers, hessian_values);
@@ -89,7 +89,7 @@ namespace uno {
 
    void Subproblem::regularize_lagrangian_hessian(Statistics& statistics, double* hessian_values) const {
       // regularize the Hessian only if necessary
-      if (!this->hessian_model.is_positive_definite() && this->inertia_correction_strategy.performs_primal_regularization()) {
+      if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
          const Inertia problem_inertia = this->problem.get_inertia();
          const Inertia expected_inertia = {problem_inertia.positive, 0, problem_inertia.zero};
          if (expected_inertia.positive + expected_inertia.zero != this->number_variables) {
@@ -114,7 +114,7 @@ namespace uno {
 
    void Subproblem::regularize_augmented_matrix(Statistics& statistics, double* augmented_matrix_values,
          double dual_regularization_parameter, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver) const {
-      if ((!this->hessian_model.is_positive_definite() && this->inertia_correction_strategy.performs_primal_regularization()) ||
+      if ((!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) ||
             this->inertia_correction_strategy.performs_dual_regularization()) {
          const Inertia expected_inertia = this->problem.get_inertia();
          if (expected_inertia.positive + expected_inertia.negative + expected_inertia.zero !=
@@ -198,7 +198,7 @@ namespace uno {
       }
       else {
          // otherwise, the regularization strategy may introduce curvature
-         if (!this->hessian_model.is_positive_definite() && this->inertia_correction_strategy.performs_primal_regularization()) {
+         if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
             return !this->problem.get_primal_regularization_variables().empty();
          }
          return false;
@@ -222,7 +222,7 @@ namespace uno {
    }
 
    const Collection<size_t>& Subproblem::get_primal_regularization_variables() const {
-      if (!this->hessian_model.is_positive_definite() && this->inertia_correction_strategy.performs_primal_regularization()) {
+      if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
          return this->problem.get_primal_regularization_variables();
       }
       return this->empty_set;
@@ -248,15 +248,18 @@ namespace uno {
       return number_nonzeros;
    }
 
-   size_t Subproblem::number_regularized_augmented_system_nonzeros() const {
-      size_t number_nonzeros = this->number_hessian_nonzeros() + this->problem.number_jacobian_nonzeros();
+   size_t Subproblem::number_primal_inertia_correction_nonzeros() const {
       if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
-         number_nonzeros += this->get_primal_regularization_variables().size();
+         return this->get_primal_regularization_variables().size();
       }
+      return 0;
+   }
+
+   size_t Subproblem::number_dual_inertia_correction_nonzeros() const {
       if (this->performs_dual_regularization()) {
-         number_nonzeros += this->get_dual_regularization_constraints().size();
+         return this->get_dual_regularization_constraints().size();
       }
-      return number_nonzeros;
+      return 0;
    }
 
    double Subproblem::dual_regularization_factor() const {

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -8,7 +8,7 @@
 #include "ingredients/globalization_strategies/ProgressMeasures.hpp"
 #include "linear_algebra/MatrixOrder.hpp"
 #include "linear_algebra/Vector.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/OptimizationProblem.hpp"
 #include "symbolic/IntegerRange.hpp"
 

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -40,7 +40,7 @@ namespace uno {
 
       // regularized Hessian
       void evaluate_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const;
-      void regularize_lagrangian_hessian(Statistics& statistics, double* hessian_values) const;
+      void regularize_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const;
       void compute_hessian_vector_product(const double* x, const double* vector, double* result) const;
 
       // augmented system

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -36,10 +36,10 @@ namespace uno {
       void compute_regularized_hessian_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int solver_indexing) const;
       void compute_regularized_augmented_matrix_sparsity(uno_int* row_indices, uno_int* column_indices, uno_int solver_indexing) const;
 
-      void evaluate_jacobian(double* jacobian_values, Evaluations& evaluations) const;
+      void evaluate_jacobian(View<double> jacobian_values, Evaluations& evaluations) const;
 
       // regularized Hessian
-      void evaluate_lagrangian_hessian(Statistics& statistics, double* hessian_values) const;
+      void evaluate_lagrangian_hessian(Statistics& statistics, View<double> hessian_values) const;
       void regularize_lagrangian_hessian(Statistics& statistics, double* hessian_values) const;
       void compute_hessian_vector_product(const double* x, const double* vector, double* result) const;
 
@@ -74,7 +74,8 @@ namespace uno {
       [[nodiscard]] size_t number_jacobian_nonzeros() const;
       [[nodiscard]] size_t number_hessian_nonzeros() const;
       [[nodiscard]] size_t number_regularized_hessian_nonzeros() const;
-      [[nodiscard]] size_t number_regularized_augmented_system_nonzeros() const;
+      [[nodiscard]] size_t number_primal_inertia_correction_nonzeros() const;
+      [[nodiscard]] size_t number_dual_inertia_correction_nonzeros() const;
 
       [[nodiscard]] double dual_regularization_factor() const;
 

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -44,8 +44,9 @@ namespace uno {
       void compute_hessian_vector_product(const double* x, const double* vector, double* result) const;
 
       // augmented system
-      void regularize_augmented_matrix(Statistics& statistics, double* augmented_matrix_values,
-         double dual_regularization_parameter, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver) const;
+      void regularize_augmented_matrix(Statistics& statistics, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block, double dual_regularization_parameter,
+         DirectSymmetricIndefiniteLinearSolver<double>& linear_solver) const;
       void assemble_augmented_rhs(Evaluations& evaluations, Vector<double>& rhs) const;
       void assemble_primal_dual_direction(const Vector<double>& solution, Direction& direction) const;
 

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
@@ -8,7 +8,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "linear_algebra/Indexing.hpp"
 #include "linear_algebra/Vector.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "symbolic/Range.hpp"

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
@@ -100,7 +100,7 @@ namespace uno {
          }
          // evaluate + regularize the explicit Hessian once per iterate
          if (this->hessian_evaluation_required) {
-            subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.data());
+            subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.view());
             subproblem.regularize_lagrangian_hessian(statistics, this->hessian_values.data());
             this->hessian_evaluation_required = false;
          }
@@ -336,7 +336,7 @@ namespace uno {
 
    void BQPDQuadraticProgram::evaluate_jacobian(const OptimizationProblem& problem, const Vector<double>& primals,
          Evaluations& evaluations) {
-      problem.evaluate_jacobian(primals, this->jacobian_values.data(), evaluations);
+      problem.evaluate_jacobian(primals, this->jacobian_values.view(), evaluations);
       this->scatter_jacobian_values(problem.number_variables);
    }
 } // namespace

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
@@ -101,7 +101,7 @@ namespace uno {
          // evaluate + regularize the explicit Hessian once per iterate
          if (this->hessian_evaluation_required) {
             subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.view());
-            subproblem.regularize_lagrangian_hessian(statistics, this->hessian_values.data());
+            subproblem.regularize_lagrangian_hessian(statistics, this->hessian_values.view());
             this->hessian_evaluation_required = false;
          }
          this->hessian_operator = nullptr;

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -7,7 +7,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "linear_algebra/Indexing.hpp"
 #include "linear_algebra/Vector.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "options/Options.hpp"

--- a/uno/ingredients/subproblem_solvers/COOLinearSystem.cpp
+++ b/uno/ingredients/subproblem_solvers/COOLinearSystem.cpp
@@ -22,11 +22,6 @@ namespace uno {
       this->matrix_values.resize(this->number_nonzeros);
       this->rhs.resize(this->dimension);
       this->solution.resize(this->dimension);
-      // create the views
-      this->hessian = view(this->matrix_values.data(), number_hessian_nonzeros);
-      this->jacobian = view(this->hessian.end(), 0);
-      this->primal_inertia_correction = view(this->jacobian.end(), number_primal_inertia_correction_nonzeros);
-      this->dual_inertia_correction = view(this->primal_inertia_correction.end(), 0);
    }
 
    void COOLinearSystem::initialize_augmented_system(const Subproblem& subproblem) {
@@ -46,11 +41,6 @@ namespace uno {
       this->matrix_values.resize(this->number_nonzeros);
       this->rhs.resize(this->dimension);
       this->solution.resize(this->dimension);
-      // create the views
-      this->hessian = view(this->matrix_values.data(), number_hessian_nonzeros);
-      this->jacobian = view(this->hessian.end(), number_jacobian_nonzeros);
-      this->primal_inertia_correction = view(this->jacobian.end(), number_primal_inertia_correction_nonzeros);
-      this->dual_inertia_correction = view(this->primal_inertia_correction.end(), number_dual_inertia_correction_nonzeros);
    }
 
    double COOLinearSystem::compute_hessian_quadratic_form(const Subproblem& /*subproblem*/,

--- a/uno/ingredients/subproblem_solvers/COOLinearSystem.cpp
+++ b/uno/ingredients/subproblem_solvers/COOLinearSystem.cpp
@@ -9,9 +9,11 @@ namespace uno {
    }
 
    void COOLinearSystem::initialize_hessian(const Subproblem& subproblem) {
+      const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
       // Hessian
       this->dimension = subproblem.number_variables;
-      this->number_nonzeros = subproblem.number_regularized_hessian_nonzeros();
+      this->number_nonzeros = number_hessian_nonzeros + number_primal_inertia_correction_nonzeros;
       this->matrix_row_indices.resize(this->number_nonzeros);
       this->matrix_column_indices.resize(this->number_nonzeros);
       // compute the COO sparse representation
@@ -20,12 +22,22 @@ namespace uno {
       this->matrix_values.resize(this->number_nonzeros);
       this->rhs.resize(this->dimension);
       this->solution.resize(this->dimension);
+      // create the views
+      this->hessian = view(this->matrix_values.data(), number_hessian_nonzeros);
+      this->jacobian = view(this->hessian.end(), 0);
+      this->primal_inertia_correction = view(this->jacobian.end(), number_primal_inertia_correction_nonzeros);
+      this->dual_inertia_correction = view(this->primal_inertia_correction.end(), 0);
    }
 
    void COOLinearSystem::initialize_augmented_system(const Subproblem& subproblem) {
+      const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
+      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+      const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
       // augmented system
       this->dimension = subproblem.number_variables + subproblem.number_constraints;
-      this->number_nonzeros = subproblem.number_regularized_augmented_system_nonzeros();
+      this->number_nonzeros = number_hessian_nonzeros + number_jacobian_nonzeros + number_primal_inertia_correction_nonzeros +
+         number_dual_inertia_correction_nonzeros;
       this->matrix_row_indices.resize(this->number_nonzeros);
       this->matrix_column_indices.resize(this->number_nonzeros);
       // compute the COO sparse representation
@@ -34,6 +46,11 @@ namespace uno {
       this->matrix_values.resize(this->number_nonzeros);
       this->rhs.resize(this->dimension);
       this->solution.resize(this->dimension);
+      // create the views
+      this->hessian = view(this->matrix_values.data(), number_hessian_nonzeros);
+      this->jacobian = view(this->hessian.end(), number_jacobian_nonzeros);
+      this->primal_inertia_correction = view(this->jacobian.end(), number_primal_inertia_correction_nonzeros);
+      this->dual_inertia_correction = view(this->primal_inertia_correction.end(), number_dual_inertia_correction_nonzeros);
    }
 
    double COOLinearSystem::compute_hessian_quadratic_form(const Subproblem& /*subproblem*/,

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -44,9 +44,8 @@ namespace uno {
       // set up the linear system by evaluating the functions at the current iterate
       if (warmstart_information.new_iterate) {
          // assemble the augmented matrix
-         subproblem.evaluate_lagrangian_hessian(statistics, linear_system.matrix_values.data());
-         const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-         subproblem.evaluate_jacobian(linear_system.matrix_values.data() + number_hessian_nonzeros, current_evaluations);
+         subproblem.evaluate_lagrangian_hessian(statistics, linear_system.hessian);
+         subproblem.evaluate_jacobian(linear_system.jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all
          if (!this->analysis_performed) {

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -44,8 +44,17 @@ namespace uno {
       // set up the linear system by evaluating the functions at the current iterate
       if (warmstart_information.new_iterate) {
          // assemble the augmented matrix
-         subproblem.evaluate_lagrangian_hessian(statistics, linear_system.hessian);
-         subproblem.evaluate_jacobian(linear_system.jacobian, current_evaluations);
+         const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+         const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
+         const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+         const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
+         View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);
+         View jacobian(hessian.end(), number_jacobian_nonzeros);
+         View primal_inertia_correction(jacobian.end(), number_primal_inertia_correction_nonzeros);
+         View dual_inertia_correction(primal_inertia_correction.end(), number_dual_inertia_correction_nonzeros);
+
+         subproblem.evaluate_lagrangian_hessian(statistics, hessian);
+         subproblem.evaluate_jacobian(jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all
          if (!this->analysis_performed) {
@@ -55,8 +64,8 @@ namespace uno {
          }
 
          // regularize the augmented matrix (this calls the analysis and the factorization)
-         subproblem.regularize_augmented_matrix(statistics, linear_system.primal_inertia_correction,
-            linear_system.dual_inertia_correction, subproblem.dual_regularization_factor(), *this->linear_solver);
+         subproblem.regularize_augmented_matrix(statistics, primal_inertia_correction, dual_inertia_correction,
+            subproblem.dual_regularization_factor(), *this->linear_solver);
 
          // assemble the RHS
          subproblem.assemble_augmented_rhs(current_evaluations, linear_system.rhs);

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -45,13 +45,13 @@ namespace uno {
       if (warmstart_information.new_iterate) {
          // assemble the augmented matrix
          const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-         const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
          const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+         const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
          const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
          View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);
-         View jacobian(hessian.end(), number_jacobian_nonzeros);
-         View primal_inertia_correction(jacobian.end(), number_primal_inertia_correction_nonzeros);
-         View dual_inertia_correction(primal_inertia_correction.end(), number_dual_inertia_correction_nonzeros);
+         View primal_inertia_correction(hessian.end(), number_primal_inertia_correction_nonzeros);
+         View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
+         View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
 
          subproblem.evaluate_lagrangian_hessian(statistics, hessian);
          subproblem.evaluate_jacobian(jacobian, current_evaluations);

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -55,8 +55,8 @@ namespace uno {
          }
 
          // regularize the augmented matrix (this calls the analysis and the factorization)
-         subproblem.regularize_augmented_matrix(statistics, linear_system.matrix_values.data(),
-            subproblem.dual_regularization_factor(), *this->linear_solver);
+         subproblem.regularize_augmented_matrix(statistics, linear_system.primal_inertia_correction,
+            linear_system.dual_inertia_correction, subproblem.dual_regularization_factor(), *this->linear_solver);
 
          // assemble the RHS
          subproblem.assemble_augmented_rhs(current_evaluations, linear_system.rhs);

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
@@ -192,7 +192,8 @@ namespace uno {
          subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.view());
          // copy the Hessian with permutation into this->model.hessian_.value_
          this->scatter_hessian_values();
-         subproblem.regularize_lagrangian_hessian(statistics, this->model.hessian_.value_.data());
+         View hessian(this->model.hessian_.value_.data(), subproblem.number_regularized_hessian_nonzeros());
+         subproblem.regularize_lagrangian_hessian(statistics, hessian);
       }
    }
 

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
@@ -189,7 +189,7 @@ namespace uno {
          subproblem.problem.evaluate_constraints(subproblem.current_iterate, this->constraints.data(), current_evaluations);
          this->evaluate_jacobian(subproblem.problem, subproblem.current_iterate.primals, current_evaluations);
          // evaluate the Hessian and regularize it
-         subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.data());
+         subproblem.evaluate_lagrangian_hessian(statistics, this->hessian_values.view());
          // copy the Hessian with permutation into this->model.hessian_.value_
          this->scatter_hessian_values();
          subproblem.regularize_lagrangian_hessian(statistics, this->model.hessian_.value_.data());
@@ -198,7 +198,7 @@ namespace uno {
 
    void HiGHSQuadraticProgram::evaluate_jacobian(const OptimizationProblem& problem, const Vector<double>& primals,
          Evaluations& evaluations) {
-      problem.evaluate_jacobian(primals, this->jacobian_values.data(), evaluations);
+      problem.evaluate_jacobian(primals, this->jacobian_values.view(), evaluations);
       this->scatter_jacobian_values();
    }
 

--- a/uno/ingredients/subproblem_solvers/LinearSystem.hpp
+++ b/uno/ingredients/subproblem_solvers/LinearSystem.hpp
@@ -16,7 +16,9 @@ namespace uno {
 
       size_t dimension{0};
       size_t number_nonzeros{0};
+
       Vector<double> matrix_values{};
+
       Vector<double> rhs{};
       Vector<double> solution{};
 

--- a/uno/ingredients/subproblem_solvers/LinearSystem.hpp
+++ b/uno/ingredients/subproblem_solvers/LinearSystem.hpp
@@ -18,12 +18,6 @@ namespace uno {
       size_t number_nonzeros{0};
 
       Vector<double> matrix_values{};
-      // views into the blocks
-      View<double> hessian;
-      View<double> jacobian;
-      View<double> primal_inertia_correction;
-      View<double> dual_inertia_correction;
-
       Vector<double> rhs{};
       Vector<double> solution{};
 

--- a/uno/ingredients/subproblem_solvers/LinearSystem.hpp
+++ b/uno/ingredients/subproblem_solvers/LinearSystem.hpp
@@ -18,6 +18,11 @@ namespace uno {
       size_t number_nonzeros{0};
 
       Vector<double> matrix_values{};
+      // views into the blocks
+      View<double> hessian;
+      View<double> jacobian;
+      View<double> primal_inertia_correction;
+      View<double> dual_inertia_correction;
 
       Vector<double> rhs{};
       Vector<double> solution{};

--- a/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <vector>
 #include "MA86Solver.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 
 #ifdef HSL_RUNTIME_LOADING
 // route the calls through the runtime-resolved function pointers

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -45,8 +45,17 @@ namespace uno {
       // set up the linear system by evaluating the functions at the current iterate
       if (warmstart_information.new_iterate) {
          // assemble the augmented matrix with only the diagonal part of the quasi-Newton Hessian
-         subproblem.evaluate_lagrangian_hessian(statistics, linear_system.hessian);
-         subproblem.evaluate_jacobian(linear_system.jacobian, current_evaluations);
+         const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+         const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
+         const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+         const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
+         View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);
+         View jacobian(hessian.end(), number_jacobian_nonzeros);
+         View primal_inertia_correction(jacobian.end(), number_primal_inertia_correction_nonzeros);
+         View dual_inertia_correction(primal_inertia_correction.end(), number_dual_inertia_correction_nonzeros);
+
+         subproblem.evaluate_lagrangian_hessian(statistics, hessian);
+         subproblem.evaluate_jacobian(jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all
          if (!this->analysis_performed) {
@@ -56,8 +65,8 @@ namespace uno {
          }
 
          // regularize the augmented matrix (this calls the analysis and the factorization)
-         subproblem.regularize_augmented_matrix(statistics, linear_system.primal_inertia_correction,
-            linear_system.dual_inertia_correction, subproblem.dual_regularization_factor(), *this->linear_solver);
+         subproblem.regularize_augmented_matrix(statistics, primal_inertia_correction, dual_inertia_correction,
+            subproblem.dual_regularization_factor(), *this->linear_solver);
 
          // assemble the RHS
          subproblem.assemble_augmented_rhs(current_evaluations, linear_system.rhs);

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -45,9 +45,8 @@ namespace uno {
       // set up the linear system by evaluating the functions at the current iterate
       if (warmstart_information.new_iterate) {
          // assemble the augmented matrix with only the diagonal part of the quasi-Newton Hessian
-         subproblem.evaluate_lagrangian_hessian(statistics, linear_system.matrix_values.data());
-         const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-         subproblem.evaluate_jacobian(linear_system.matrix_values.data() + number_hessian_nonzeros, current_evaluations);
+         subproblem.evaluate_lagrangian_hessian(statistics, linear_system.hessian);
+         subproblem.evaluate_jacobian(linear_system.jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all
          if (!this->analysis_performed) {

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -56,8 +56,8 @@ namespace uno {
          }
 
          // regularize the augmented matrix (this calls the analysis and the factorization)
-         subproblem.regularize_augmented_matrix(statistics, linear_system.matrix_values.data(),
-            subproblem.dual_regularization_factor(), *this->linear_solver);
+         subproblem.regularize_augmented_matrix(statistics, linear_system.primal_inertia_correction,
+            linear_system.dual_inertia_correction, subproblem.dual_regularization_factor(), *this->linear_solver);
 
          // assemble the RHS
          subproblem.assemble_augmented_rhs(current_evaluations, linear_system.rhs);

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -46,13 +46,13 @@ namespace uno {
       if (warmstart_information.new_iterate) {
          // assemble the augmented matrix with only the diagonal part of the quasi-Newton Hessian
          const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-         const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
          const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+         const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
          const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
          View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);
-         View jacobian(hessian.end(), number_jacobian_nonzeros);
-         View primal_inertia_correction(jacobian.end(), number_primal_inertia_correction_nonzeros);
-         View dual_inertia_correction(primal_inertia_correction.end(), number_dual_inertia_correction_nonzeros);
+         View primal_inertia_correction(hessian.end(), number_primal_inertia_correction_nonzeros);
+         View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
+         View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
 
          subproblem.evaluate_lagrangian_hessian(statistics, hessian);
          subproblem.evaluate_jacobian(jacobian, current_evaluations);

--- a/uno/linear_algebra/BLASMatrix.hpp
+++ b/uno/linear_algebra/BLASMatrix.hpp
@@ -7,7 +7,7 @@
 #include "Vector.hpp"
 #include "linear_algebra/BLAS.hpp"
 #include "linear_algebra/LAPACK.hpp"
-#include "VectorView.hpp"
+#include "View.hpp"
 #include "symbolic/Inverse.hpp"
 #include "symbolic/Multiplication.hpp"
 #include "symbolic/Sum.hpp"

--- a/uno/linear_algebra/DenseMatrix.hpp
+++ b/uno/linear_algebra/DenseMatrix.hpp
@@ -7,7 +7,7 @@
 #include <ostream>
 #include <vector>
 #include "linear_algebra/BLASMatrix.hpp"
-#include "VectorView.hpp"
+#include "View.hpp"
 #include "symbolic/Range.hpp"
 
 namespace uno {
@@ -62,8 +62,8 @@ namespace uno {
       [[nodiscard]] T& entry(size_t row_index, size_t column_index);
       [[nodiscard]] const T& entry(size_t row_index, size_t column_index) const;
       // vector view
-      [[nodiscard]] VectorView<double> column(size_t column_index);
-      [[nodiscard]] VectorView<const double> column(size_t column_index) const;
+      [[nodiscard]] View<double> column(size_t column_index);
+      [[nodiscard]] View<const double> column(size_t column_index) const;
       [[nodiscard]] Submatrix submatrix(size_t number_rows, size_t number_columns);
 
       [[nodiscard]] T* data() override;
@@ -92,12 +92,12 @@ namespace uno {
    }
 
    template <typename T>
-   VectorView<double> DenseMatrix<T>::column(size_t column_index) {
+   View<double> DenseMatrix<T>::column(size_t column_index) {
       return {this->matrix.data() + column_index * this->number_rows, this->number_rows};
    }
 
    template <typename T>
-   VectorView<const double> DenseMatrix<T>::column(size_t column_index) const {
+   View<const double> DenseMatrix<T>::column(size_t column_index) const {
       return {this->matrix.data() + column_index * this->number_rows, this->number_rows};
    }
 

--- a/uno/linear_algebra/Vector.hpp
+++ b/uno/linear_algebra/Vector.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 #include <initializer_list>
-#include "VectorView.hpp"
+#include "View.hpp"
 #include "symbolic/Range.hpp"
 
 namespace uno {
@@ -149,11 +149,11 @@ namespace uno {
          this->view().scale(factor);
       }
 
-      VectorView<const T> view() const noexcept {
+      View<const T> view() const noexcept {
          return uno::view(this->data(), this->size());
       }
 
-      VectorView<T> view() noexcept {
+      View<T> view() noexcept {
          return uno::view(this->data(), this->size());
       }
 

--- a/uno/linear_algebra/View.hpp
+++ b/uno/linear_algebra/View.hpp
@@ -4,6 +4,7 @@
 #ifndef UNO_VIEW_H
 #define UNO_VIEW_H
 
+#include <cassert>
 #include <cstddef>
 #include "BLAS.hpp"
 #include "symbolic/Inverse.hpp"
@@ -66,10 +67,12 @@ namespace uno {
       }
 
       [[nodiscard]] T& operator[](size_t index) noexcept {
+         assert(index < this->size());
          return this->pointer[index];
       }
 
       [[nodiscard]] const T& operator[](size_t index) const noexcept {
+         assert(index < this->size());
          return this->pointer[index];
       }
 

--- a/uno/linear_algebra/View.hpp
+++ b/uno/linear_algebra/View.hpp
@@ -20,18 +20,28 @@ namespace uno {
    class View {
    protected:
       T* pointer;
-      const size_t view_size;
+      size_t view_size;
 
    public:
       using value_type = std::remove_const_t<T>;
 
       View(T* pointer, size_t size): pointer(pointer), view_size(size) { }
+      View(): pointer(nullptr), view_size(0) { }
       ~View() = default;
       View(const View& other) = default;
       View(View&& other) = default;
       View<T>& operator=(const View<T>& other) {
          if (&other != this) {
             blas1::copy(this->size(), other.data(), this->data());
+         }
+         return *this;
+      }
+      View<T>& operator=(View<T>&& other) noexcept {
+         if (&other != this) {
+            this->pointer = other.pointer;
+            this->view_size = other.view_size;
+            other.pointer = nullptr;
+            other.view_size = 0;
          }
          return *this;
       }
@@ -50,6 +60,18 @@ namespace uno {
 
       [[nodiscard]] const T* data() const noexcept {
          return this->pointer;
+      }
+
+      // this returns a pointer to the end of the view
+      // careful: this may not be a valid element, do not dereference
+      [[nodiscard]] T* end() noexcept {
+         return this->pointer + this->size();
+      }
+
+      // this returns a pointer to the end of the view
+      // careful: this may not be a valid element, do not dereference
+      [[nodiscard]] const T* end() const noexcept {
+         return this->pointer + this->size();
       }
 
       [[nodiscard]] T& operator[](size_t index) noexcept {

--- a/uno/linear_algebra/View.hpp
+++ b/uno/linear_algebra/View.hpp
@@ -36,15 +36,6 @@ namespace uno {
          }
          return *this;
       }
-      View<T>& operator=(View<T>&& other) noexcept {
-         if (&other != this) {
-            this->pointer = other.pointer;
-            this->view_size = other.view_size;
-            other.pointer = nullptr;
-            other.view_size = 0;
-         }
-         return *this;
-      }
 
       [[nodiscard]] size_t size() const noexcept {
          return this->view_size;

--- a/uno/linear_algebra/View.hpp
+++ b/uno/linear_algebra/View.hpp
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Charlie Vanaret
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
-#ifndef UNO_VECTORVIEW_H
-#define UNO_VECTORVIEW_H
+#ifndef UNO_VIEW_H
+#define UNO_VIEW_H
 
 #include <cstddef>
 #include "BLAS.hpp"
@@ -17,7 +17,7 @@
 namespace uno {
    // constant contiguous array in memory on which BLAS can be called
    template <typename T>
-   class VectorView {
+   class View {
    protected:
       T* pointer;
       const size_t view_size;
@@ -25,11 +25,11 @@ namespace uno {
    public:
       using value_type = std::remove_const_t<T>;
 
-      VectorView(T* pointer, size_t size): pointer(pointer), view_size(size) { }
-      ~VectorView() = default;
-      VectorView(const VectorView& other) = default;
-      VectorView(VectorView&& other) = default;
-      VectorView<T>& operator=(const VectorView<T>& other) {
+      View(T* pointer, size_t size): pointer(pointer), view_size(size) { }
+      ~View() = default;
+      View(const View& other) = default;
+      View(View&& other) = default;
+      View<T>& operator=(const View<T>& other) {
          if (&other != this) {
             blas1::copy(this->size(), other.data(), this->data());
          }
@@ -62,7 +62,7 @@ namespace uno {
 
       // specialized operation y = x, when the other vector has the member function data()
       template <typename Vector, decltype(Vector{}.data()) = true>
-      VectorView& operator=(const Vector& other) {
+      View& operator=(const Vector& other) {
          if (other.size() != this->size()) {
             throw std::invalid_argument("Dimension mismatch between x and y");
          }
@@ -72,7 +72,7 @@ namespace uno {
 
       // generic operation y = expression
       template <typename Expression>
-      VectorView& operator=(const Expression& expression) {
+      View& operator=(const Expression& expression) {
          // static_assert(std::is_same_v<typename Expression::value_type, T>);
          if (expression.size() != this->size()) {
             throw std::invalid_argument("Dimension mismatch between expression and y");
@@ -85,7 +85,7 @@ namespace uno {
 
       // specialized operation y = a * x (note: no BLAS operation available)
       template <typename Vector>
-      VectorView& operator=(ScalarMultiple<Vector>&& expression) {
+      View& operator=(ScalarMultiple<Vector>&& expression) {
          const auto& a = expression.get_factor();
          const auto& x = expression.get_expression();
          if (x.size() != this->size()) {
@@ -100,7 +100,7 @@ namespace uno {
       // specialized operation y = x - z
       // note: no BLAS operation available
       template <typename Vector>
-      VectorView& operator=(Subtraction<Vector, Vector>&& expression) {
+      View& operator=(Subtraction<Vector, Vector>&& expression) {
          const auto& x = expression.get_left();
          const auto& z = expression.get_right();
          if (x.size() != z.size()) {
@@ -116,7 +116,7 @@ namespace uno {
 
       // y = Ax (or y = A x + 0 * y)
       template <typename Matrix, typename Vector>
-      VectorView& operator=(Multiplication<Matrix, Vector>&& expression) {
+      View& operator=(Multiplication<Matrix, Vector>&& expression) {
          const auto& x = expression.get_right();
          if (x.data() == this->data()) {
             throw std::invalid_argument("BLASVector::operator= cannot be called with x == y");
@@ -135,7 +135,7 @@ namespace uno {
 
       // specialized operation y += a * x
       template <typename Vector>
-      VectorView& operator+=(ScalarMultiple<Vector>&& expression) {
+      View& operator+=(ScalarMultiple<Vector>&& expression) {
          const auto& a = expression.get_factor();
          const auto& x = expression.get_expression();
          if (x.size() != this->size()) {
@@ -147,7 +147,7 @@ namespace uno {
 
       // generic operation y += x
       template <typename Vector>
-      VectorView& operator+=(const Vector& other) {
+      View& operator+=(const Vector& other) {
          if (other.size() != this->size()) {
             throw std::invalid_argument("Dimension mismatch between x and y");
          }
@@ -157,7 +157,7 @@ namespace uno {
 
       // generic operation y -= x
       template <typename Vector>
-      VectorView& operator-=(const Vector& other) {
+      View& operator-=(const Vector& other) {
          if (other.size() != this->size()) {
             throw std::invalid_argument("Dimension mismatch between x and y");
          }
@@ -167,7 +167,7 @@ namespace uno {
 
       // x := U⁻ᵀ y with U upper triangular (solve Uᵀ x := y)
       template <typename Matrix, typename Vector>
-      VectorView<T>& operator=(Multiplication<Transpose<Inverse<UpperTriangular<Matrix>>>, Vector>&& expression) {
+      View<T>& operator=(Multiplication<Transpose<Inverse<UpperTriangular<Matrix>>>, Vector>&& expression) {
          const auto& U = expression.get_left().get_matrix().get_matrix().get_matrix();
          const auto& y = expression.get_right();
          if (this->size() != U.number_columns) {
@@ -182,7 +182,7 @@ namespace uno {
 
       // x := U⁻¹ y with U upper triangular (solve U x := y)
       template <typename Matrix, typename Vector>
-      VectorView<T>& operator=(Multiplication<Inverse<UpperTriangular<Matrix>>, Vector>&& expression) {
+      View<T>& operator=(Multiplication<Inverse<UpperTriangular<Matrix>>, Vector>&& expression) {
          const auto& U = expression.get_left().get_matrix().get_matrix();
          const auto& y = expression.get_right();
          if (this->size() != U.number_columns) {
@@ -197,7 +197,7 @@ namespace uno {
 
       // y := A^T x
       template <typename Matrix, typename Vector>
-      VectorView& operator=(Multiplication<Transpose<Matrix>, Vector>&& expression) {
+      View& operator=(Multiplication<Transpose<Matrix>, Vector>&& expression) {
          const auto& A = expression.get_left().get_matrix();
          const auto& x = expression.get_right();
          if (A.number_rows != x.size()) {
@@ -213,7 +213,7 @@ namespace uno {
 
       // y += Ax (or y = A x + y)
       template <typename Matrix, typename Vector>
-      VectorView& operator+=(Multiplication<Matrix, Vector>&& expression) {
+      View& operator+=(Multiplication<Matrix, Vector>&& expression) {
          const auto& A = expression.get_left();
          const auto& x = expression.get_right();
          if (A.number_columns != x.size()) {
@@ -229,7 +229,7 @@ namespace uno {
 
       // y -= Ax (or y = -A x + y)
       template <typename Matrix, typename Vector>
-      VectorView& operator-=(Multiplication<Matrix, Vector>&& expression) {
+      View& operator-=(Multiplication<Matrix, Vector>&& expression) {
          const auto& A = expression.get_left();
          const auto& x = expression.get_right();
          if (A.number_columns != x.size()) {
@@ -262,12 +262,12 @@ namespace uno {
       if (start > end || end > container.size()) {
          throw std::out_of_range("invalid vector view");
       }
-      return VectorView{container.data() + start, end - start};
+      return View{container.data() + start, end - start};
    }
 
    template <typename T>
    auto view(T* pointer, size_t size) {
-      return VectorView{pointer, size};
+      return View{pointer, size};
    }
 
    template <typename T>
@@ -275,11 +275,11 @@ namespace uno {
       if (start > end) {
          throw std::out_of_range("invalid vector view");
       }
-      return VectorView{pointer + start, end - start};
+      return View{pointer + start, end - start};
    }
 
    template <typename Expression>
-   std::ostream& operator<<(std::ostream& stream, const VectorView<Expression>& view) {
+   std::ostream& operator<<(std::ostream& stream, const View<Expression>& view) {
       for (size_t index: Range(view.size())) {
          stream << view[index] << " ";
       }
@@ -294,9 +294,9 @@ namespace uno {
       return blas1::dot(x.size(), x.data(), y.data());
    }
 
-   inline double dot(const VectorView<double>& x, const double* y) {
+   inline double dot(const View<double>& x, const double* y) {
       return blas1::dot(x.size(), x.data(), y);
    }
 } // namespace
 
-#endif //UNO_VECTORVIEW_H
+#endif //UNO_VIEW_H

--- a/uno/model/BoundRelaxedModel.hpp
+++ b/uno/model/BoundRelaxedModel.hpp
@@ -65,7 +65,7 @@ namespace uno {
       }
 
       void evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier, const Vector<double>& multipliers,
-            double* hessian_values) const override {
+            View<double> hessian_values) const override {
          this->model.evaluate_lagrangian_hessian(x, objective_multiplier, multipliers, hessian_values);
       }
 

--- a/uno/model/FixedBoundsConstraintsModel.cpp
+++ b/uno/model/FixedBoundsConstraintsModel.cpp
@@ -105,7 +105,7 @@ namespace uno {
    }
 
    void FixedBoundsConstraintsModel::evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier,
-         const Vector<double>& multipliers, double* hessian_values) const {
+         const Vector<double>& multipliers, View<double> hessian_values) const {
       this->model.evaluate_lagrangian_hessian(x, objective_multiplier, multipliers, hessian_values);
    }
 

--- a/uno/model/FixedBoundsConstraintsModel.cpp
+++ b/uno/model/FixedBoundsConstraintsModel.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include "FixedBoundsConstraintsModel.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/Iterate.hpp"
 
 namespace uno {

--- a/uno/model/FixedBoundsConstraintsModel.hpp
+++ b/uno/model/FixedBoundsConstraintsModel.hpp
@@ -43,7 +43,7 @@ namespace uno {
       // numerical evaluations of Jacobian and Hessian
       void evaluate_jacobian(const Vector<double>& x, double* jacobian_values) const override;
       void evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier, const Vector<double>& multipliers,
-         double* hessian_values) const override;
+         View<double> hessian_values) const override;
 
       // linear operators for Jacobian-, Jacobian^T-, and Hessian-vector products
       void compute_jacobian_vector_product(const double* x, const double* vector, double* result) const override;

--- a/uno/model/HomogeneousEqualityConstrainedModel.cpp
+++ b/uno/model/HomogeneousEqualityConstrainedModel.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include "HomogeneousEqualityConstrainedModel.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/Iterate.hpp"
 #include "symbolic/Range.hpp"
 

--- a/uno/model/HomogeneousEqualityConstrainedModel.cpp
+++ b/uno/model/HomogeneousEqualityConstrainedModel.cpp
@@ -110,7 +110,7 @@ namespace uno {
    }
 
    void HomogeneousEqualityConstrainedModel::evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier,
-         const Vector<double>& multipliers, double* hessian_values) const {
+         const Vector<double>& multipliers, View<double> hessian_values) const {
       this->model.evaluate_lagrangian_hessian(x, objective_multiplier, multipliers, hessian_values);
    }
 

--- a/uno/model/HomogeneousEqualityConstrainedModel.hpp
+++ b/uno/model/HomogeneousEqualityConstrainedModel.hpp
@@ -40,7 +40,7 @@ namespace uno {
       // numerical evaluations of Jacobian and Hessian
       void evaluate_jacobian(const Vector<double>& x, double* jacobian_values) const override;
       void evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier, const Vector<double>& multipliers,
-         double* hessian_values) const override;
+         View<double> hessian_values) const override;
 
       // linear operators for Jacobian-, Jacobian^T-, and Hessian-vector products
       void compute_jacobian_vector_product(const double* x, const double* vector, double* result) const override;

--- a/uno/model/Model.cpp
+++ b/uno/model/Model.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include "Model.hpp"
 #include "linear_algebra/Vector.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
 #include "symbolic/ScalarMultiple.hpp"

--- a/uno/model/Model.hpp
+++ b/uno/model/Model.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include "linear_algebra/MatrixOrder.hpp"
 #include "linear_algebra/Norm.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/ProblemType.hpp"
 #include "symbolic/VectorExpression.hpp"
 #include "../interfaces/C/uno_int.h"
@@ -68,7 +69,7 @@ namespace uno {
       void evaluate_lagrangian_gradient(const Vector<double>& primals, const Multipliers& multipliers, double objective_multiplier,
          Evaluations& evaluations, Vector<double>& lagrangian_gradient) const;
       virtual void evaluate_lagrangian_hessian(const Vector<double>& x, double objective_multiplier, const Vector<double>& multipliers,
-         double* hessian_values) const = 0;
+         View<double> hessian_values) const = 0;
 
       // linear operators for Jacobian-, Jacobian^T-, and Hessian-vector products
       // here we use pointers, since the vector and the result may be provided by a low-level subproblem solver

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -5,7 +5,7 @@
 #include "ingredients/hessian_models/HessianModel.hpp"
 #include "ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp"
 #include "linear_algebra/MatrixOrder.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Evaluations.hpp"

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -85,7 +85,7 @@ namespace uno {
       }
    }
 
-   void OptimizationProblem::evaluate_jacobian(const Vector<double>& primals, double* jacobian_values, Evaluations& evaluations) const {
+   void OptimizationProblem::evaluate_jacobian(const Vector<double>& primals, View<double> jacobian_values, Evaluations& evaluations) const {
       evaluations.evaluate_jacobian(this->model, primals);
       for (size_t nonzero_index: Range(this->model.number_jacobian_nonzeros())) {
          jacobian_values[nonzero_index] = evaluations.jacobian_values[nonzero_index];
@@ -99,7 +99,7 @@ namespace uno {
    }
 
    void OptimizationProblem::evaluate_lagrangian_hessian(Statistics& statistics, HessianModel& hessian_model,
-         const Vector<double>& primal_variables, const Multipliers& multipliers, double* hessian_values) const {
+         const Vector<double>& primal_variables, const Multipliers& multipliers, View<double> hessian_values) const {
       hessian_model.evaluate_hessian(statistics, primal_variables, this->get_objective_multiplier(),
          multipliers.constraints, hessian_values);
    }

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -9,6 +9,7 @@
 #include "ingredients/inertia_correction_strategies/Inertia.hpp"
 #include "linear_algebra/MatrixOrder.hpp"
 #include "linear_algebra/Norm.hpp"
+#include "linear_algebra/View.hpp"
 #include "optimization/SolutionStatus.hpp"
 #include "../interfaces/C/uno_int.h"
 #include "model/Model.hpp"
@@ -35,7 +36,7 @@ namespace uno {
       explicit OptimizationProblem(const Model& model);
       OptimizationProblem(const Model& model, size_t number_variables, size_t number_constraints);
       virtual ~OptimizationProblem() = default;
-      virtual std::unique_ptr<OptimizationProblem> clone() const;
+      [[nodiscard]] virtual std::unique_ptr<OptimizationProblem> clone() const;
 
       const Model& model;
       const size_t number_variables; /*!< Number of variables */
@@ -60,11 +61,11 @@ namespace uno {
       // numerical evaluations of constraints, objective gradient, Jacobian and Hessian
       virtual void evaluate_constraints(const Iterate& iterate, double* constraints, Evaluations& evaluations) const;
       virtual void evaluate_objective_gradient(const Iterate& iterate, double* objective_gradient, Evaluations& evaluations) const;
-      virtual void evaluate_jacobian(const Vector<double>& primals, double* jacobian_values, Evaluations& evaluations) const;
+      virtual void evaluate_jacobian(const Vector<double>& primals, View<double> jacobian_values, Evaluations& evaluations) const;
       virtual void evaluate_lagrangian_gradient(const Iterate& iterate, Evaluations& evaluations,
          Vector<double>& lagrangian_gradient) const;
       virtual void evaluate_lagrangian_hessian(Statistics& statistics, HessianModel& hessian_model,
-         const Vector<double>& primal_variables, const Multipliers& multipliers, double* hessian_values) const;
+         const Vector<double>& primal_variables, const Multipliers& multipliers, View<double> hessian_values) const;
 
       // linear operators
       virtual void compute_jacobian_vector_product(const double* vector, double* result, const Evaluations& evaluations) const;

--- a/uno/optimization/Result.cpp
+++ b/uno/optimization/Result.cpp
@@ -4,7 +4,7 @@
 #include <iomanip>
 #include "Result.hpp"
 #include "SolutionStatus.hpp"
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 #include "tools/Logger.hpp"
 #include "tools/Symbols.hpp"
 

--- a/unotest/unit_tests/ViewTests.cpp
+++ b/unotest/unit_tests/ViewTests.cpp
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include <gtest/gtest.h>
-#include "linear_algebra/VectorView.hpp"
+#include "linear_algebra/View.hpp"
 
 using namespace uno;
 
-TEST(VectorView, Size) {
+TEST(View, Size) {
    const std::vector<double> x{1., 2., 3., 100., 200., 300.};
    // vector view
    const size_t start_index = 2;


### PR DESCRIPTION
- Renamed `VectorView` into `View`
- Constructed views in the KKT blocks in `LinearSystem`
- Passed views to `Subproblem::evaluate_jacobian`, `Subproblem::evaluate_lagrangian_hessian` and the inertia correction function