### PR TITLE
Apply dual regularization iteratively, not just once at the beginning

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -117,9 +117,12 @@ namespace uno {
       current_iterate.set_number_variables(this->feasibility_problem.number_variables);
       this->initial_point.resize(this->feasibility_problem.number_variables);
       // swap the iterate's multipliers and the feasibility multipliers maintained by the class
-      this->other_phase_multipliers.constraints.resize(this->feasibility_problem.number_constraints);
-      this->other_phase_multipliers.lower_bounds.resize(this->feasibility_problem.number_variables);
-      this->other_phase_multipliers.upper_bounds.resize(this->feasibility_problem.number_variables);
+      if (this->first_switch_to_feasibility) {
+         this->other_phase_multipliers.constraints.resize(this->feasibility_problem.number_constraints);
+         this->other_phase_multipliers.lower_bounds.resize(this->feasibility_problem.number_variables);
+         this->other_phase_multipliers.upper_bounds.resize(this->feasibility_problem.number_variables);
+         this->first_switch_to_feasibility = false;
+      }
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
 
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
@@ -192,9 +195,9 @@ namespace uno {
       this->current_phase = Phase::OPTIMALITY;
       this->globalization_strategy->notify_switch_to_optimality(current_iterate.progress);
 
-      current_iterate.set_number_variables(this->original_problem.number_variables);
       // swap the iterate's multipliers and the optimality multipliers maintained by the class
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
+      current_iterate.set_number_variables(this->original_problem.number_variables);
       trial_iterate.set_number_variables(this->original_problem.number_variables);
       current_iterate.objective_multiplier = trial_iterate.objective_multiplier = 1.;
       this->initial_point.resize(this->original_problem.number_variables);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -66,6 +66,7 @@ namespace uno {
       const bool switch_to_optimality_requires_linearized_feasibility;
       ProgressMeasures reference_optimality_progress{};
       Vector<double> reference_optimality_primals{};
+      bool first_switch_to_feasibility{true};
 
       Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
@@ -127,7 +127,16 @@ namespace uno {
             this->previous_primal_regularization = this->primal_regularization;
          }
          else {
-            if (this->previous_primal_regularization == 0. || this->threshold_unsuccessful_attempts < number_attempts) {
+            if (linear_solver.matrix_is_singular()) {
+               DEBUG << "Matrix is singular\n";
+               if (this->dual_regularization == 0.) {
+                  this->dual_regularization = this->dual_regularization_fraction * dual_regularization_parameter;
+               }
+               else {
+                  this->dual_regularization *= 10.;
+               }
+            }
+            else if (this->previous_primal_regularization == 0. || this->threshold_unsuccessful_attempts < number_attempts) {
                this->primal_regularization *= this->primal_regularization_fast_increase_factor;
             }
             else {

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -32,7 +32,7 @@ namespace uno {
    }
 
    void EQPSolver::generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) {
-      INFO << "Computing least-square multipliers at initial point\n";
+      INFO << "Computing least-squares multipliers at initial point\n";
 
       // compute least-square multipliers
       auto& linear_system = this->linear_solver->get_linear_system();
@@ -81,6 +81,9 @@ namespace uno {
       if (norm_inf(least_squares_multipliers) <= 1000.) {
          initial_iterate.multipliers.constraints = least_squares_multipliers;
          DEBUG << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
+      }
+      else {
+         DEBUG << "Least-squares multipliers too large\n";
       }
    }
 

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -35,7 +35,7 @@ namespace uno {
 
    void WoodburyEQPSolver::generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate,
          Evaluations& evaluations) {
-      INFO << "Computing least-square multipliers at initial point\n";
+      INFO << "Computing least-squares multipliers at initial point\n";
 
       // compute least-square multipliers
       auto& linear_system = this->linear_solver->get_linear_system();
@@ -84,6 +84,9 @@ namespace uno {
       if (norm_inf(least_squares_multipliers) <= 1000.) {
          initial_iterate.multipliers.constraints = least_squares_multipliers;
          DEBUG << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
+      }
+      else {
+         DEBUG << "Least-squares multipliers too large\n";
       }
    }
 


### PR DESCRIPTION
- Improvement: resize the feasibility multipliers once and for all
- Bug fix: apply dual regularization iteratively, not just once at the beginning