### PR TITLE
Print the versions of the subproblem solvers

### DIFF
--- a/interfaces/AMPL/uno_ampl.cpp
+++ b/interfaces/AMPL/uno_ampl.cpp
@@ -88,9 +88,6 @@ int main(int argc, char* argv[]) {
          const AMPLModel model(model_name);
 
          // set the preset (default: auto)
-         // model name
-         const char* model_name = argv[1];
-         const AMPLModel model(model_name);
          Presets::set(model, options, options.get_string("preset"));
 
          // set the rest of the command line options

--- a/interfaces/AMPL/uno_ampl.cpp
+++ b/interfaces/AMPL/uno_ampl.cpp
@@ -88,6 +88,9 @@ int main(int argc, char* argv[]) {
          const AMPLModel model(model_name);
 
          // set the preset (default: auto)
+         // model name
+         const char* model_name = argv[1];
+         const AMPLModel model(model_name);
          Presets::set(model, options, options.get_string("preset"));
 
          // set the rest of the command line options

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -41,10 +41,9 @@ namespace uno {
 
    // solve with user callbacks
    Result Uno::solve(const Model& model, Options& options, UserCallbacks& user_callbacks) {
-      DISCRETE << "Original model " << model.name << '\n' << model.number_variables << " variables, " <<
-         model.number_constraints << " constraints (" << model.get_equality_constraints().size() <<
+      DISCRETE << to_string(model.get_problem_type()) << " model " << model.name << " has " << model.number_variables <<
+         " variables, " << model.number_constraints << " constraints (" << model.get_equality_constraints().size() <<
          " equality, " << model.get_inequality_constraints().size() << " inequality)\n";
-      INFO << "Problem type: " << to_string(model.get_problem_type()) << '\n';
 
       // reformulate the model if:
       // - the user wants an interior-point method with log barrier function
@@ -58,7 +57,7 @@ namespace uno {
          // slightly relax the bound constraints
          const BoundRelaxedModel bound_relaxed_model(homogeneous_model, options);
 
-         DISCRETE << "Reformulated model " << bound_relaxed_model.name << '\n' << bound_relaxed_model.number_variables << " variables, " <<
+         DISCRETE << "Reformulated model has " << bound_relaxed_model.number_variables << " variables, " <<
             bound_relaxed_model.number_constraints << " constraints (" << bound_relaxed_model.get_equality_constraints().size() <<
             " equality, " << bound_relaxed_model.get_inequality_constraints().size() << " inequality)\n";
          Result result = uno_solve(bound_relaxed_model, options, user_callbacks);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -45,8 +45,10 @@ namespace uno {
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
 
       // reformulation of the original problem and the feasibility problem
+      INFO << "- Allocating optimality (original) problem:\n";
       this->inequality_handling_method = InequalityHandlingMethodFactory::create(this->original_problem, uses_trust_region,
          1., options);
+      INFO << "- Allocating feasibility problem:\n";
       this->feasibility_inequality_handling_method = InequalityHandlingMethodFactory::create(this->feasibility_problem,
          uses_trust_region, 0., options);
 

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethodFactory.cpp
@@ -34,6 +34,7 @@ namespace uno {
       // inequality-constrained methods
       if (inequality_handling_method == "inequality_constrained") {
          // no inequality reformulation: let the subproblem solver handle them
+         INFO << "Picking an inequality-constrained (LP or QP) method\n";
          return std::make_unique<NoInequalityReformulation>("inequality-constrained SQP method", problem, uses_trust_region,
             objective_multiplier, options);
       }
@@ -41,6 +42,7 @@ namespace uno {
       else if (inequality_handling_method == "interior_point") {
          const std::string barrier_function = options.get_string("barrier_function");
          if (barrier_function == "log") {
+            INFO << "Picking a barrier method\n";
             return std::make_unique<InteriorPointMethod<PrimalDualInteriorPointProblem>>(problem, uses_trust_region,
                objective_multiplier, options);
          }

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -162,7 +162,7 @@ namespace uno {
 
       // flip the sign
       rhs.scale(-1.);
-      DEBUG2 << "RHS: "; print_vector(DEBUG2, view(rhs, 0, this->number_variables + this->number_constraints)); DEBUG << '\n';
+      DEBUG2 << "RHS: "; print_vector(DEBUG2, view(rhs, 0, this->number_variables + this->number_constraints));
    }
 
    void Subproblem::assemble_primal_dual_direction(const Iterate& current_iterate, const Vector<double>& solution, Direction& direction) const {

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDSolver.cpp
@@ -65,6 +65,7 @@ namespace uno {
          alp(static_cast<size_t>(this->mlp)),
          lp(static_cast<size_t>(this->mlp)),
          print_subproblem(options.get_bool("print_subproblem")) {
+      INFO << "Running BQPD v2011.10.05\n";
       // construct an empty BQPD-native quadratic program so that get_quadratic_program() can be used to build
       // it directly from data (no Subproblem); the full solver instead calls initialize_memory(subproblem)
       this->quadratic_program = std::make_unique<BQPDQuadraticProgram>();

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -77,7 +77,7 @@ namespace uno {
       }
 
       // solve the linear system
-      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << '\n';
+      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << "\n\n";
       this->linear_solver->solve_indefinite_system(linear_system.solution.data());
 
       // set the constraint multipliers if their norm is reasonable
@@ -134,7 +134,7 @@ namespace uno {
       }
 
       // solve the linear system
-      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << '\n';
+      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << "\n\n";
       this->linear_solver->solve_indefinite_system(linear_system.solution.data());
       if (this->linear_solver->matrix_is_singular()) {
          this->direction.status = SubproblemStatus::INFEASIBLE;

--- a/uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp
+++ b/uno/ingredients/subproblem_solvers/HSL/HSLLoader.cpp
@@ -15,6 +15,7 @@
 #endif
 
 namespace uno {
+   LIBHSL_version_fp hsl_libhsl_version = nullptr;
    ma57id_fp hsl_ma57id = nullptr;
    ma57ad_fp hsl_ma57ad = nullptr;
    ma57bd_fp hsl_ma57bd = nullptr;
@@ -62,6 +63,7 @@ namespace uno {
       hsl_loaded_name = name;
       DEBUG << "Uno: loaded the HSL library '" << name << "' at runtime\n";
 
+      resolve(hsl_handle, hsl_libhsl_version, "LIBHSL_version");
       resolve(hsl_handle, hsl_ma57id, "ma57id");
       resolve(hsl_handle, hsl_ma57ad, "ma57ad");
       resolve(hsl_handle, hsl_ma57bd, "ma57bd");

--- a/uno/ingredients/subproblem_solvers/HSL/HSLLoader.hpp
+++ b/uno/ingredients/subproblem_solvers/HSL/HSLLoader.hpp
@@ -18,6 +18,8 @@ namespace uno {
       struct mc68_control;
       struct mc68_info;
 
+      using LIBHSL_version_fp = void (*)(int *major, int *minor, int *patch);
+
       // MA57
       using ma57id_fp = void (*)(double cntl[], int icntl[]);
       using ma57ad_fp = void (*)(const int* n, const int* ne, const int irn[], const int jcn[], const int* lkeep,
@@ -59,6 +61,7 @@ namespace uno {
    }
 
    // Resolved by load_hsl_library(); nullptr until loaded or if the symbol is absent.
+   extern LIBHSL_version_fp hsl_libhsl_version;
    extern ma57id_fp hsl_ma57id;
    extern ma57ad_fp hsl_ma57ad;
    extern ma57bd_fp hsl_ma57bd;

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSSolver.cpp
@@ -12,6 +12,7 @@
 namespace uno {
    HiGHSSolver::HiGHSSolver(const Options& options):
          QPSolver(), print_subproblem(options.get_bool("print_subproblem")) {
+      INFO << "Running HiGHS v" << highsVersion() << '\n';
       this->highs_solver.setOptionValue("output_flag", "false");
       // construct an empty HiGHS-native quadratic program so that get_quadratic_program() can be used to
       // build it directly from data (no Subproblem); the full solver instead calls initialize_memory(subproblem)

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -33,7 +33,7 @@ extern "C" {
       int IW1[], int* NSTEPS, int ICNTL[], int INFO[]);
 }
 #endif
-#ifdef HAS_HSL
+#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
 // libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
 // Temporarily rename it with #define
 #define new hsl_new
@@ -63,7 +63,7 @@ namespace uno {
             "runtime (set the UNO_HSL_LIBRARY environment variable to point at libhsl)");
       }
 #endif
-#ifdef HAS_HSL
+#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
       INFO << "Running MA27 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
 #else
       INFO << "Running MA27 v1.0.0\n";

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -5,6 +5,8 @@
 #include <cassert>
 #include <stdexcept>
 #include "MA27Solver.hpp"
+
+#include "ingredients/subproblem_solvers/HSL/HSLLoader.hpp"
 #include "tools/Logger.hpp"
 #ifdef HSL_RUNTIME_LOADING
 #include "ingredients/subproblem_solvers/HSL/HSLLoader.hpp"
@@ -52,6 +54,22 @@ namespace uno {
       RANK_DEFICIENT, // Matrix is rank deficient. In this case, a decomposition will still have been produced which will enable the subsequent solution of consistent equations (MA27B/BD entry only). INFO(2) will be set to the rank of the matrix. Note that this warning will overwrite an INFO(1)=1 or INFO(1)=2 warning.
    };
 
+   static void print_version() {
+#if defined(HAS_HSL)
+   #if defined(HSL_RUNTIME_LOADING)
+      if (LIBHSL_version != nullptr) {
+   #endif
+         int major, minor, patch;
+         LIBHSL_version(&major, &minor, &patch);
+         INFO << "Running MA27 v" << major << "." << minor << "." << patch << '\n';
+         return;
+   #if defined(HSL_RUNTIME_LOADING)
+      }
+   #endif
+#endif
+      INFO << "Running MA27\n";
+   }
+
    MA27Solver::MA27Solver(): DirectSymmetricIndefiniteLinearSolver() {
 #ifdef HSL_RUNTIME_LOADING
       if (!ma27_symbols_available()) {
@@ -59,13 +77,7 @@ namespace uno {
             "runtime (set the UNO_HSL_LIBRARY environment variable to point at libhsl)");
       }
 #endif
-#if defined(HAS_HSL)
-      int major, minor, patch;
-      LIBHSL_version(&major, &minor, &patch);
-      INFO << "Running MA27 v" << major << "." << minor << "." << patch << '\n';
-#else
-      INFO << "Running MA27 v1.0.0\n";
-#endif
+      print_version();
       // initialization: set the default values of the controlling parameters
       MA27_set_default_parameters(this->workspace.icntl.data(), this->workspace.cntl.data());
       MA27_ICNTL(1) = 0; // no warning messages

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -34,6 +34,13 @@ extern "C" {
       int IW1[], int* NSTEPS, int ICNTL[], int INFO[]);
 }
 #endif
+#ifdef HAS_HSL
+// libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
+// Temporarily rename it with #define
+#define new hsl_new
+#include <libhsl.h>
+#undef new
+#endif
 
 namespace uno {
    enum eIFLAG {
@@ -57,12 +64,17 @@ namespace uno {
             "runtime (set the UNO_HSL_LIBRARY environment variable to point at libhsl)");
       }
 #endif
+#ifdef HAS_HSL
+      INFO << "Running MA27 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
+#else
+      INFO << "Running MA27 v1.0.0\n";
+#endif
       // initialization: set the default values of the controlling parameters
       MA27_set_default_parameters(this->workspace.icntl.data(), this->workspace.cntl.data());
-      ICNTL(1) = 0; // no warning messages
-      ICNTL(2) = 0; // no diagnostic printing
-      ICNTL(3) = 0; // no diagnostic printing
-      CNTL(1) = MA27Settings::pivoting_threshold;
+      MA27_ICNTL(1) = 0; // no warning messages
+      MA27_ICNTL(2) = 0; // no diagnostic printing
+      MA27_ICNTL(3) = 0; // no diagnostic printing
+      MA27_CNTL(1) = MA27Settings::pivoting_threshold;
       this->workspace.iflag = 0; // a suitable pivot order is to be chosen automatically
    }
 
@@ -85,15 +97,15 @@ namespace uno {
          this->workspace.iw.data(), &this->workspace.liw, this->workspace.ikeep.data(), this->workspace.iw1.data(),  /* solver workspace */
          &this->workspace.nsteps, &this->workspace.iflag, this->workspace.icntl.data(), this->workspace.cntl.data(),
          this->workspace.info.data(), &this->workspace.ops);
-      if (INFO(1) != 0) {
+      if (MA27_INFO(1) != 0) {
          throw std::runtime_error("MA27: the symbolic analysis failed");
       }
       // resize IW
-      const int nirnec = INFO(6);
+      const int nirnec = MA27_INFO(6);
       this->workspace.liw = MA27Settings::liw_init_factor * nirnec;
       this->workspace.iw.reserve(static_cast<size_t>(this->workspace.liw));
       // resize factor (A)
-      const int nrlnec = INFO(5);
+      const int nrlnec = MA27_INFO(5);
       this->workspace.la = MA27Settings::la_init_factor * nrlnec;
       this->workspace.factor.resize(static_cast<size_t>(this->workspace.la));
 
@@ -124,13 +136,13 @@ namespace uno {
             this->workspace.icntl.data(), this->workspace.cntl.data(), this->workspace.info.data());
          factorization_done = true;
 
-         if (INFO(1) == eIFLAG::INSUFFICIENTINTEGER) {
+         if (MA27_INFO(1) == eIFLAG::INSUFFICIENTINTEGER) {
             DEBUG << "MA27: insufficient integer workspace, resizing and retrying. \n";
             // increase the size of iw by 50%
             this->workspace.iw.resize(static_cast<size_t>(3 * this->workspace.info[1] / 2));
             factorization_done = false;
          }
-         if (INFO(1) == eIFLAG::INSUFFICIENTREAL) {
+         if (MA27_INFO(1) == eIFLAG::INSUFFICIENTREAL) {
             DEBUG << "MA27: insufficient real workspace, resizing and retrying. \n";
             // increase the size of factor by 50%
             this->workspace.factor.resize(static_cast<size_t>(3 * this->workspace.info[1] / 2));
@@ -153,9 +165,9 @@ namespace uno {
          &this->workspace.liw, this->workspace.w.data(), &this->workspace.maxfrt, solution, this->workspace.iw1.data(),
          &this->workspace.nsteps, this->workspace.icntl.data(), this->workspace.info.data());
 
-      assert(INFO(1) == 0 && "MA27: the linear solve failed");
-      if (INFO(1) != 0) {
-         WARNING << "MA27 has issued a warning: IFLAG = " << INFO(1) << " additional info, IERROR = "
+      assert(MA27_INFO(1) == 0 && "MA27: the linear solve failed");
+      if (MA27_INFO(1) != 0) {
+         WARNING << "MA27 has issued a warning: IFLAG = " << MA27_INFO(1) << " additional info, IERROR = "
             << this->workspace.info[1] << '\n';
       }
    }
@@ -171,15 +183,15 @@ namespace uno {
    }
 
    size_t MA27Solver::number_negative_eigenvalues() const {
-      return static_cast<size_t>(INFO(15));
+      return static_cast<size_t>(MA27_INFO(15));
    }
 
    bool MA27Solver::matrix_is_singular() const {
-      return (INFO(1) == eIFLAG::SINGULAR || INFO(1) == eIFLAG::RANK_DEFICIENT);
+      return (MA27_INFO(1) == eIFLAG::SINGULAR || MA27_INFO(1) == eIFLAG::RANK_DEFICIENT);
    }
 
    size_t MA27Solver::rank() const {
-      return (INFO(1) == eIFLAG::RANK_DEFICIENT) ?
+      return (MA27_INFO(1) == eIFLAG::RANK_DEFICIENT) ?
          static_cast<size_t>(this->workspace.info[1]) :
          static_cast<size_t>(this->workspace.n);
    }
@@ -195,7 +207,7 @@ namespace uno {
    // protected member functions
 
    void MA27Solver::check_factorization_status() const {
-      switch (INFO(1)) {
+      switch (MA27_INFO(1)) {
          case NSTEPS:
             WARNING << "MA27BD: Value of NSTEPS outside the range 1 ≤ NSTEPS ≤ N" << '\n';
             break;
@@ -226,17 +238,17 @@ namespace uno {
       }
    }
 
-   int& MA27Solver::ICNTL(size_t index) {
+   int& MA27Solver::MA27_ICNTL(size_t index) {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.icntl[index-1];
    }
 
-   double& MA27Solver::CNTL(size_t index) {
+   double& MA27Solver::MA27_CNTL(size_t index) {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.cntl[index-1];
    }
 
-   int MA27Solver::INFO(size_t index) const {
+   int MA27Solver::MA27_INFO(size_t index) const {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.info[index-1];
    }

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -15,7 +15,6 @@
 #define MA27_linear_solve uno::hsl_ma27cd
 #else
 #include "fortran_interface.h"
-
 #define MA27_set_default_parameters FC_GLOBAL(ma27id, MA27ID)
 #define MA27_symbolic_analysis FC_GLOBAL(ma27ad, MA27AD)
 #define MA27_numerical_factorization FC_GLOBAL(ma27bd, MA27BD)

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.cpp
@@ -9,6 +9,7 @@
 #ifdef HSL_RUNTIME_LOADING
 #include "ingredients/subproblem_solvers/HSL/HSLLoader.hpp"
 // route the calls through the runtime-resolved function pointers
+#define LIBHSL_version uno::hsl_libhsl_version
 #define MA27_set_default_parameters uno::hsl_ma27id
 #define MA27_symbolic_analysis uno::hsl_ma27ad
 #define MA27_numerical_factorization uno::hsl_ma27bd
@@ -21,6 +22,8 @@
 #define MA27_linear_solve FC_GLOBAL(ma27cd, MA27CD)
 
 extern "C" {
+   void LIBHSL_version(int *major, int *minor, int *patch);
+
    void MA27_set_default_parameters(int ICNTL[], double CNTL[]);
 
    void MA27_symbolic_analysis(int* N, int* NZ, int IRN[], int ICN[], int IW[], int* LIW, int IKEEP[], int IW1[],
@@ -32,13 +35,6 @@ extern "C" {
    void MA27_linear_solve(int* N, double A[], int* LA, int IW[], int* LIW, double W[], int* MAXFRT, double RHS[],
       int IW1[], int* NSTEPS, int ICNTL[], int INFO[]);
 }
-#endif
-#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
-// libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
-// Temporarily rename it with #define
-#define new hsl_new
-#include <libhsl.h>
-#undef new
 #endif
 
 namespace uno {
@@ -63,8 +59,10 @@ namespace uno {
             "runtime (set the UNO_HSL_LIBRARY environment variable to point at libhsl)");
       }
 #endif
-#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
-      INFO << "Running MA27 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
+#if defined(HAS_HSL)
+      int major, minor, patch;
+      LIBHSL_version(&major, &minor, &patch);
+      INFO << "Running MA27 v" << major << "." << minor << "." << patch << '\n';
 #else
       INFO << "Running MA27 v1.0.0\n";
 #endif

--- a/uno/ingredients/subproblem_solvers/MA27/MA27Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA27/MA27Solver.hpp
@@ -75,9 +75,9 @@ namespace uno {
 
       void check_factorization_status() const;
 
-      [[nodiscard]] int& ICNTL(size_t index);
-      [[nodiscard]] double& CNTL(size_t index);
-      [[nodiscard]] int INFO(size_t index) const;
+      [[nodiscard]] int& MA27_ICNTL(size_t index);
+      [[nodiscard]] double& MA27_CNTL(size_t index);
+      [[nodiscard]] int MA27_INFO(size_t index) const;
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include "MA57Solver.hpp"
 #include "tools/Logger.hpp"
+
 #ifdef HSL_RUNTIME_LOADING
 #include <stdexcept>
 #include "ingredients/subproblem_solvers/HSL/HSLLoader.hpp"
@@ -19,7 +20,6 @@
 #define MA57_enlarge_workspace uno::hsl_ma57ed
 #else
 #include "fortran_interface.h"
-
 #define MA57_set_default_parameters FC_GLOBAL(ma57id, MA57ID)
 #define MA57_symbolic_analysis FC_GLOBAL(ma57ad, MA57AD)
 #define MA57_numerical_factorization FC_GLOBAL(ma57bd, MA57BD)

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -26,7 +26,7 @@
 #define MA57_linear_solve FC_GLOBAL(ma57cd, MA57CD)
 #define MA57_enlarge_workspace FC_GLOBAL(ma57ed, MA57ED)
 #endif
-#ifdef HAS_HSL
+#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
 // libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
 // Temporarily rename it with #define
 #define new hsl_new
@@ -93,7 +93,7 @@ namespace uno {
             "runtime (set the UNO_HSL_LIBRARY environment variable to point at libhsl)");
       }
 #endif
-#ifdef HAS_HSL
+#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
       INFO << "Running MA57 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
 #else
       INFO << "Running MA57 v1.0.0\n";

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -26,6 +26,13 @@
 #define MA57_linear_solve FC_GLOBAL(ma57cd, MA57CD)
 #define MA57_enlarge_workspace FC_GLOBAL(ma57ed, MA57ED)
 #endif
+#ifdef HAS_HSL
+// libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
+// Temporarily rename it with #define
+#define new hsl_new
+#include <libhsl.h>
+#undef new
+#endif
 
 namespace uno {
 #ifndef HSL_RUNTIME_LOADING
@@ -86,16 +93,21 @@ namespace uno {
             "runtime (set the UNO_HSL_LIBRARY environment variable to point at libhsl)");
       }
 #endif
+#ifdef HAS_HSL
+      INFO << "Running MA57 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
+#else
+      INFO << "Running MA57 v1.0.0\n";
+#endif
       // set the default values of the controlling parameters
       MA57_set_default_parameters(this->workspace.cntl.data(), this->workspace.icntl.data());
-      ICNTL(5) = 0; // suppress warning messages
-      ICNTL(6) = 5; // pivot order (auto between METIS and MC47)
-      ICNTL(7) = 1; // numerical pivoting (uses threshold in CNTL(1))
-      ICNTL(11) = 16; // block size used by the Level 3 BLAS
-      ICNTL(12) = 16; // assembly tree
-      ICNTL(15) = MA57Settings::mc64_scaling; // MC64 scaling (disabled)
-      ICNTL(16) = 0; // small entries removed (disabled)
-      CNTL(1) = MA57Settings::pivoting_threshold; // pivoting threshold
+      MA57_ICNTL(5) = 0; // suppress warning messages
+      MA57_ICNTL(6) = 5; // pivot order (auto between METIS and MC47)
+      MA57_ICNTL(7) = 1; // numerical pivoting (uses threshold in CNTL(1))
+      MA57_ICNTL(11) = 16; // block size used by the Level 3 BLAS
+      MA57_ICNTL(12) = 16; // assembly tree
+      MA57_ICNTL(15) = MA57Settings::mc64_scaling; // MC64 scaling (disabled)
+      MA57_ICNTL(16) = 0; // small entries removed (disabled)
+      MA57_CNTL(1) = MA57Settings::pivoting_threshold; // pivoting threshold
    }
 
    void MA57Solver::initialize_memory() {
@@ -116,16 +128,16 @@ namespace uno {
          this->linear_system.matrix_column_indices.data(), &this->workspace.lkeep, this->workspace.keep.data(),
          this->workspace.iwork.data(), this->workspace.icntl.data(), this->workspace.info.data(), this->workspace.rinfo.data());
 
-      if (INFO(1) < 0) {
+      if (MA57_INFO(1) < 0) {
          throw std::runtime_error("MA57: the symbolic analysis failed");
       }
-      if (0 < INFO(1)) {
-         WARNING << "MA57 has issued a warning: info(1) = " << INFO(1) << '\n';
+      if (0 < MA57_INFO(1)) {
+         WARNING << "MA57 has issued a warning: info(1) = " << MA57_INFO(1) << '\n';
       }
 
       // get LFACT and LIFACT and resize FACT and IFACT (no effect if resized to <= size)
-      this->workspace.lfact = static_cast<int>(MA57Settings::allocation_safety_factor * INFO(11));
-      this->workspace.lifact = static_cast<int>(MA57Settings::allocation_safety_factor * INFO(12));
+      this->workspace.lfact = static_cast<int>(MA57Settings::allocation_safety_factor * MA57_INFO(11));
+      this->workspace.lifact = static_cast<int>(MA57Settings::allocation_safety_factor * MA57_INFO(12));
       this->workspace.fact.resize(static_cast<size_t>(this->workspace.lfact));
       this->workspace.ifact.resize(static_cast<size_t>(this->workspace.lifact));
       this->analysis_performed = true;
@@ -142,7 +154,7 @@ namespace uno {
             &this->workspace.lkeep, this->workspace.keep.data(), this->workspace.iwork.data(), this->workspace.icntl.data(),
             this->workspace.cntl.data(), this->workspace.info.data(), this->workspace.rinfo.data());
 
-         if (is_error_code_insufficient_real_workspace(INFO(1)) || is_error_code_insufficient_integer_workspace(INFO(1))) {
+         if (is_error_code_insufficient_real_workspace(MA57_INFO(1)) || is_error_code_insufficient_integer_workspace(MA57_INFO(1))) {
             const bool is_real_workspace = is_error_code_insufficient_real_workspace(this->workspace.info[0]);
 
             const int lnewfact = !is_real_workspace ? 0 : get_larger_real_workspace_size(this->workspace);
@@ -165,7 +177,7 @@ namespace uno {
                this->workspace.lifact = lnewifact;
             }
          }
-         else if (INFO(1) < 0) {
+         else if (MA57_INFO(1) < 0) {
             throw std::runtime_error("MA57 fatal error");
          }
          else {
@@ -213,7 +225,7 @@ namespace uno {
    }
 
    size_t MA57Solver::number_negative_eigenvalues() const {
-      return static_cast<size_t>(INFO(24));
+      return static_cast<size_t>(MA57_INFO(24));
    }
 
    /*
@@ -224,7 +236,7 @@ namespace uno {
    */
 
    bool MA57Solver::matrix_is_singular() const {
-      return (INFO(1) == 4);
+      return (MA57_INFO(1) == 4);
    }
 
    size_t MA57Solver::rank() const {
@@ -241,17 +253,17 @@ namespace uno {
 
    // protected member functions
 
-   int& MA57Solver::ICNTL(size_t index) {
+   int& MA57Solver::MA57_ICNTL(size_t index) {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.icntl[index-1];
    }
 
-   double& MA57Solver::CNTL(size_t index) {
+   double& MA57Solver::MA57_CNTL(size_t index) {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.cntl[index-1];
    }
 
-   int MA57Solver::INFO(size_t index) const {
+   int MA57Solver::MA57_INFO(size_t index) const {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.info[index-1];
    }

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -82,6 +82,22 @@ namespace uno {
       }
    }  // anonymous namespace
 
+   static void print_version() {
+#if defined(HAS_HSL)
+   #if defined(HSL_RUNTIME_LOADING)
+      if (LIBHSL_version != nullptr) {
+   #endif
+         int major, minor, patch;
+         LIBHSL_version(&major, &minor, &patch);
+         INFO << "Running MA57 v" << major << "." << minor << "." << patch << '\n';
+         return;
+   #if defined(HSL_RUNTIME_LOADING)
+      }
+   #endif
+#endif
+      INFO << "Running MA57\n";
+   }
+
    MA57Solver::MA57Solver(): DirectSymmetricIndefiniteLinearSolver() {
 #ifdef HSL_RUNTIME_LOADING
       if (!ma57_symbols_available()) {
@@ -89,13 +105,7 @@ namespace uno {
             "runtime (set the UNO_HSL_LIBRARY environment variable to point at libhsl)");
       }
 #endif
-#if defined(HAS_HSL)
-      int major, minor, patch;
-      LIBHSL_version(&major, &minor, &patch);
-      INFO << "Running MA57 v" << major << "." << minor << "." << patch << '\n';
-#else
-      INFO << "Running MA57 v1.0.0\n";
-#endif
+      print_version();
       // set the default values of the controlling parameters
       MA57_set_default_parameters(this->workspace.cntl.data(), this->workspace.icntl.data());
       MA57_ICNTL(5) = 0; // suppress warning messages

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include "ingredients/subproblem_solvers/HSL/HSLLoader.hpp"
 // route the calls through the runtime-resolved function pointers
+#define LIBHSL_version uno::hsl_libhsl_version
 #define MA57_set_default_parameters uno::hsl_ma57id
 #define MA57_symbolic_analysis uno::hsl_ma57ad
 #define MA57_numerical_factorization uno::hsl_ma57bd
@@ -26,17 +27,12 @@
 #define MA57_linear_solve FC_GLOBAL(ma57cd, MA57CD)
 #define MA57_enlarge_workspace FC_GLOBAL(ma57ed, MA57ED)
 #endif
-#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
-// libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
-// Temporarily rename it with #define
-#define new hsl_new
-#include <libhsl.h>
-#undef new
-#endif
 
 namespace uno {
 #ifndef HSL_RUNTIME_LOADING
    extern "C" {
+      void LIBHSL_version(int *major, int *minor, int *patch);
+
       void MA57_set_default_parameters(double cntl[], int icntl[]);
 
       void MA57_symbolic_analysis(const int* n, const int* ne, const int irn[], const int jcn[], const int* lkeep,
@@ -93,8 +89,10 @@ namespace uno {
             "runtime (set the UNO_HSL_LIBRARY environment variable to point at libhsl)");
       }
 #endif
-#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
-      INFO << "Running MA57 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
+#if defined(HAS_HSL)
+      int major, minor, patch;
+      LIBHSL_version(&major, &minor, &patch);
+      INFO << "Running MA57 v" << major << "." << minor << "." << patch << '\n';
 #else
       INFO << "Running MA57 v1.0.0\n";
 #endif

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
@@ -74,9 +74,9 @@ namespace uno {
       bool analysis_performed{false};
       bool factorization_performed{false};
 
-      [[nodiscard]] int& ICNTL(size_t index);
-      [[nodiscard]] double& CNTL(size_t index);
-      [[nodiscard]] int INFO(size_t index) const;
+      [[nodiscard]] int& MA57_ICNTL(size_t index);
+      [[nodiscard]] double& MA57_CNTL(size_t index);
+      [[nodiscard]] int MA57_INFO(size_t index) const;
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include "MA86Solver.hpp"
 #include "linear_algebra/View.hpp"
+#include "tools/Logger.hpp"
 
 #ifdef HSL_RUNTIME_LOADING
 // route the calls through the runtime-resolved function pointers
@@ -26,6 +27,13 @@
 #define MA86_finalise ma86_finalise_d
 #define MC68_default_control mc68_default_control_i
 #define MC68_order mc68_order_i
+#endif
+#ifdef HAS_HSL
+// libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
+// Temporarily rename it with #define
+#define new hsl_new
+#include <libhsl.h>
+#undef new
 #endif
 
 namespace uno {
@@ -61,6 +69,11 @@ namespace uno {
             "runtime, or it does not export the MA86/MC68 C interface (set the UNO_HSL_LIBRARY environment variable "
             "to point at a libhsl providing ma86_*_d and mc68_*_i)");
       }
+#endif
+#ifdef HAS_HSL
+      INFO << "Running MA86 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
+#else
+      INFO << "Running MA86 v1.0.0\n";
 #endif
       // set the default values of the controlling parameters
       MA86_default_control(&this->control);

--- a/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
@@ -54,6 +54,22 @@ namespace uno {
    // ma86_solve job: 0 solves the full system A x = b
    constexpr int MA86_SOLVE_FULL_SYSTEM = 0;
 
+   static void print_version() {
+#if defined(HAS_HSL)
+   #if defined(HSL_RUNTIME_LOADING)
+      if (LIBHSL_version != nullptr) {
+   #endif
+         int major, minor, patch;
+         LIBHSL_version(&major, &minor, &patch);
+         INFO << "Running MA86 v" << major << "." << minor << "." << patch << '\n';
+         return;
+   #if defined(HSL_RUNTIME_LOADING)
+      }
+   #endif
+#endif
+      INFO << "Running MA86\n";
+   }
+
    MA86Solver::MA86Solver(int solver_indexing):
          DirectSymmetricIndefiniteLinearSolver<double>(),
          solver_indexing(solver_indexing),
@@ -65,13 +81,7 @@ namespace uno {
             "to point at a libhsl providing ma86_*_d and mc68_*_i)");
       }
 #endif
-#if defined(HAS_HSL)
-      int major, minor, patch;
-      LIBHSL_version(&major, &minor, &patch);
-      INFO << "Running MA86 v" << major << "." << minor << "." << patch << '\n';
-#else
-      INFO << "Running MA86 v1.0.0\n";
-#endif
+      print_version();
       // set the default values of the controlling parameters
       MA86_default_control(&this->control);
       // build_csc_from_coo emits the CSC in the COO base (solver_indexing); MA86's C interface

--- a/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
@@ -28,7 +28,7 @@
 #define MC68_default_control mc68_default_control_i
 #define MC68_order mc68_order_i
 #endif
-#ifdef HAS_HSL
+#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
 // libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
 // Temporarily rename it with #define
 #define new hsl_new
@@ -70,7 +70,7 @@ namespace uno {
             "to point at a libhsl providing ma86_*_d and mc68_*_i)");
       }
 #endif
-#ifdef HAS_HSL
+#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
       INFO << "Running MA86 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
 #else
       INFO << "Running MA86 v1.0.0\n";

--- a/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA86/MA86Solver.cpp
@@ -12,6 +12,7 @@
 
 #ifdef HSL_RUNTIME_LOADING
 // route the calls through the runtime-resolved function pointers
+#define LIBHSL_version uno::hsl_libhsl_version
 #define MA86_default_control uno::hsl_ma86_default_control
 #define MA86_analyse uno::hsl_ma86_analyse
 #define MA86_factor uno::hsl_ma86_factor
@@ -28,17 +29,11 @@
 #define MC68_default_control mc68_default_control_i
 #define MC68_order mc68_order_i
 #endif
-#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
-// libhsl.h declares some functions with a parameter called "new", which is a reserved C++ keyword.
-// Temporarily rename it with #define
-#define new hsl_new
-#include <libhsl.h>
-#undef new
-#endif
 
 namespace uno {
 #ifndef HSL_RUNTIME_LOADING
    extern "C" {
+      void LIBHSL_version(int *major, int *minor, int *patch);
       void MA86_default_control(ma86_control* control);
       void MA86_analyse(const int n, const int ptr[], const int row[], int order[], void** keep,
          const ma86_control* control, ma86_info* info);
@@ -70,8 +65,10 @@ namespace uno {
             "to point at a libhsl providing ma86_*_d and mc68_*_i)");
       }
 #endif
-#if defined(HAS_HSL) && !defined(HSL_RUNTIME_LOADING)
-      INFO << "Running MA86 v" << LIBHSL_VER_MAJOR << "." << LIBHSL_VER_MINOR << "." << LIBHSL_VER_PATCH << '\n';
+#if defined(HAS_HSL)
+      int major, minor, patch;
+      LIBHSL_version(&major, &minor, &patch);
+      INFO << "Running MA86 v" << major << "." << minor << "." << patch << '\n';
 #else
       INFO << "Running MA86 v1.0.0\n";
 #endif

--- a/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.cpp
@@ -6,7 +6,6 @@
 #include "MUMPSSolver.hpp"
 #include "linear_algebra/Vector.hpp"
 #include "options/Options.hpp"
-#include "symbolic/Range.hpp"
 #include "tools/Logger.hpp"
 #if defined(HAS_MPI) && defined(MUMPS_PARALLEL)
 #include "mpi.h"
@@ -16,6 +15,7 @@
 
 namespace uno {
    MUMPSSolver::MUMPSSolver(): DirectSymmetricIndefiniteLinearSolver() {
+      INFO << "Running MUMPS v" << MUMPS_VERSION << '\n';
       this->workspace.sym = MUMPSSolver::GENERAL_SYMMETRIC;
 #if defined(HAS_MPI) && defined(MUMPS_PARALLEL)
       // TODO load number of processes from option file
@@ -27,19 +27,19 @@ namespace uno {
       this->workspace.comm_fortran = USE_COMM_WORLD;
       dmumps_c(&this->workspace);
       // control parameters
-      ICNTL(1) = -1; // output stream for error messages (off)
-      ICNTL(2) = -1; // output stream for diagnostic printing (off)
-      ICNTL(3) = -1; // output stream for global information (off)
-      ICNTL(4) = 0; // level of printing for error, warning, and diagnostic message (off)
+      MUMPS_ICNTL(1) = -1; // output stream for error messages (off)
+      MUMPS_ICNTL(2) = -1; // output stream for diagnostic printing (off)
+      MUMPS_ICNTL(3) = -1; // output stream for global information (off)
+      MUMPS_ICNTL(4) = 0; // level of printing for error, warning, and diagnostic message (off)
 
-      ICNTL(6) = MUMPSSettings::permuting_scaling; // column permutation (none)
-      ICNTL(7) = MUMPSSettings::pivot_order; // pivot order (AMD)
-      ICNTL(8) = MUMPSSettings::scaling; // scaling strategy (diagonal scaling during factorization)
-      ICNTL(10) = 0; // iterative refinement (none)
-      ICNTL(13) = 1; // parallelism of the root nod (ScaLAPACK not used, partly recover parallelism of the root node)
-      ICNTL(14) = MUMPSSettings::mem_percent; // percentage increase in the estimated working space (35)
-      ICNTL(24) = 1; // controls the detection of “null pivot rows” (null pivot row detection)
-      CNTL(1) = MUMPSSettings::pivtol; // relative threshold for numerical pivoting (1e-6)
+      MUMPS_ICNTL(6) = MUMPSSettings::permuting_scaling; // column permutation (none)
+      MUMPS_ICNTL(7) = MUMPSSettings::pivot_order; // pivot order (AMD)
+      MUMPS_ICNTL(8) = MUMPSSettings::scaling; // scaling strategy (diagonal scaling during factorization)
+      MUMPS_ICNTL(10) = 0; // iterative refinement (none)
+      MUMPS_ICNTL(13) = 1; // parallelism of the root nod (ScaLAPACK not used, partly recover parallelism of the root node)
+      MUMPS_ICNTL(14) = MUMPSSettings::mem_percent; // percentage increase in the estimated working space (35)
+      MUMPS_ICNTL(24) = 1; // controls the detection of “null pivot rows” (null pivot row detection)
+      MUMPS_CNTL(1) = MUMPSSettings::pivtol; // relative threshold for numerical pivoting (1e-6)
       // debug for MUMPS team ICNTL(2) = 6; ICNTL(3) = 6; ICNTL(4) = 6;
    }
 
@@ -61,10 +61,10 @@ namespace uno {
       this->workspace.irn = this->linear_system.matrix_row_indices.data();
       this->workspace.jcn = this->linear_system.matrix_column_indices.data();
       dmumps_c(&this->workspace);
-      if (INFO(1) < 0) {
+      if (MUMPS_INFO(1) < 0) {
          throw std::runtime_error("The MUMPS analysis failed");
       }
-      ICNTL(8) = 8; // recompute scaling before factorization
+      MUMPS_ICNTL(8) = 8; // recompute scaling before factorization
       this->analysis_performed = true;
    }
 
@@ -76,21 +76,21 @@ namespace uno {
       bool success = false;
       while (!success) {
          dmumps_c(&this->workspace);
-         if (INFO(1) == -8 || INFO(1) == -9) { // workspace too small
+         if (MUMPS_INFO(1) == -8 || MUMPS_INFO(1) == -9) { // workspace too small
             if (this->number_factorization_failures >= this->max_number_factorization_failures) {
                this->number_factorization_failures = 0;
                throw std::runtime_error("The MUMPS factorization failed (workspace too small)");
             }
             // increase the workspace size and retry
-            ICNTL(14) = ICNTL(14) * MUMPSSettings::mem_percent_increase;
+            MUMPS_ICNTL(14) = MUMPS_ICNTL(14) * MUMPSSettings::mem_percent_increase;
             ++this->number_factorization_failures;
          }
-         else if (INFO(1) == -10) {
+         else if (MUMPS_INFO(1) == -10) {
             // singular matrix, should be caught by the calling code via the inertia
             DEBUG << "MUMPS detected a numerically singular matrix\n";
             success = true;
          }
-         else if (INFO(1) < 0) {
+         else if (MUMPS_INFO(1) < 0) {
             throw std::runtime_error("The MUMPS factorization failed");
          }
          else {
@@ -116,7 +116,7 @@ namespace uno {
       this->workspace.rhs = solution;
       this->workspace.job = MUMPSSolver::JOB_SOLVE;
       dmumps_c(&this->workspace);
-      if (INFO(1) < 0) {
+      if (MUMPS_INFO(1) < 0) {
          throw std::runtime_error("The MUMPS solve failed");
       }
    }
@@ -131,11 +131,11 @@ namespace uno {
    }
 
    size_t MUMPSSolver::number_negative_eigenvalues() const {
-      return static_cast<size_t>(INFOG(12));
+      return static_cast<size_t>(MUMPS_INFOG(12));
    }
 
    size_t MUMPSSolver::number_zero_eigenvalues() const {
-      return static_cast<size_t>(INFOG(28));
+      return static_cast<size_t>(MUMPS_INFOG(28));
    }
 
    bool MUMPSSolver::matrix_is_singular() const {
@@ -156,22 +156,22 @@ namespace uno {
 
    // protected member functions
 
-   int& MUMPSSolver::ICNTL(size_t index) {
+   int& MUMPSSolver::MUMPS_ICNTL(size_t index) {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.icntl[index-1];
    }
 
-   double& MUMPSSolver::CNTL(size_t index) {
+   double& MUMPSSolver::MUMPS_CNTL(size_t index) {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.cntl[index-1];
    }
 
-   int MUMPSSolver::INFO(size_t index) const {
+   int MUMPSSolver::MUMPS_INFO(size_t index) const {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.info[index-1];
    }
 
-   int MUMPSSolver::INFOG(size_t index) const {
+   int MUMPSSolver::MUMPS_INFOG(size_t index) const {
       // handle the Fortran indexing (starting at 1)
       return this->workspace.infog[index-1];
    }

--- a/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/MUMPS/MUMPSSolver.hpp
@@ -61,10 +61,10 @@ namespace uno {
       size_t number_factorization_failures{0};
       const size_t max_number_factorization_failures{MUMPSSettings::max_number_factorization_failures};
 
-      [[nodiscard]] int& ICNTL(size_t index);
-      [[nodiscard]] double& CNTL(size_t index);
-      [[nodiscard]] int INFO(size_t index) const;
-      [[nodiscard]] int INFOG(size_t index) const;
+      [[nodiscard]] int& MUMPS_ICNTL(size_t index);
+      [[nodiscard]] double& MUMPS_CNTL(size_t index);
+      [[nodiscard]] int MUMPS_INFO(size_t index) const;
+      [[nodiscard]] int MUMPS_INFOG(size_t index) const;
    };
 } // namespace
 

--- a/uno/ingredients/subproblem_solvers/SSIDS/SSIDSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/SSIDS/SSIDSSolver.cpp
@@ -3,12 +3,11 @@
 
 #include <cassert>
 #include "SSIDSSolver.hpp"
-#include "symbolic/Range.hpp"
 #include "tools/Logger.hpp"
 
 namespace uno {
    SSIDSSolver::SSIDSSolver(): DirectSymmetricIndefiniteLinearSolver<double>() {
-      INFO << "Running SPRAL's SSIDS\n";
+      INFO << "Running SPRAL's SSIDS v" << SPRAL_VERSION << '\n';
       spral_ssids_default_options(&this->workspace.options);
       this->workspace.options.array_base = 1; // Fortran indexing
       this->workspace.options.print_level = -1; // no printing

--- a/uno/ingredients/subproblem_solvers/SSIDS/SSIDSSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/SSIDS/SSIDSSolver.cpp
@@ -4,9 +4,11 @@
 #include <cassert>
 #include "SSIDSSolver.hpp"
 #include "symbolic/Range.hpp"
+#include "tools/Logger.hpp"
 
 namespace uno {
    SSIDSSolver::SSIDSSolver(): DirectSymmetricIndefiniteLinearSolver<double>() {
+      INFO << "Running SPRAL's SSIDS\n";
       spral_ssids_default_options(&this->workspace.options);
       this->workspace.options.array_base = 1; // Fortran indexing
       this->workspace.options.print_level = -1; // no printing

--- a/uno/ingredients/subproblem_solvers/SSIDS/SSIDSSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SSIDS/SSIDSSolver.hpp
@@ -4,6 +4,7 @@
 #ifndef UNO_SSIDSSOLVER_H
 #define UNO_SSIDSSOLVER_H
 
+#include <spral.h>
 #include <spral_ssids.h>
 #include "../DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "../COOLinearSystem.hpp"

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -80,7 +80,7 @@ namespace uno {
       }
 
       // solve the linear system
-      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << '\n';
+      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << "\n\n";
       this->linear_solver->solve_indefinite_system(linear_system.solution.data());
 
       // set the constraint multipliers if their norm is reasonable
@@ -138,7 +138,7 @@ namespace uno {
 
       // solve the linear system with only the diagonal part and store the result in solution_diagonal_part
       Vector<double> solution_diagonal_part(subproblem.number_variables + subproblem.number_constraints);
-      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << '\n';
+      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << "\n\n";
       this->linear_solver->solve_indefinite_system(solution_diagonal_part.data());
       if (this->linear_solver->matrix_is_singular()) {
          this->direction.status = SubproblemStatus::INFEASIBLE;


### PR DESCRIPTION
Print the versions of the subproblem solvers.
For HSL solvers:
- if standalone MA57, MA27, MA86 are linked, print no version
- if libHSL is linked, call `libhsl`'s `LIBHSL_version`
- if libHSL is dynamically loaded, check if `LIBHSL_version` is set

@amontoison nothing for SSIDS apparently?