### PR TITLE
Tentative upgrade to ASL_jll v0.1.5

### DIFF
--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -229,7 +229,7 @@ dependencies = [
     BuildDependency(PackageSpec(name="BQPD_jll", uuid="1325ac01-0a49-589f-8355-43321054aaab")),
     Dependency(PackageSpec(name="HSL_jll", uuid="017b0a0e-03f4-516a-9b91-836bbd1904dd")),
     Dependency(PackageSpec(name="METIS_jll", uuid="d00139f3-1899-568f-a2f0-47f597d42d70")),
-    Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), compat="0.1.3"),
+    Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), compat="0.1.5"),
     Dependency(PackageSpec(name="OpenBLAS32_jll", uuid="656ef2d0-ae68-5445-9ca0-591084a874a2")),
     # For OpenMP we use libomp from `LLVMOpenMP_jll` where we use LLVM as compiler (BSD systems),
     # and libgomp from `CompilerSupportLibraries_jll` everywhere else.

--- a/.github/julia/build_tarballs_yggdrasil.jl
+++ b/.github/julia/build_tarballs_yggdrasil.jl
@@ -100,7 +100,7 @@ dependencies = [
     Dependency(PackageSpec(name="HiGHS_jll", uuid="8fd58aa0-07eb-5a78-9b36-339c94fd15ea"), compat="=1.15.1"),
     Dependency(PackageSpec(name="HSL_jll", uuid="017b0a0e-03f4-516a-9b91-836bbd1904dd")),
     Dependency(PackageSpec(name="METIS_jll", uuid="d00139f3-1899-568f-a2f0-47f597d42d70")),
-    Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), compat="0.1.3"),
+    Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), compat="0.1.5"),
     Dependency(PackageSpec(name="MUMPS_seq_jll", uuid="d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"), compat="~500.900.100"),
     Dependency(PackageSpec(name="SPRAL_jll", uuid="319450e9-13b8-58e8-aa9f-8fd1420848ab")),
     Dependency(PackageSpec(name="libblastrampoline_jll", uuid="8e850b90-86db-534c-a0d3-1478176c7d93"), compat="5.4.0"),

--- a/.github/workflows/build-cross-compiler.yml
+++ b/.github/workflows/build-cross-compiler.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Compile Uno_jll.jl for ${{ matrix.platform }}
         run: |
-          julia --color=yes -e 'using Pkg; Pkg.add("BinaryBuilder")'
+          julia --color=yes -e 'using Pkg; Pkg.update(); Pkg.add("BinaryBuilder")'
           # julia --color=yes .github/julia/build_tarballs_utils.jl ${{ matrix.platform }} --verbose --deploy=local
           julia --color=yes .github/julia/build_tarballs_yggdrasil.jl ${{ matrix.platform }} --verbose --deploy=local
           julia --color=yes .github/julia/build_tarballs_release.jl ${{ matrix.platform }} --verbose --deploy=local

--- a/.github/workflows/julia-tests-ubuntu.yml
+++ b/.github/workflows/julia-tests-ubuntu.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Compile Uno_jll.jl
         run: |
-          julia --color=yes -e 'using Pkg; Pkg.add("BinaryBuilder")'
+          julia --color=yes -e 'using Pkg; Pkg.update(); Pkg.add("BinaryBuilder")'
           julia --color=yes .github/julia/build_tarballs_yggdrasil.jl x86_64-linux-gnu-cxx11 --verbose --deploy="local"
 
       # The local deploy writes the JLL wrapper to ~/.julia/dev/Uno_jll and

--- a/.github/workflows/julia-tests-unosolver.yml
+++ b/.github/workflows/julia-tests-unosolver.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Compile Uno_jll.jl
         run: |
-          julia --color=yes -e 'using Pkg; Pkg.add("BinaryBuilder")'
+          julia --color=yes -e 'using Pkg; Pkg.update(); Pkg.add("BinaryBuilder")'
           julia --color=yes .github/julia/build_tarballs_yggdrasil.jl x86_64-linux-gnu-cxx11 --verbose --deploy="local"
 
       # Now install a newer version of Julia to actually test Uno_jll.jl.

