### PR TITLE
Compute least-squares multipliers when switching back to optimality phase

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -190,13 +190,17 @@ namespace uno {
       return false;
    }
 
-   void FeasibilityRestoration::switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate) {
+   void FeasibilityRestoration::switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate,
+         Evaluations& trial_evaluations) {
       DEBUG << "Switching from restoration back to optimality phase\n";
       this->current_phase = Phase::OPTIMALITY;
       this->globalization_strategy->notify_switch_to_optimality(current_iterate.progress);
 
-      // swap the iterate's multipliers and the optimality multipliers maintained by the class
+      // swap the iterate's multipliers and the optimality multipliers maintained by the class, and possibly compute
+      // least-squares multipliers for the original problem
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
+      this->inequality_handling_method->compute_least_squares_multipliers(trial_iterate, trial_evaluations);
+
       current_iterate.set_number_variables(this->original_problem.number_variables);
       trial_iterate.set_number_variables(this->original_problem.number_variables);
       current_iterate.objective_multiplier = trial_iterate.objective_multiplier = 1.;
@@ -230,7 +234,7 @@ namespace uno {
       // possibly go from restoration phase to optimality phase
       if (accept_iterate && this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(model,
             trial_iterate, direction, step_length, current_evaluations)) {
-         this->switch_back_to_optimality_phase(current_iterate, trial_iterate);
+         this->switch_back_to_optimality_phase(current_iterate, trial_iterate, trial_evaluations);
          // set a cold start in the subproblem solver
          warmstart_information.whole_problem_changed();
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -71,7 +71,7 @@ namespace uno {
       Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information);
-      void switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate);
+      void switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate, Evaluations& trial_evaluations);
 
       [[nodiscard]] bool can_switch_to_optimality_phase(const Model& model, const Iterate& trial_iterate,
          const Direction& direction, double step_length, Evaluations& current_evaluations) const;

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -42,6 +42,7 @@ namespace uno {
       [[nodiscard]] virtual bool has_second_order_corrections() const = 0;
       [[nodiscard]] virtual const Direction& compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) = 0;
+      virtual void compute_least_squares_multipliers(Iterate& iterate, Evaluations& evaluations) = 0;
 
       virtual void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const = 0;
       [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -71,6 +71,10 @@ namespace uno {
       return this->subproblem_solver->compute_second_order_correction(*this->subproblem, current_iterate, constraints_SOC);
    }
 
+   void NoInequalityReformulation::compute_least_squares_multipliers(Iterate& iterate, Evaluations& evaluations) {
+      this->subproblem_solver->compute_least_squares_multipliers(*this->subproblem, iterate, evaluations);
+   }
+
    void NoInequalityReformulation::evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const {
       InequalityHandlingMethod::evaluate_progress_measures(this->problem, iterate, evaluations);
    }

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
@@ -36,6 +36,7 @@ namespace uno {
       [[nodiscard]] bool has_second_order_corrections() const override;
       [[nodiscard]] const Direction& compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) override;
+      void compute_least_squares_multipliers(Iterate& iterate, Evaluations& evaluations) override;
 
       void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -39,6 +39,7 @@ namespace uno {
       [[nodiscard]] bool has_second_order_corrections() const override;
       [[nodiscard]] const Direction& compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) override;
+      void compute_least_squares_multipliers(Iterate& iterate, Evaluations& evaluations) override;
 
       void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
@@ -208,6 +209,11 @@ namespace uno {
    const Direction& InteriorPointMethod<BarrierProblem>::compute_second_order_correction(const Iterate& current_iterate,
          const Vector<double>& constraints_SOC) {
       return this->subproblem_solver->compute_second_order_correction(*this->subproblem, current_iterate, constraints_SOC);
+   }
+
+   template <typename BarrierProblem>
+   void InteriorPointMethod<BarrierProblem>::compute_least_squares_multipliers(Iterate& iterate, Evaluations& evaluations) {
+      this->subproblem_solver->compute_least_squares_multipliers(*this->subproblem, iterate, evaluations);
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
@@ -5,6 +5,7 @@
 #include "BoxLPSolver.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "optimization/Direction.hpp"
+#include "tools/Logger.hpp"
 
 namespace uno {
    void BoxLPSolver::initialize_memory(const Subproblem& subproblem) {
@@ -17,6 +18,11 @@ namespace uno {
    void BoxLPSolver::generate_initial_iterate(const Subproblem& /*subproblem*/, Iterate& /*initial_iterate*/,
          Evaluations& /*evaluations*/) {
       // do nothing
+   }
+
+   void BoxLPSolver::compute_least_squares_multipliers(const Subproblem& /*subproblem*/, Iterate& /*iterate*/,
+         Evaluations& /*evaluations*/) {
+      DEBUG << "The box LP solver does not compute least-squares multipliers, keeping existing multipliers";
    }
 
    Direction& BoxLPSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
@@ -30,6 +30,7 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
       void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
+      void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -32,6 +32,10 @@ namespace uno {
    }
 
    void EQPSolver::generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) {
+      compute_least_squares_multipliers(subproblem, initial_iterate, evaluations);
+   }
+
+   void EQPSolver::compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations) {
       INFO << "Computing least-squares multipliers at initial point\n";
 
       // compute least-square multipliers
@@ -49,7 +53,7 @@ namespace uno {
 
       hessian.fill(0.); // no Hessian contribution
       primal_inertia_correction.fill(1.); // Identity block
-      subproblem.evaluate_jacobian(initial_iterate, jacobian, evaluations);
+      subproblem.evaluate_jacobian(iterate, jacobian, evaluations);
       dual_inertia_correction.fill(0.); // no dual regularization
 
       // perform the symbolic analysis once and for all
@@ -64,11 +68,11 @@ namespace uno {
 
       // assemble the RHS
       linear_system.rhs.fill(0.);
-      evaluations.evaluate_objective_gradient(subproblem.problem.model, initial_iterate.primals);
+      evaluations.evaluate_objective_gradient(subproblem.problem.model, iterate.primals);
       view(linear_system.rhs.data(), subproblem.number_variables) = evaluations.objective_gradient;
       for (size_t variable_index: Range(subproblem.number_variables)) {
-         linear_system.rhs[variable_index] -= (initial_iterate.multipliers.lower_bounds[variable_index] +
-            initial_iterate.multipliers.upper_bounds[variable_index]);
+         linear_system.rhs[variable_index] -= (iterate.multipliers.lower_bounds[variable_index] +
+            iterate.multipliers.upper_bounds[variable_index]);
       }
 
       // solve the linear system
@@ -79,7 +83,7 @@ namespace uno {
       const auto least_squares_multipliers = view(linear_system.solution.data(), subproblem.number_variables,
          subproblem.number_variables + subproblem.number_constraints);
       if (norm_inf(least_squares_multipliers) <= 1000.) {
-         initial_iterate.multipliers.constraints = least_squares_multipliers;
+         iterate.multipliers.constraints = least_squares_multipliers;
          DEBUG << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
       }
       else {

--- a/uno/ingredients/subproblem_solvers/EQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.hpp
@@ -21,6 +21,7 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
       void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
+      void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/IQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.cpp
@@ -7,6 +7,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Iterate.hpp"
+#include "tools/Logger.hpp"
 
 namespace uno {
    IQPSolver::IQPSolver(std::unique_ptr<LPSolver> qp_solver):
@@ -23,6 +24,11 @@ namespace uno {
    void IQPSolver::generate_initial_iterate(const Subproblem& /*subproblem*/, Iterate& /*initial_iterate*/,
          Evaluations& /*evaluations*/) {
       // do nothing
+   }
+
+   void IQPSolver::compute_least_squares_multipliers(const Subproblem& /*subproblem*/, Iterate& /*iterate*/,
+         Evaluations& /*evaluations*/) {
+      DEBUG << "The EQP solver does not compute least-squares multipliers, keeping existing multipliers";
    }
 
    Direction& IQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/IQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.hpp
@@ -27,6 +27,7 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
       void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
+      void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
@@ -25,6 +25,11 @@ namespace uno {
       // do nothing
    }
 
+   void InverseNewtonSolver::compute_least_squares_multipliers(const Subproblem& /*subproblem*/, Iterate& /*iterate*/,
+         Evaluations& /*evaluations*/) {
+      DEBUG << "The inverse Newton solver does not compute least-squares multipliers, keeping existing multipliers";
+   }
+
    Direction& InverseNewtonSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
          [[maybe_unused]] double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& /*warmstart_information*/) {

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
@@ -32,6 +32,7 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
       void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
+      void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
@@ -24,6 +24,7 @@ namespace uno {
 
       virtual void initialize_memory(const Subproblem& subproblem) = 0;
       virtual void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) = 0;
+      virtual void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations) = 0;
 
       [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -35,6 +35,11 @@ namespace uno {
 
    void WoodburyEQPSolver::generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate,
          Evaluations& evaluations) {
+      compute_least_squares_multipliers(subproblem, initial_iterate, evaluations);
+   }
+
+   void WoodburyEQPSolver::compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate,
+         Evaluations& evaluations) {
       INFO << "Computing least-squares multipliers at initial point\n";
 
       // compute least-square multipliers
@@ -52,7 +57,7 @@ namespace uno {
 
       hessian.fill(0.); // no Hessian contribution
       primal_inertia_correction.fill(1.); // Identity block
-      subproblem.evaluate_jacobian(initial_iterate, jacobian, evaluations);
+      subproblem.evaluate_jacobian(iterate, jacobian, evaluations);
       dual_inertia_correction.fill(0.); // no dual regularization
 
       // perform the symbolic analysis once and for all
@@ -67,11 +72,11 @@ namespace uno {
 
       // assemble the RHS
       linear_system.rhs.fill(0.);
-      evaluations.evaluate_objective_gradient(subproblem.problem.model, initial_iterate.primals);
+      evaluations.evaluate_objective_gradient(subproblem.problem.model, iterate.primals);
       view(linear_system.rhs.data(), subproblem.number_variables) = evaluations.objective_gradient;
       for (size_t variable_index: Range(subproblem.number_variables)) {
-         linear_system.rhs[variable_index] -= (initial_iterate.multipliers.lower_bounds[variable_index] +
-            initial_iterate.multipliers.upper_bounds[variable_index]);
+         linear_system.rhs[variable_index] -= (iterate.multipliers.lower_bounds[variable_index] +
+            iterate.multipliers.upper_bounds[variable_index]);
       }
 
       // solve the linear system
@@ -82,7 +87,7 @@ namespace uno {
       const auto least_squares_multipliers = view(linear_system.solution.data(), subproblem.number_variables,
          subproblem.number_variables + subproblem.number_constraints);
       if (norm_inf(least_squares_multipliers) <= 1000.) {
-         initial_iterate.multipliers.constraints = least_squares_multipliers;
+         iterate.multipliers.constraints = least_squares_multipliers;
          DEBUG << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
       }
       else {

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
@@ -37,6 +37,7 @@ namespace uno {
 
       void initialize_memory(const Subproblem& subproblem) override;
       void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
+      void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations) override;
 
       [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,


### PR DESCRIPTION
Compute least-squares multipliers when switching from feasibility restoration back to optimality phase