### PR TITLE
Split `Filter::acceptable_wrt_infeasibility_upper_bound` and `Filter::filter_acceptable`

### DIFF
--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
@@ -24,39 +24,42 @@ namespace uno {
 
       std::string scenario;
       bool accept = false;
-      if (this->filter->acceptable(trial_progress.infeasibility, trial_merit)) {
-         if (this->filter->acceptable_wrt_current_iterate(current_progress.infeasibility, current_merit, trial_progress.infeasibility, trial_merit)) {
-            // switching condition: check whether the unconstrained predicted reduction is sufficiently positive
-            if (this->switching_condition(merit_predicted_reduction, current_progress.infeasibility)) {
-               // unconstrained Armijo sufficient decrease condition: predicted reduction should be positive (f-type)
-               const double merit_actual_reduction = this->compute_actual_objective_reduction(current_merit, current_progress.infeasibility, trial_merit);
-               DEBUG << "Unconstrained actual reduction = " << merit_actual_reduction << '\n';
-               if (this->armijo_sufficient_decrease(merit_predicted_reduction, merit_actual_reduction)) {
-                  DEBUG << "Trial iterate (f-type) was accepted by satisfying the Armijo condition\n";
-                  accept = true;
-               }
-               else { // switching condition holds, but not Armijo condition
-                  DEBUG << "Trial iterate (f-type) was rejected by violating the Armijo condition\n";
-               }
-               scenario = "f-type";
-            }
-               // switching condition violated: predicted reduction is not promising (h-type)
-            else {
-               DEBUG << "Trial iterate (h-type) was accepted by violating the switching condition\n";
-               accept = true;
-               this->filter->add(current_progress.infeasibility, current_merit);
-               DEBUG << "Current iterate was added to the filter\n";
-               scenario = "h-type";
-            }
-         }
-         else {
-            DEBUG << "Trial iterate not acceptable with respect to current point\n";
-            scenario = "current";
-         }
+      if (!this->filter->acceptable_wrt_infeasibility_upper_bound(trial_progress.infeasibility)) {
+         DEBUG << "Trial iterate not acceptable wrt infeasibility upper bound\n";
+         scenario = "upper bound";
       }
-      else {
+      // now acceptable wrt infeasibility upper bound
+      else if (!this->filter->filter_acceptable(trial_progress.infeasibility, trial_merit)) {
          DEBUG << "Trial iterate not filter acceptable\n";
          scenario = "filter";
+      }
+      // now filter acceptable
+      else if (!this->filter->acceptable_wrt_current_iterate(current_progress.infeasibility, current_merit, trial_progress.infeasibility, trial_merit)) {
+         DEBUG << "Trial iterate not acceptable with respect to current point\n";
+         scenario = "current";
+      }
+      // now acceptable wrt current iterate
+      // switching condition: check whether the unconstrained predicted reduction is sufficiently positive
+      else if (this->switching_condition(merit_predicted_reduction, current_progress.infeasibility)) {
+         // unconstrained Armijo sufficient decrease condition: predicted reduction should be positive (f-type)
+         const double merit_actual_reduction = this->compute_actual_objective_reduction(current_merit, current_progress.infeasibility, trial_merit);
+         DEBUG << "Unconstrained actual reduction = " << merit_actual_reduction << '\n';
+         if (this->armijo_sufficient_decrease(merit_predicted_reduction, merit_actual_reduction)) {
+            DEBUG << "Trial iterate (f-type) was accepted by satisfying the Armijo condition\n";
+            accept = true;
+         }
+         else { // switching condition holds, but not Armijo condition
+            DEBUG << "Trial iterate (f-type) was rejected by violating the Armijo condition\n";
+         }
+         scenario = "f-type";
+      }
+      // switching condition violated: predicted reduction is not promising (h-type)
+      else {
+         DEBUG << "Trial iterate (h-type) was accepted by violating the switching condition\n";
+         accept = true;
+         this->filter->add(current_progress.infeasibility, current_merit);
+         DEBUG << "Current iterate was added to the filter\n";
+         scenario = "h-type";
       }
       statistics.set("Status", std::string(accept ? symbols::check : symbols::fail) + " (" + scenario + ")");
       return accept;

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
@@ -35,7 +35,17 @@ namespace uno {
 
       std::string scenario;
       bool accept = false;
-      if (this->filter->acceptable(trial_progress.infeasibility, trial_merit)) {
+      if (!this->filter->acceptable_wrt_infeasibility_upper_bound(trial_progress.infeasibility)) {
+         DEBUG << "Trial iterate not acceptable wrt infeasibility upper bound\n";
+         scenario = "upper bound";
+      }
+      // now acceptable wrt infeasibility upper bound
+      else if (!this->filter->filter_acceptable(trial_progress.infeasibility, trial_merit)) {
+         DEBUG << "Trial iterate not filter acceptable\n";
+         scenario = "filter";
+      }
+      // now filter acceptable
+      else {
          const double merit_actual_reduction = this->compute_actual_objective_reduction(current_merit, current_progress.infeasibility, trial_merit);
          DEBUG << "Unconstrained actual reduction = " << merit_actual_reduction << '\n';
 
@@ -73,17 +83,13 @@ namespace uno {
             this->filter->add(current_progress.infeasibility, current_merit);
          }
       }
-      else {
-         DEBUG << "Trial iterate not filter acceptable\n";
-         scenario = "filter";
-      }
       statistics.set("Status", std::string(accept ? symbols::check : symbols::fail) + " (" + scenario + ")");
       return accept;
    }
 
    bool WaechterFilterMethod::is_infeasibility_sufficiently_reduced(const ProgressMeasures& reference_progress, const ProgressMeasures& trial_progress) const {
       return trial_progress.infeasibility <= this->sufficient_infeasibility_decrease_factor * reference_progress.infeasibility &&
-         this->filter->acceptable(trial_progress.infeasibility, FilterMethod::unconstrained_merit_function(trial_progress));
+         this->filter->filter_acceptable(trial_progress.infeasibility, FilterMethod::unconstrained_merit_function(trial_progress));
    }
 
    std::string WaechterFilterMethod::get_name() const {

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/filters/Filter.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/filters/Filter.cpp
@@ -37,14 +37,13 @@ namespace uno {
       this->infeasibility_upper_bound = new_upper_bound;
    }
 
-   // return true if (infeasibility, objective) acceptable, false otherwise
-   bool Filter::acceptable(double trial_infeasibility, double trial_objective) {
-      // check upper bound first
-      if (!this->acceptable_wrt_upper_bound(trial_infeasibility)) {
-         DEBUG << "Rejected because of filter upper bound\n";
-         return false;
-      }
+   bool Filter::acceptable_wrt_infeasibility_upper_bound(double trial_infeasibility) const {
+      return this->infeasibility_sufficient_reduction(this->infeasibility_upper_bound, trial_infeasibility);
+   }
 
+   // return true if (infeasibility, objective) acceptable, false otherwise
+   // note: the infeasibility upper bound must be tested separately (see acceptable_wrt_infeasibility_upper_bound)
+   bool Filter::filter_acceptable(double trial_infeasibility, double trial_objective) const {
       // TODO: use binary search (use some form of https://en.cppreference.com/w/cpp/algorithm/binary_search.html)
       size_t position = 0;
       while (position < this->number_entries && !this->infeasibility_sufficient_reduction(this->infeasibility[position], trial_infeasibility)) {
@@ -187,10 +186,6 @@ namespace uno {
 
    bool Filter::is_empty() const {
       return (this->number_entries == 0);
-   }
-
-   bool Filter::acceptable_wrt_upper_bound(double trial_infeasibility) const {
-      return this->infeasibility_sufficient_reduction(this->infeasibility_upper_bound, trial_infeasibility);
    }
 
    bool Filter::objective_sufficient_reduction(double current_objective, double trial_objective, double trial_infeasibility) const {

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/filters/Filter.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/filters/Filter.hpp
@@ -20,19 +20,20 @@ namespace uno {
    class Filter {
    public:
       explicit Filter(const Options& options);
-      virtual ~Filter() = default;
+      ~Filter() = default;
 
       void reset();
       [[nodiscard]] double get_smallest_infeasibility() const;
       void set_infeasibility_upper_bound(double new_upper_bound);
 
-      [[nodiscard]] virtual bool acceptable(double trial_infeasibility, double trial_objective);
-      [[nodiscard]] virtual bool acceptable_wrt_current_iterate(double current_infeasibility, double current_objective,
+      [[nodiscard]] bool acceptable_wrt_infeasibility_upper_bound(double trial_infeasibility) const;
+      [[nodiscard]] bool filter_acceptable(double trial_infeasibility, double trial_objective) const;
+      [[nodiscard]] bool acceptable_wrt_current_iterate(double current_infeasibility, double current_objective,
          double trial_infeasibility, double trial_objective) const;
       [[nodiscard]] bool infeasibility_sufficient_reduction(double current_infeasibility, double trial_infeasibility) const;
-      [[nodiscard]] virtual double compute_actual_objective_reduction(double current_objective, double current_infeasibility, double trial_objective);
+      [[nodiscard]] double compute_actual_objective_reduction(double current_objective, double current_infeasibility, double trial_objective);
 
-      virtual void add(double current_infeasibility, double current_objective);
+      void add(double current_infeasibility, double current_objective);
 
       friend std::ostream& operator<<(std::ostream& stream, const Filter& filter);
 
@@ -47,7 +48,6 @@ namespace uno {
       static constexpr size_t fixed_length_column2 = 10;
 
       [[nodiscard]] bool is_empty() const;
-      [[nodiscard]] bool acceptable_wrt_upper_bound(double trial_infeasibility) const;
       [[nodiscard]] bool objective_sufficient_reduction(double current_objective, double trial_objective, double trial_infeasibility) const;
       void left_shift(size_t start, size_t shift_size);
       void right_shift(size_t start, size_t shift_size);


### PR DESCRIPTION
Split `Filter::acceptable_wrt_infeasibility_upper_bound` and `Filter::filter_acceptable`.
The IPOPT implementation should take different actions, depending if the trial iterate is rejected wrt the infeasibility upper bound or wrt the filter.