### PR TITLE
Upon `BacktrackingLineSearch::is_tiny_direction()`, skip backtracking and accept

### DIFF
--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -72,7 +72,7 @@ namespace uno {
       assert(this->constraint_relaxation_strategy->solving_feasibility_problem());
       Direction& direction = this->constraint_relaxation_strategy->compute_feasible_direction(statistics, current_iterate,
          INF<double>, evaluation_cache.current_evaluations, warmstart_information);
-      BacktrackingLineSearch::check_unboundedness(direction);
+      check_unboundedness(direction);
       const bool backtracking_success = this->backtrack_along_direction(statistics, model, current_iterate,
          trial_iterate, direction, evaluation_cache, warmstart_information, user_callbacks);
       if (!backtracking_success) {
@@ -117,10 +117,15 @@ namespace uno {
             assemble_trial_iterate(model, current_iterate, trial_iterate, direction, step_length);
             statistics.set("||Step||", step_length * direction.norm);
 
-            is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
+            if (number_iterations == 1 && is_tiny_direction(current_iterate, direction)) {
+               is_acceptable = true;
+            }
+            else {
+               is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
                trial_iterate, direction, step_length, false, evaluation_cache.current_evaluations, evaluation_cache.trial_evaluations,
                warmstart_information, user_callbacks);
-            BacktrackingLineSearch::set_primal_statistics(statistics, model, trial_iterate, evaluation_cache.trial_evaluations);
+            }
+            set_primal_statistics(statistics, model, trial_iterate, evaluation_cache.trial_evaluations);
          }
          catch (const EvaluationError&) {
             statistics.set("Status", "eval. error");
@@ -164,6 +169,19 @@ namespace uno {
          }
          if (Logger::level == INFO) statistics.print_current_line();
       } // end while loop
+      return true;
+   }
+
+   bool BacktrackingLineSearch::is_tiny_direction(const Iterate& current_iterate, const Direction& direction) {
+      constexpr double macheps = std::numeric_limits<double>::epsilon();
+      for (size_t variable_index: Range(current_iterate.number_variables)) {
+         if (std::abs(direction.primals[variable_index]) / (1. + std::abs(current_iterate.primals[variable_index])) >= 10.*macheps) {
+            return false;
+         }
+      }
+      if (current_iterate.primal_feasibility > 1e-4) { // TODO add option
+         return false;
+      }
       return true;
    }
 

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -118,21 +118,21 @@ namespace uno {
             assemble_trial_iterate(model, current_iterate, trial_iterate, direction, step_length);
             statistics.set("||Step||", step_length * direction.norm);
 
-            if (number_iterations == 1 && is_tiny_direction(current_iterate, direction)) {
-               is_acceptable = true;
-               statistics.set("Status", std::string(symbols::check) + " (tiny)");
-            }
-            else {
-               is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
+            is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
                trial_iterate, direction, step_length, false, evaluation_cache.current_evaluations, evaluation_cache.trial_evaluations,
                warmstart_information, user_callbacks);
-            }
             set_primal_statistics(statistics, model, trial_iterate, evaluation_cache.trial_evaluations);
          }
          catch (const EvaluationError&) {
             statistics.set("Status", "eval. error");
          }
          statistics.set("Minor", number_iterations);
+
+         // tiny direction test
+         if (!is_acceptable && number_iterations == 1 && is_tiny_direction(current_iterate, direction)) {
+            is_acceptable = true;
+            statistics.set("Status", std::string(symbols::check) + " (tiny)");
+         }
 
          if (is_acceptable) {
             termination = true;

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -128,10 +128,15 @@ namespace uno {
          }
          statistics.set("Minor", number_iterations);
 
-         // tiny direction test
+         // tiny direction test: if the primal direction is tiny over a certain number of successive iterations,
+         // accept the step unconditionally
          if (!is_acceptable && number_iterations == 1 && is_tiny_direction(current_iterate, direction)) {
-            is_acceptable = true;
-            statistics.set("Status", std::string(symbols::check) + " (tiny)");
+            ++this->number_consecutive_tiny_directions;
+            if (this->number_consecutive_tiny_directions >= this->consecutive_tiny_directions_threshold) {
+               is_acceptable = true;
+               statistics.set("Status", std::string(symbols::check) + " (tiny)");
+               this->number_consecutive_tiny_directions = 0;
+            }
          }
 
          if (is_acceptable) {

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -14,6 +14,7 @@
 #include "tools/Logger.hpp"
 #include "options/Options.hpp"
 #include "tools/Statistics.hpp"
+#include "tools/Symbols.hpp"
 
 namespace uno {
    BacktrackingLineSearch::BacktrackingLineSearch(const Model& model, Options& options):
@@ -119,6 +120,7 @@ namespace uno {
 
             if (number_iterations == 1 && is_tiny_direction(current_iterate, direction)) {
                is_acceptable = true;
+               statistics.set("Status", std::string(symbols::check) + " (tiny)");
             }
             else {
                is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
@@ -27,6 +27,9 @@ namespace uno {
       const double backtracking_ratio;
       const double minimum_step_length;
       const bool scale_duals_with_step_length;
+      // tiny directions
+      size_t number_consecutive_tiny_directions{0};
+      const size_t consecutive_tiny_directions_threshold{2}; // TODO add option
       // second-order corrections
       const size_t SOC_max_iterations;
       const double SOC_infeasibility_fraction;

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
@@ -38,6 +38,7 @@ namespace uno {
       [[nodiscard]] bool backtrack_along_direction(Statistics& statistics, const Model& model, Iterate& current_iterate,
          Iterate& trial_iterate, Direction& direction, EvaluationCache& evaluation_cache, WarmstartInformation& warmstart_information,
          UserCallbacks& user_callbacks);
+      [[nodiscard]] static bool is_tiny_direction(const Iterate& current_iterate, const Direction& direction);
       [[nodiscard]] bool compute_second_order_directions(Statistics& statistics, const Model& model, Iterate& current_iterate,
          Iterate& trial_iterate, Direction& direction, EvaluationCache& evaluation_cache,
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks);


### PR DESCRIPTION
Upon `BacktrackingLineSearch::is_tiny_direction()`, skip backtracking and accept trial iterate (section 3.9 in IPOPT paper)