### PR TITLE
Set `OptimizationProblem::dual_regularization_factor` to 1

### DIFF
--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -174,7 +174,7 @@ namespace uno {
    }
 
    double OptimizationProblem::dual_regularization_factor() const {
-      return 0.;
+      return 1.;
    }
    
    double OptimizationProblem::complementarity_error(const Vector<double>& primals, const Vector<double>& constraints,


### PR DESCRIPTION
By construction, `PrimalDualInteriorPointProblem::dual_regularization_factor` is positive. However, when no inequality constraints are present, Uno bypasses the IPM and runs a pure SQP method. But `OptimizationProblem::dual_regularization_factor` was set to 0...
It is now set to 1 (and scaled by something like 1e-8 in `PrimalDualInertiaCorrection`).