### PR TITLE
Computation of least-square multipliers for equality-constrained problems

### DIFF
--- a/.github/workflows/julia-tests-hsl.yml
+++ b/.github/workflows/julia-tests-hsl.yml
@@ -25,6 +25,10 @@ env:
   VENV: /home/optimi/cvanaret/myenv
   RUNNER_PATH: /home/optimi/cvanaret/actions-runner
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   compilation-uno-hsl:
     runs-on: self-hosted

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -80,8 +80,6 @@ namespace uno {
       Iterate current_iterate(model.number_variables, model.number_constraints);
       model.initial_primal_point(current_iterate.primals);
       model.initial_dual_point(current_iterate.multipliers.constraints);
-      // temporarily set nonzero multipliers, until we have least-square multipliers
-      current_iterate.multipliers.constraints.fill(1.);
       model.reset_number_evaluations();
       EvaluationCache evaluation_cache{model};
       Statistics statistics = Uno::create_statistics(model);

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -80,6 +80,8 @@ namespace uno {
       Iterate current_iterate(model.number_variables, model.number_constraints);
       model.initial_primal_point(current_iterate.primals);
       model.initial_dual_point(current_iterate.multipliers.constraints);
+      // temporarily set nonzero multipliers, until we have least-square multipliers
+      current_iterate.multipliers.constraints.fill(1.);
       model.reset_number_evaluations();
       EvaluationCache evaluation_cache{model};
       Statistics statistics = Uno::create_statistics(model);

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -22,7 +22,7 @@ namespace uno {
 
    void NoInequalityReformulation::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
       this->problem.generate_initial_iterate(initial_iterate, evaluations);
-      this->subproblem_solver->generate_initial_iterate(initial_iterate, evaluations);
+      this->subproblem_solver->generate_initial_iterate(*this->subproblem, initial_iterate, evaluations);
    }
 
    void NoInequalityReformulation::initialize_statistics(Statistics& statistics) {

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -22,6 +22,7 @@ namespace uno {
 
    void NoInequalityReformulation::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
       this->problem.generate_initial_iterate(initial_iterate, evaluations);
+      this->subproblem_solver->generate_initial_iterate(initial_iterate, evaluations);
    }
 
    void NoInequalityReformulation::initialize_statistics(Statistics& statistics) {

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -103,7 +103,7 @@ namespace uno {
    template <typename BarrierProblem>
    void InteriorPointMethod<BarrierProblem>::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
       this->barrier_problem.generate_initial_iterate(initial_iterate, evaluations);
-      this->subproblem_solver->generate_initial_iterate(initial_iterate, evaluations);
+      this->subproblem_solver->generate_initial_iterate(*this->subproblem, initial_iterate, evaluations);
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -103,6 +103,7 @@ namespace uno {
    template <typename BarrierProblem>
    void InteriorPointMethod<BarrierProblem>::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
       this->barrier_problem.generate_initial_iterate(initial_iterate, evaluations);
+      this->subproblem_solver->generate_initial_iterate(initial_iterate, evaluations);
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -75,10 +75,6 @@ namespace uno {
             initial_iterate.multipliers.upper_bounds[variable_index] = -this->parameters.default_multiplier;
          }
       }
-
-      // TODO compute least-square multipliers
-      if (0 < this->number_constraints) {
-      }
    }
 
    size_t PrimalDualInteriorPointProblem::number_jacobian_nonzeros() const {

--- a/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/NoInertiaCorrection.cpp
@@ -21,9 +21,10 @@ namespace uno {
    }
 
    void NoInertiaCorrection::regularize_augmented_matrix(Statistics& /*statistics*/, const Subproblem& /*subproblem*/,
-         double /*dual_regularization_parameter*/, const Inertia& /*expected_inertia*/, View<double> /*primal_inertia_correction_block*/,
-         View<double> /*dual_inertia_correction_block*/) {
-      // do nothing
+         double /*dual_regularization_parameter*/, const Inertia& /*expected_inertia*/, View<double> primal_inertia_correction_block,
+         View<double> dual_inertia_correction_block) {
+      primal_inertia_correction_block.fill(0.);
+      dual_inertia_correction_block.fill(0.);
    }
 
    void NoInertiaCorrection::regularize_augmented_matrix(Statistics& /*statistics*/, const Subproblem& /*subproblem*/,

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
@@ -100,8 +100,9 @@ namespace uno {
 
    void PrimalInertiaCorrection::regularize_augmented_matrix(Statistics& statistics, const Subproblem& subproblem,
          double /*dual_regularization_parameter*/, const Inertia& expected_inertia, DirectSymmetricIndefiniteLinearSolver<double>& linear_solver,
-         View<double> primal_inertia_correction_block, View<double> /*dual_inertia_correction_block*/) {
+         View<double> primal_inertia_correction_block, View<double> dual_inertia_correction_block) {
       this->regularize_hessian(statistics, subproblem, expected_inertia, linear_solver, primal_inertia_correction_block);
+      dual_inertia_correction_block.fill(0.);
    }
 
    bool PrimalInertiaCorrection::performs_primal_regularization() const {

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -51,14 +51,13 @@ namespace uno {
       // sparsity of original Lagrangian Hessian in the (1, 1) block
       this->problem.compute_hessian_sparsity(this->hessian_model, row_indices, column_indices, solver_indexing);
 
-      // primal inertia correction (if applicable)
+      // primal inertia correction. This block is always allocated (even if not applicable - it may be used for computing
+      // least-squares multipliers)
       size_t nonzero_index = this->number_hessian_nonzeros();
-      if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
-         for (size_t variable_index: this->get_primal_regularization_variables()) {
-            row_indices[nonzero_index] = static_cast<uno_int>(variable_index) + solver_indexing;
-            column_indices[nonzero_index] = static_cast<uno_int>(variable_index) + solver_indexing;
-            ++nonzero_index;
-         }
+      for (size_t variable_index: Range(this->number_variables)) {
+         row_indices[nonzero_index] = static_cast<uno_int>(variable_index) + solver_indexing;
+         column_indices[nonzero_index] = static_cast<uno_int>(variable_index) + solver_indexing;
+         ++nonzero_index;
       }
 
       // copy Jacobian of general constraints into the (2, 1) block
@@ -248,10 +247,8 @@ namespace uno {
    }
 
    size_t Subproblem::number_primal_inertia_correction_nonzeros() const {
-      if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
-         return this->get_primal_regularization_variables().size();
-      }
-      return 0;
+      // always allocate the full block (see compute_regularized_augmented_matrix_sparsity())
+      return this->number_variables;
    }
 
    size_t Subproblem::number_dual_inertia_correction_nonzeros() const {

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
@@ -14,7 +14,8 @@ namespace uno {
       this->workspace.objective_gradient.resize(subproblem.number_variables);
    }
 
-   void BoxLPSolver::generate_initial_iterate(Iterate& /*initial_iterate*/, Evaluations& /*evaluations*/) const {
+   void BoxLPSolver::generate_initial_iterate(const Subproblem& /*subproblem*/, Iterate& /*initial_iterate*/,
+         Evaluations& /*evaluations*/) {
       // do nothing
    }
 

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
@@ -14,6 +14,10 @@ namespace uno {
       this->workspace.objective_gradient.resize(subproblem.number_variables);
    }
 
+   void BoxLPSolver::generate_initial_iterate(Iterate& /*initial_iterate*/, Evaluations& /*evaluations*/) const {
+      // do nothing
+   }
+
    Direction& BoxLPSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& /*warmstart_information*/) {

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
@@ -29,7 +29,7 @@ namespace uno {
       ~BoxLPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
+      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
@@ -29,6 +29,7 @@ namespace uno {
       ~BoxLPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
+      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -32,8 +32,7 @@ namespace uno {
    }
 
    void EQPSolver::generate_initial_iterate(Iterate& initial_iterate, Evaluations& /*evaluations*/) const {
-      // temporarily set nonzero multipliers, until we have least-square multipliers
-      initial_iterate.multipliers.constraints.fill(-1.);
+
    }
 
    Direction& EQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -8,6 +8,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Evaluations.hpp"
+#include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "options/Options.hpp"
 #include "tools/Logger.hpp"
@@ -28,6 +29,11 @@ namespace uno {
       auto& linear_system = this->linear_solver->get_linear_system();
       linear_system.initialize_augmented_system(subproblem);
       this->linear_solver->initialize_memory();
+   }
+
+   void EQPSolver::generate_initial_iterate(Iterate& initial_iterate, Evaluations& /*evaluations*/) const {
+      // temporarily set nonzero multipliers, until we have least-square multipliers
+      initial_iterate.multipliers.constraints.fill(1.);
    }
 
    Direction& EQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -31,8 +31,55 @@ namespace uno {
       this->linear_solver->initialize_memory();
    }
 
-   void EQPSolver::generate_initial_iterate(Iterate& initial_iterate, Evaluations& /*evaluations*/) const {
+   void EQPSolver::generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) {
+      INFO << "Computing least-square multipliers at initial point\n";
 
+      // compute least-square multipliers
+      auto& linear_system = this->linear_solver->get_linear_system();
+
+      // set up the linear system
+      const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+      const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
+      const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
+      View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);
+      View primal_inertia_correction(hessian.end(), number_primal_inertia_correction_nonzeros);
+      View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
+      View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
+
+      hessian.fill(0.); // no Hessian contribution
+      primal_inertia_correction.fill(1.); // Identity block
+      subproblem.evaluate_jacobian(initial_iterate, jacobian, evaluations);
+      dual_inertia_correction.fill(0.); // no dual regularization
+
+      // perform the symbolic analysis once and for all
+      if (!this->analysis_performed) {
+         DEBUG << "Performing symbolic analysis of the indefinite system\n";
+         this->linear_solver->do_symbolic_analysis();
+         this->analysis_performed = true;
+      }
+
+      // factorize the matrix
+      this->linear_solver->do_numerical_factorization(false);
+
+      // assemble the RHS
+      linear_system.rhs.fill(0.);
+      evaluations.evaluate_objective_gradient(subproblem.problem.model, initial_iterate.primals);
+      view(linear_system.rhs.data(), subproblem.number_variables) = evaluations.objective_gradient;
+      for (size_t variable_index: Range(subproblem.number_variables)) {
+         linear_system.rhs[variable_index] -= (initial_iterate.multipliers.lower_bounds[variable_index] +
+            initial_iterate.multipliers.upper_bounds[variable_index]);
+      }
+
+      // solve the linear system
+      this->linear_solver->solve_indefinite_system(linear_system.solution.data());
+
+      // set the constraint multipliers if their norm is reasonable
+      const auto least_squares_multipliers = view(linear_system.solution.data(), subproblem.number_variables,
+         subproblem.number_variables + subproblem.number_constraints);
+      if (norm_inf(least_squares_multipliers) <= 1000.) {
+         initial_iterate.multipliers.constraints = least_squares_multipliers;
+      }
    }
 
    Direction& EQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -79,6 +79,7 @@ namespace uno {
          subproblem.number_variables + subproblem.number_constraints);
       if (norm_inf(least_squares_multipliers) <= 1000.) {
          initial_iterate.multipliers.constraints = least_squares_multipliers;
+         DEBUG << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
       }
    }
 

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -33,7 +33,7 @@ namespace uno {
 
    void EQPSolver::generate_initial_iterate(Iterate& initial_iterate, Evaluations& /*evaluations*/) const {
       // temporarily set nonzero multipliers, until we have least-square multipliers
-      initial_iterate.multipliers.constraints.fill(1.);
+      initial_iterate.multipliers.constraints.fill(-1.);
    }
 
    Direction& EQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/EQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.hpp
@@ -20,7 +20,7 @@ namespace uno {
       ~EQPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
+      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/EQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.hpp
@@ -20,6 +20,7 @@ namespace uno {
       ~EQPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
+      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/IQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.cpp
@@ -20,6 +20,10 @@ namespace uno {
       this->qp_solver->initialize_memory(subproblem);
    }
 
+   void IQPSolver::generate_initial_iterate(Iterate& /*initial_iterate*/, Evaluations& /*evaluations*/) const {
+      // do nothing
+   }
+
    Direction& IQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {

--- a/uno/ingredients/subproblem_solvers/IQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.cpp
@@ -20,7 +20,8 @@ namespace uno {
       this->qp_solver->initialize_memory(subproblem);
    }
 
-   void IQPSolver::generate_initial_iterate(Iterate& /*initial_iterate*/, Evaluations& /*evaluations*/) const {
+   void IQPSolver::generate_initial_iterate(const Subproblem& /*subproblem*/, Iterate& /*initial_iterate*/,
+         Evaluations& /*evaluations*/) {
       // do nothing
    }
 

--- a/uno/ingredients/subproblem_solvers/IQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.hpp
@@ -26,6 +26,7 @@ namespace uno {
       ~IQPSolver() override;
 
       void initialize_memory(const Subproblem& subproblem) override;
+      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/IQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.hpp
@@ -26,7 +26,7 @@ namespace uno {
       ~IQPSolver() override;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
+      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
@@ -20,7 +20,8 @@ namespace uno {
       this->rhs.resize(subproblem.number_variables);
    }
 
-   void InverseNewtonSolver::generate_initial_iterate(Iterate& /*initial_iterate*/, Evaluations& /*evaluations*/) const {
+   void InverseNewtonSolver::generate_initial_iterate(const Subproblem& /*subproblem*/, Iterate& /*initial_iterate*/,
+         Evaluations& /*evaluations*/) {
       // do nothing
    }
 

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
@@ -20,6 +20,10 @@ namespace uno {
       this->rhs.resize(subproblem.number_variables);
    }
 
+   void InverseNewtonSolver::generate_initial_iterate(Iterate& /*initial_iterate*/, Evaluations& /*evaluations*/) const {
+      // do nothing
+   }
+
    Direction& InverseNewtonSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
          [[maybe_unused]] double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& /*warmstart_information*/) {

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
@@ -31,6 +31,7 @@ namespace uno {
       ~InverseNewtonSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
+      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
@@ -31,7 +31,7 @@ namespace uno {
       ~InverseNewtonSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
+      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -142,11 +142,7 @@ namespace uno {
             &this->workspace.lkeep, this->workspace.keep.data(), this->workspace.iwork.data(), this->workspace.icntl.data(),
             this->workspace.cntl.data(), this->workspace.info.data(), this->workspace.rinfo.data());
 
-         if (INFO(1) == 0) {
-            factorization_done = true;
-         }
-         else if (is_error_code_insufficient_real_workspace(INFO(1)) ||
-             is_error_code_insufficient_integer_workspace(INFO(1))) {
+         if (is_error_code_insufficient_real_workspace(INFO(1)) || is_error_code_insufficient_integer_workspace(INFO(1))) {
             const bool is_real_workspace = is_error_code_insufficient_real_workspace(this->workspace.info[0]);
 
             const int lnewfact = !is_real_workspace ? 0 : get_larger_real_workspace_size(this->workspace);
@@ -171,6 +167,9 @@ namespace uno {
          }
          else if (INFO(1) < 0) {
             throw std::runtime_error("MA57 fatal error");
+         }
+         else {
+            factorization_done = true;
          }
       }
       this->factorization_performed = true;

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -107,25 +107,25 @@ namespace uno {
       this->workspace.iwork.resize(5 * this->linear_system.dimension);
       this->workspace.lwork = static_cast<int>(static_cast<double>(this->linear_system.dimension));
       this->workspace.work.resize(static_cast<size_t>(this->workspace.lwork));
-      this->workspace.residuals.resize(this->linear_system.dimension);
    }
 
    void MA57Solver::do_symbolic_analysis() {
       assert(!this->analysis_performed);
 
-      // symbolic analysis
       MA57_symbolic_analysis(&this->workspace.n, &this->workspace.nnz, this->linear_system.matrix_row_indices.data(),
          this->linear_system.matrix_column_indices.data(), &this->workspace.lkeep, this->workspace.keep.data(),
          this->workspace.iwork.data(), this->workspace.icntl.data(), this->workspace.info.data(), this->workspace.rinfo.data());
 
-      assert(0 <= this->workspace.info[0] && "MA57: the symbolic analysis failed");
-      if (0 < this->workspace.info[0]) {
-         WARNING << "MA57 has issued a warning: info(1) = " << workspace.info[0] << '\n';
+      if (INFO(1) < 0) {
+         throw std::runtime_error("MA57: the symbolic analysis failed");
+      }
+      if (0 < INFO(1)) {
+         WARNING << "MA57 has issued a warning: info(1) = " << INFO(1) << '\n';
       }
 
       // get LFACT and LIFACT and resize FACT and IFACT (no effect if resized to <= size)
-      this->workspace.lfact = static_cast<int>(MA57Settings::allocation_safety_factor * this->workspace.info[8]);
-      this->workspace.lifact = static_cast<int>(MA57Settings::allocation_safety_factor * this->workspace.info[9]);
+      this->workspace.lfact = static_cast<int>(MA57Settings::allocation_safety_factor * INFO(11));
+      this->workspace.lifact = static_cast<int>(MA57Settings::allocation_safety_factor * INFO(12));
       this->workspace.fact.resize(static_cast<size_t>(this->workspace.lfact));
       this->workspace.ifact.resize(static_cast<size_t>(this->workspace.lifact));
       this->analysis_performed = true;
@@ -142,7 +142,10 @@ namespace uno {
             &this->workspace.lkeep, this->workspace.keep.data(), this->workspace.iwork.data(), this->workspace.icntl.data(),
             this->workspace.cntl.data(), this->workspace.info.data(), this->workspace.rinfo.data());
 
-         if (is_error_code_insufficient_real_workspace(INFO(1)) ||
+         if (INFO(1) == 0) {
+            factorization_done = true;
+         }
+         else if (is_error_code_insufficient_real_workspace(INFO(1)) ||
              is_error_code_insufficient_integer_workspace(INFO(1))) {
             const bool is_real_workspace = is_error_code_insufficient_real_workspace(this->workspace.info[0]);
 
@@ -166,8 +169,8 @@ namespace uno {
                this->workspace.lifact = lnewifact;
             }
          }
-         else {
-            factorization_done = true;
+         else if (INFO(1) < 0) {
+            throw std::runtime_error("MA57 fatal error");
          }
       }
       this->factorization_performed = true;
@@ -211,7 +214,7 @@ namespace uno {
    }
 
    size_t MA57Solver::number_negative_eigenvalues() const {
-      return static_cast<size_t>(this->workspace.info[23]);
+      return static_cast<size_t>(INFO(24));
    }
 
    /*
@@ -222,7 +225,7 @@ namespace uno {
    */
 
    bool MA57Solver::matrix_is_singular() const {
-      return (this->workspace.info[0] == 4);
+      return (INFO(1) == 4);
    }
 
    size_t MA57Solver::rank() const {

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
@@ -43,7 +43,6 @@ namespace uno {
       std::array<int, 40> info{};
 
       const int job{1};
-      std::vector<double> residuals;
 
       MA57Workspace() = default;
    };

--- a/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
@@ -23,6 +23,7 @@ namespace uno {
       virtual ~SubproblemSolver() = default;
 
       virtual void initialize_memory(const Subproblem& subproblem) = 0;
+      virtual void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const = 0;
 
       [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
@@ -23,7 +23,7 @@ namespace uno {
       virtual ~SubproblemSolver() = default;
 
       virtual void initialize_memory(const Subproblem& subproblem) = 0;
-      virtual void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const = 0;
+      virtual void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) = 0;
 
       [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -9,6 +9,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "options/Options.hpp"
@@ -32,8 +33,56 @@ namespace uno {
       this->linear_solver->initialize_memory();
    }
 
-   void WoodburyEQPSolver::generate_initial_iterate(Iterate& initial_iterate, Evaluations& /*evaluations*/) const {
+   void WoodburyEQPSolver::generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate,
+         Evaluations& evaluations) {
+      INFO << "Computing least-square multipliers at initial point\n";
 
+      // compute least-square multipliers
+      auto& linear_system = this->linear_solver->get_linear_system();
+
+      // set up the linear system
+      const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+      const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
+      const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
+      View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);
+      View primal_inertia_correction(hessian.end(), number_primal_inertia_correction_nonzeros);
+      View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
+      View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
+
+      hessian.fill(0.); // no Hessian contribution
+      primal_inertia_correction.fill(1.); // Identity block
+      subproblem.evaluate_jacobian(initial_iterate, jacobian, evaluations);
+      dual_inertia_correction.fill(0.); // no dual regularization
+
+      // perform the symbolic analysis once and for all
+      if (!this->analysis_performed) {
+         DEBUG << "Performing symbolic analysis of the indefinite system\n";
+         this->linear_solver->do_symbolic_analysis();
+         this->analysis_performed = true;
+      }
+
+      // factorize the matrix
+      this->linear_solver->do_numerical_factorization(false);
+
+      // assemble the RHS
+      linear_system.rhs.fill(0.);
+      evaluations.evaluate_objective_gradient(subproblem.problem.model, initial_iterate.primals);
+      view(linear_system.rhs.data(), subproblem.number_variables) = evaluations.objective_gradient;
+      for (size_t variable_index: Range(subproblem.number_variables)) {
+         linear_system.rhs[variable_index] -= (initial_iterate.multipliers.lower_bounds[variable_index] +
+            initial_iterate.multipliers.upper_bounds[variable_index]);
+      }
+
+      // solve the linear system
+      this->linear_solver->solve_indefinite_system(linear_system.solution.data());
+
+      // set the constraint multipliers if their norm is reasonable
+      const auto least_squares_multipliers = view(linear_system.solution.data(), subproblem.number_variables,
+         subproblem.number_variables + subproblem.number_constraints);
+      if (norm_inf(least_squares_multipliers) <= 1000.) {
+         initial_iterate.multipliers.constraints = least_squares_multipliers;
+      }
    }
 
    Direction& WoodburyEQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -82,6 +82,7 @@ namespace uno {
          subproblem.number_variables + subproblem.number_constraints);
       if (norm_inf(least_squares_multipliers) <= 1000.) {
          initial_iterate.multipliers.constraints = least_squares_multipliers;
+         DEBUG << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
       }
    }
 

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -33,8 +33,7 @@ namespace uno {
    }
 
    void WoodburyEQPSolver::generate_initial_iterate(Iterate& initial_iterate, Evaluations& /*evaluations*/) const {
-      // temporarily set nonzero multipliers, until we have least-square multipliers
-      initial_iterate.multipliers.constraints.fill(-1.);
+
    }
 
    Direction& WoodburyEQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -34,7 +34,7 @@ namespace uno {
 
    void WoodburyEQPSolver::generate_initial_iterate(Iterate& initial_iterate, Evaluations& /*evaluations*/) const {
       // temporarily set nonzero multipliers, until we have least-square multipliers
-      initial_iterate.multipliers.constraints.fill(1.);
+      initial_iterate.multipliers.constraints.fill(-1.);
    }
 
    Direction& WoodburyEQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -9,6 +9,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "options/Options.hpp"
 #include "symbolic/Multiplication.hpp"
@@ -29,6 +30,11 @@ namespace uno {
       auto& linear_system = this->linear_solver->get_linear_system();
       linear_system.initialize_augmented_system(subproblem);
       this->linear_solver->initialize_memory();
+   }
+
+   void WoodburyEQPSolver::generate_initial_iterate(Iterate& initial_iterate, Evaluations& /*evaluations*/) const {
+      // temporarily set nonzero multipliers, until we have least-square multipliers
+      initial_iterate.multipliers.constraints.fill(1.);
    }
 
    Direction& WoodburyEQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
@@ -36,6 +36,7 @@ namespace uno {
       ~WoodburyEQPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
+      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
@@ -36,7 +36,7 @@ namespace uno {
       ~WoodburyEQPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
+      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/linear_algebra/Vector.hpp
+++ b/uno/linear_algebra/Vector.hpp
@@ -83,10 +83,12 @@ namespace uno {
       }
 
       T& operator[](size_t index) {
+         assert(index < this->size());
          return this->vector[index];
       }
 
       const T& operator[](size_t index) const {
+         assert(index < this->size());
          return this->vector[index];
       }
 


### PR DESCRIPTION
Computation of least-square multipliers at initial iterate for equality-constrained problems.
We now always allocate the primal inertia correction block (whether it's used or not) and fill this block with 1s for computing the least-squares multipliers.