--- a/interfaces/AMPL/AMPLModel.cpp
+++ b/interfaces/AMPL/AMPLModel.cpp
@@ -128,7 +128,7 @@ namespace uno {
 
    double AMPLModel::evaluate_objective(const Vector<double>& x) const {
       fint error_flag = 0;
-      const double result = this->optimization_sense * this->asl->p.Objval(this->asl, 0, const_cast<double*>(x.data()), &error_flag);
+      const double result = this->optimization_sense * this->asl->p.Objval(this->asl, 0, x.data(), &error_flag);
       if (0 < error_flag) {
          throw FunctionEvaluationError();
       }
@@ -138,7 +138,7 @@ namespace uno {
 
    void AMPLModel::evaluate_constraints(const Vector<double>& x, Vector<double>& constraints) const {
       fint error_flag = 0;
-      this->asl->p.Conval(this->asl, const_cast<double*>(x.data()), constraints.data(), &error_flag);
+      this->asl->p.Conval(this->asl, x.data(), constraints.data(), &error_flag);
       if (0 < error_flag) {
          throw FunctionEvaluationError();
       }
@@ -148,7 +148,7 @@ namespace uno {
    // dense gradient
    void AMPLModel::evaluate_objective_gradient(const Vector<double>& x, Vector<double>& gradient) const {
       fint error_flag = 0;
-      this->asl->p.Objgrd(this->asl, 0, const_cast<double*>(x.data()), gradient.data(), &error_flag);
+      this->asl->p.Objgrd(this->asl, 0, x.data(), gradient.data(), &error_flag);
       if (0 < error_flag) {
          throw GradientEvaluationError();
       }
@@ -182,7 +182,7 @@ namespace uno {
 
    void AMPLModel::evaluate_jacobian(const Vector<double>& x, double* jacobian_values) const {
       fint error_flag = 0;
-      this->asl->p.Jacval(this->asl, const_cast<double*>(x.data()), jacobian_values, &error_flag);
+      this->asl->p.Jacval(this->asl, x.data(), jacobian_values, &error_flag);
       if (0 < error_flag) {
          throw GradientEvaluationError();
       }
@@ -190,24 +190,20 @@ namespace uno {
    }
 
    // register the vector of variables
-   //this->asl->p.Xknown(this->asl, const_cast<double*>(x.data()), nullptr);
+   //this->asl->p.Xknown(this->asl, x.data(), nullptr);
    // unregister the vector of variables
    //this->asl->i.x_known = 0;
 
    void AMPLModel::evaluate_lagrangian_hessian(const Vector<double>& /*x*/, double objective_multiplier, const Vector<double>& multipliers,
          View<double> hessian_values) const {
-      Jmp_buf b, *save = this->asl->i.err_jmp_;
-      this->asl->i.err_jmp_ = &b;
-      const bool failed = (setjmp(b.jb) != 0);
-      if (!failed) {
-         objective_multiplier *= this->optimization_sense;
-         this->asl->p.Sphes(this->asl, nullptr, hessian_values.data(), -1, &objective_multiplier, const_cast<double*>(multipliers.data()));
-         ++this->number_model_evaluations.hessian;
-      }
-      this->asl->i.err_jmp_ = save;      // restore, always
-      if (failed) {
+      objective_multiplier *= this->optimization_sense;
+      fint error_flag = 0;
+      this->asl->p.Sphese(this->asl, nullptr, hessian_values.data(), -1, &objective_multiplier, multipliers.data(),
+         &error_flag);
+      if (0 < error_flag) {
          throw HessianEvaluationError();
       }
+      ++this->number_model_evaluations.hessian;
    }
 
    void AMPLModel::compute_jacobian_vector_product(const double* /*x*/, const double* /*vector*/, double* /*result*/) const {
@@ -224,8 +220,7 @@ namespace uno {
       objective_multiplier *= this->optimization_sense;
 
       // compute the Hessian-vector product
-      (this->asl->p.Hvcomp)(this->asl, result.data(), const_cast<double*>(vector.data()), -1, &objective_multiplier,
-         const_cast<double*>(multipliers.data()));
+      (this->asl->p.Hvcomp)(this->asl, result.data(), vector.data(), -1, &objective_multiplier, multipliers.data());
    }
 
    const std::vector<double>& AMPLModel::get_variables_lower_bounds() const {

--- a/interfaces/AMPL/AMPLModel.cpp
+++ b/interfaces/AMPL/AMPLModel.cpp
@@ -220,7 +220,11 @@ namespace uno {
       objective_multiplier *= this->optimization_sense;
 
       // compute the Hessian-vector product
-      (this->asl->p.Hvcomp)(this->asl, result.data(), vector.data(), -1, &objective_multiplier, multipliers.data());
+      fint error_flag = 0;
+      (this->asl->p.Hvcompe)(this->asl, result.data(), vector.data(), -1, &objective_multiplier, multipliers.data(), &error_flag);
+      if (0 < error_flag) {
+         throw HessianEvaluationError();
+      }
    }
 
    const std::vector<double>& AMPLModel::get_variables_lower_bounds() const {


### PR DESCRIPTION
Tentative upgrade to latest ASL. I'm suspecting that ASL_jll.jl is not up to date, let's give it a try.

What I'm after:
- Sphese and Hvcompe: Hessian evaluation and Hessian-vector product with an extra nerror parameter
- (minor) const correctness of the ASL signatures

AFAICT there were no breaking changes in the API, only additional functions.