### PR TITLE
Test termination wrt feasibility problem before switching to feasibility restoration

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -38,7 +38,7 @@ namespace uno {
       virtual const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) = 0;
       [[nodiscard]] virtual bool solving_feasibility_problem() const = 0;
-      [[nodiscard]] virtual bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const = 0;
+      [[nodiscard]] virtual bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) = 0;
       virtual void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
          WarmstartInformation& warmstart_information) = 0;
 

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -38,6 +38,7 @@ namespace uno {
       virtual const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) = 0;
       [[nodiscard]] virtual bool solving_feasibility_problem() const = 0;
+      [[nodiscard]] virtual bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const = 0;
       virtual void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
          WarmstartInformation& warmstart_information) = 0;
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -91,42 +91,38 @@ namespace uno {
       return (this->current_phase == Phase::FEASIBILITY_RESTORATION);
    }
 
-   // precondition: this->current_phase == Phase::OPTIMALITY
-   void FeasibilityRestoration::switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate,
-         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
+   bool FeasibilityRestoration::test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const {
       DEBUG << "\nTesting the termination criteria of the feasibility problem at the current iterate\n";
-      // initialize the feasibility multipliers and swap the iterate's multipliers and the feasibility multipliers
-      if (this->first_switch_to_feasibility) {
-         this->other_phase_multipliers.resize(this->feasibility_problem.number_variables,
-            this->feasibility_problem.number_constraints);
-         this->first_switch_to_feasibility = false;
-      }
-      std::swap(current_iterate.multipliers, this->other_phase_multipliers);
-      // save the current point (infeasibility and primals) upon switching
-      this->reference_infeasibility = current_iterate.primal_infeasibility;
-      this->reference_optimality_primals = current_iterate.primals;
-      current_iterate.set_number_variables(this->feasibility_problem.number_variables);
-
       // compute the feasibility multipliers and the residuals, and test termination wrt the feasibility problem
-      this->feasibility_problem.compute_multipliers(current_iterate, current_evaluations);
+      Multipliers tentative_multipliers(current_iterate.multipliers);
+      this->feasibility_problem.compute_multipliers(tentative_multipliers, current_evaluations);
       DEBUG << current_iterate << '\n';
       // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
-      this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, current_iterate.multipliers,
+      this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, tentative_multipliers,
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
       // TODO check that all duals are not 0
       DEBUG << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
       if (norm_inf(view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
-      }
-
-      if (current_iterate.status == SolutionStatus::INFEASIBLE_STATIONARY_POINT) {
+         std::swap(tentative_multipliers, current_iterate.multipliers);
          DEBUG << "The current iterate is an infeasible stationary point\n";
-         return;
+         return true;
       }
+      return false;
+   }
 
-      DEBUG << "Switching from optimality to restoration phase\n";
+   // precondition: this->current_phase == Phase::OPTIMALITY
+   void FeasibilityRestoration::switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate,
+         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
+      DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
+      std::swap(current_iterate.multipliers, this->other_phase_multipliers);
+      // save the current point (progress and primals) upon switching
+      this->reference_infeasibility = current_iterate.primal_infeasibility;
+      this->reference_optimality_primals = current_iterate.primals;
+      current_iterate.set_number_variables(this->feasibility_problem.number_variables);
+
       this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
 
@@ -134,6 +130,7 @@ namespace uno {
       const double proximal_coefficient = this->feasibility_inequality_handling_method->proximal_coefficient();
       this->feasibility_problem.set_proximal_coefficient(proximal_coefficient);
       DEBUG << "Proximal coefficient set to " << proximal_coefficient << '\n';
+      this->feasibility_problem.compute_elastics(current_iterate, current_evaluations);
       this->feasibility_inequality_handling_method->set_elastic_variable_values(this->feasibility_problem, current_iterate,
          current_evaluations);
       // re-evaluate the progress measures at the current iterate

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -108,15 +108,18 @@ namespace uno {
       DEBUG2 << "Feasibility LB multipliers: " << this->other_phase_multipliers.lower_bounds << '\n';
       DEBUG2 << "Feasibility UB multipliers: " << this->other_phase_multipliers.upper_bounds << '\n';
 
-      // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
+      // compute residuals
       this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, this->other_phase_multipliers,
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
-      // TODO check that all duals are not 0
-      DEBUG2 << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
-      const double complementarity = this->original_problem.complementarity_error(current_iterate.primals,
+      const double stationarity_error = norm(this->residual_norm, view(current_iterate.residuals.lagrangian_gradient, 0,
+         this->original_problem.model.number_variables));
+      const double complementarity_error = this->original_problem.complementarity_error(current_iterate.primals,
          current_evaluations.constraints, this->other_phase_multipliers, 0., this->residual_norm);
-      DEBUG2 << "Complementarity: " << complementarity << '\n';
-      if (complementarity <= 1e-8) {
+      // TODO check that all duals are not 0
+
+      DEBUG2 << "Stationarity error: " << stationarity_error << '\n';
+      DEBUG2 << "Complementarity error: " << complementarity_error << '\n';
+      if (stationarity_error <= 1e-8 && complementarity_error <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
          std::swap(this->other_phase_multipliers, current_iterate.multipliers);
          DEBUG << current_iterate << '\n';

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -114,6 +114,7 @@ namespace uno {
       this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, current_iterate.multipliers,
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
       // TODO check that all duals are not 0
+      DEBUG << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
       if (norm_inf(view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -103,6 +103,7 @@ namespace uno {
          this->first_use_feasibility_multipliers = false;
       }
 
+      /*
       this->feasibility_problem.compute_multipliers(this->other_phase_multipliers, current_evaluations);
       DEBUG2 << "Feasibility constraint multipliers: " << this->other_phase_multipliers.constraints << '\n';
       DEBUG2 << "Feasibility LB multipliers: " << this->other_phase_multipliers.lower_bounds << '\n';
@@ -129,6 +130,7 @@ namespace uno {
       else {
          DEBUG << "The current iterate does not satisfy the infeasible stationary termination criteria\n";
       }
+      */
       return false;
    }
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -93,26 +93,24 @@ namespace uno {
    bool FeasibilityRestoration::test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const {
       DEBUG << "\nTesting the termination criteria of the feasibility problem at the current iterate\n";
       // compute the feasibility multipliers and the residuals, and test termination wrt the feasibility problem
-      std::cout << "x = " << current_iterate.primals << '\n';
-      std::cout << "c(x) = " << current_evaluations.constraints << '\n';
+      DEBUG2 << "x = " << current_iterate.primals << '\n';
+      DEBUG2 << "c(x) = " << current_evaluations.constraints << '\n';
       Multipliers tentative_multipliers(current_iterate.multipliers);
       this->feasibility_problem.compute_multipliers(tentative_multipliers, current_evaluations);
-      std::cout << "Feasibility constraint multipliers: " << tentative_multipliers.constraints << '\n';
-      std::cout << "Feasibility LB multipliers: " << tentative_multipliers.lower_bounds << '\n';
-      std::cout << "Feasibility UB multipliers: " << tentative_multipliers.upper_bounds << '\n';
+      DEBUG2 << "Feasibility constraint multipliers: " << tentative_multipliers.constraints << '\n';
+      DEBUG2 << "Feasibility LB multipliers: " << tentative_multipliers.lower_bounds << '\n';
+      DEBUG2 << "Feasibility UB multipliers: " << tentative_multipliers.upper_bounds << '\n';
 
       // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
       this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, tentative_multipliers,
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
       // TODO check that all duals are not 0
-      std::cout << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
-      if (norm_inf(view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
+      DEBUG2 << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
+      if (false && norm_inf(view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
          std::swap(tentative_multipliers, current_iterate.multipliers);
          compute_residuals(this->feasibility_problem, current_iterate, current_evaluations);
-         std::cout << current_iterate << '\n';
          DEBUG << current_iterate << '\n';
-         std::cout << "The current iterate is an infeasible stationary point\n";
          DEBUG << "The current iterate is an infeasible stationary point\n";
          return true;
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -93,17 +93,26 @@ namespace uno {
    bool FeasibilityRestoration::test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const {
       DEBUG << "\nTesting the termination criteria of the feasibility problem at the current iterate\n";
       // compute the feasibility multipliers and the residuals, and test termination wrt the feasibility problem
+      std::cout << "x = " << current_iterate.primals << '\n';
+      std::cout << "c(x) = " << current_evaluations.constraints << '\n';
       Multipliers tentative_multipliers(current_iterate.multipliers);
       this->feasibility_problem.compute_multipliers(tentative_multipliers, current_evaluations);
+      std::cout << "Feasibility constraint multipliers: " << tentative_multipliers.constraints << '\n';
+      std::cout << "Feasibility LB multipliers: " << tentative_multipliers.lower_bounds << '\n';
+      std::cout << "Feasibility UB multipliers: " << tentative_multipliers.upper_bounds << '\n';
+
       // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
       this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, tentative_multipliers,
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
       // TODO check that all duals are not 0
-      DEBUG << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
+      std::cout << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
       if (norm_inf(view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
          std::swap(tentative_multipliers, current_iterate.multipliers);
+         compute_residuals(this->feasibility_problem, current_iterate, current_evaluations);
+         std::cout << current_iterate << '\n';
          DEBUG << current_iterate << '\n';
+         std::cout << "The current iterate is an infeasible stationary point\n";
          DEBUG << "The current iterate is an infeasible stationary point\n";
          return true;
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -106,10 +106,12 @@ namespace uno {
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
       // TODO check that all duals are not 0
       DEBUG2 << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
-      if (false && norm_inf(view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
+      const double complementarity = this->original_problem.complementarity_error(current_iterate.primals,
+         current_evaluations.constraints, current_iterate.multipliers, 0., this->residual_norm);
+      DEBUG2 << "Complementarity: " << complementarity << '\n';
+      if (complementarity <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
          std::swap(tentative_multipliers, current_iterate.multipliers);
-         compute_residuals(this->feasibility_problem, current_iterate, current_evaluations);
          DEBUG << current_iterate << '\n';
          DEBUG << "The current iterate is an infeasible stationary point\n";
          return true;

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -109,7 +109,7 @@ namespace uno {
       const double complementarity = this->original_problem.complementarity_error(current_iterate.primals,
          current_evaluations.constraints, current_iterate.multipliers, 0., this->residual_norm);
       DEBUG2 << "Complementarity: " << complementarity << '\n';
-      if (complementarity <= 1e-8) {
+      if (false && complementarity <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
          std::swap(tentative_multipliers, current_iterate.multipliers);
          DEBUG << current_iterate << '\n';

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -96,6 +96,11 @@ namespace uno {
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
       DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
+      //current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
+      //DEBUG << "The current iterate is stationary for the feasibility problem\n";
+      //statistics.set("Status", "stationary");
+      //return;
+
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
 
       // save the current point (infeasibility and primals) upon switching
@@ -113,6 +118,10 @@ namespace uno {
          this->first_switch_to_feasibility = false;
       }
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
+
+      // approximate the multipliers based on infeasibility
+      this->feasibility_problem.approximate_multipliers(current_iterate, current_evaluations);
+      // test for termination wrt the feasibility problem
 
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
       const double proximal_coefficient = this->feasibility_inequality_handling_method->proximal_coefficient();

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -94,34 +94,31 @@ namespace uno {
    // precondition: this->current_phase == Phase::OPTIMALITY
    void FeasibilityRestoration::switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
-      DEBUG << "\nSwitching from optimality to restoration phase\n";
-      this->current_phase = Phase::FEASIBILITY_RESTORATION;
-      //current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
-      //DEBUG << "The current iterate is stationary for the feasibility problem\n";
-      //statistics.set("Status", "stationary");
-      //return;
-
-      this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
-
-      // save the current point (infeasibility and primals) upon switching
-      this->reference_infeasibility = current_iterate.primal_infeasibility;
-      this->reference_optimality_primals = current_iterate.primals;
-      this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
-
-      current_iterate.set_number_variables(this->feasibility_problem.number_variables);
-      this->initial_point.resize(this->feasibility_problem.number_variables);
-      // swap the iterate's multipliers and the feasibility multipliers maintained by the class
+      DEBUG << "Testing the termination criteria of the feasibility problem\n";
+      // initialize the feasibility multipliers and swap the iterate's multipliers and the feasibility multipliers
       if (this->first_switch_to_feasibility) {
-         this->other_phase_multipliers.constraints.resize(this->feasibility_problem.number_constraints);
-         this->other_phase_multipliers.lower_bounds.resize(this->feasibility_problem.number_variables);
-         this->other_phase_multipliers.upper_bounds.resize(this->feasibility_problem.number_variables);
+         this->other_phase_multipliers.resize(this->feasibility_problem.number_variables,
+            this->feasibility_problem.number_constraints);
          this->first_switch_to_feasibility = false;
       }
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
+      // save the current point (infeasibility and primals) upon switching
+      this->reference_infeasibility = current_iterate.primal_infeasibility;
+      this->reference_optimality_primals = current_iterate.primals;
+      current_iterate.set_number_variables(this->feasibility_problem.number_variables);
 
-      // approximate the multipliers based on infeasibility
-      this->feasibility_problem.approximate_multipliers(current_iterate, current_evaluations);
-      // test for termination wrt the feasibility problem
+      // compute the feasibility multipliers and test termination wrt the feasibility problem
+      //this->feasibility_problem.approximate_multipliers(current_iterate, current_evaluations);
+      if (current_iterate.status == SolutionStatus::INFEASIBLE_STATIONARY_POINT) {
+         DEBUG << "The current iterate is an infeasible stationary point\n";
+         return;
+      }
+
+      DEBUG << "\nSwitching from optimality to restoration phase\n";
+      this->current_phase = Phase::FEASIBILITY_RESTORATION;
+      this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
+      this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
+      this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
 
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
       const double proximal_coefficient = this->feasibility_inequality_handling_method->proximal_coefficient();
@@ -131,6 +128,7 @@ namespace uno {
          current_evaluations);
       // re-evaluate the progress measures at the current iterate
       this->feasibility_inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
+      this->initial_point.resize(this->feasibility_problem.number_variables);
 
       DEBUG2 << "\nCurrent iterate to start feasibility restoration:\n" << current_iterate << '\n';
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -68,7 +68,6 @@ namespace uno {
 
    const Direction& FeasibilityRestoration::compute_direction(Statistics& statistics, Iterate& current_iterate,
          double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
-
       // solve the current problem (OPTIMALITY or FEASIBILITY_RESTORATION)
       if (this->current_phase == Phase::OPTIMALITY) {
          DEBUG << "Solving the optimality subproblem\n";

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -94,7 +94,7 @@ namespace uno {
    // precondition: this->current_phase == Phase::OPTIMALITY
    void FeasibilityRestoration::switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
-      DEBUG << "\nTesting the termination criteria of the feasibility problem\n";
+      DEBUG << "\nTesting the termination criteria of the feasibility problem at the current iterate\n";
       // initialize the feasibility multipliers and swap the iterate's multipliers and the feasibility multipliers
       if (this->first_switch_to_feasibility) {
          this->other_phase_multipliers.resize(this->feasibility_problem.number_variables,
@@ -109,11 +109,12 @@ namespace uno {
 
       // compute the feasibility multipliers and the residuals, and test termination wrt the feasibility problem
       this->feasibility_problem.compute_multipliers(current_iterate, current_evaluations);
+      DEBUG << current_iterate << '\n';
       // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
-      Vector<double> lagrangian_gradient(this->original_problem.model.number_variables);
       this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, current_iterate.multipliers,
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
-      if (norm_inf(view(lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
+      // TODO check that all duals are not 0
+      if (norm_inf(view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
       }
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -110,6 +110,13 @@ namespace uno {
       // compute the feasibility multipliers and the residuals, and test termination wrt the feasibility problem
       this->feasibility_problem.compute_multipliers(current_iterate, current_evaluations);
       // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
+      Vector<double> lagrangian_gradient(this->original_problem.model.number_variables);
+      this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, current_iterate.multipliers,
+         0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
+      if (norm_inf(view(lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
+         current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
+      }
+
       if (current_iterate.status == SolutionStatus::INFEASIBLE_STATIONARY_POINT) {
          DEBUG << "The current iterate is an infeasible stationary point\n";
          return;

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -94,7 +94,7 @@ namespace uno {
    // precondition: this->current_phase == Phase::OPTIMALITY
    void FeasibilityRestoration::switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
-      DEBUG << "Testing the termination criteria of the feasibility problem\n";
+      DEBUG << "\nTesting the termination criteria of the feasibility problem\n";
       // initialize the feasibility multipliers and swap the iterate's multipliers and the feasibility multipliers
       if (this->first_switch_to_feasibility) {
          this->other_phase_multipliers.resize(this->feasibility_problem.number_variables,
@@ -107,14 +107,15 @@ namespace uno {
       this->reference_optimality_primals = current_iterate.primals;
       current_iterate.set_number_variables(this->feasibility_problem.number_variables);
 
-      // compute the feasibility multipliers and test termination wrt the feasibility problem
-      //this->feasibility_problem.approximate_multipliers(current_iterate, current_evaluations);
+      // compute the feasibility multipliers and the residuals, and test termination wrt the feasibility problem
+      this->feasibility_problem.compute_multipliers(current_iterate, current_evaluations);
+      // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
       if (current_iterate.status == SolutionStatus::INFEASIBLE_STATIONARY_POINT) {
          DEBUG << "The current iterate is an infeasible stationary point\n";
          return;
       }
 
-      DEBUG << "\nSwitching from optimality to restoration phase\n";
+      DEBUG << "Switching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
       this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -138,25 +138,25 @@ namespace uno {
       DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
-      std::swap(current_iterate.multipliers, this->other_phase_multipliers);
-      // save the current point (progress and primals) upon switching
+
+      // save the current point (infeasibility and primals) upon switching
       this->reference_infeasibility = current_iterate.primal_infeasibility;
       this->reference_optimality_primals = current_iterate.primals;
-      current_iterate.set_number_variables(this->feasibility_problem.number_variables);
-
-      this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
+
+      current_iterate.set_number_variables(this->feasibility_problem.number_variables);
+      this->initial_point.resize(this->feasibility_problem.number_variables);
+      // swap the iterate's multipliers and the feasibility multipliers maintained by the class
+      std::swap(current_iterate.multipliers, this->other_phase_multipliers);
 
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
       const double proximal_coefficient = this->feasibility_inequality_handling_method->proximal_coefficient();
       this->feasibility_problem.set_proximal_coefficient(proximal_coefficient);
       DEBUG << "Proximal coefficient set to " << proximal_coefficient << '\n';
-      this->feasibility_problem.compute_elastics(current_iterate, current_evaluations);
       this->feasibility_inequality_handling_method->set_elastic_variable_values(this->feasibility_problem, current_iterate,
          current_evaluations);
       // re-evaluate the progress measures at the current iterate
       this->feasibility_inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
-      this->initial_point.resize(this->feasibility_problem.number_variables);
 
       DEBUG2 << "\nCurrent iterate to start feasibility restoration:\n" << current_iterate << '\n';
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -96,7 +96,6 @@ namespace uno {
       // compute the feasibility multipliers and the residuals, and test termination wrt the feasibility problem
       Multipliers tentative_multipliers(current_iterate.multipliers);
       this->feasibility_problem.compute_multipliers(tentative_multipliers, current_evaluations);
-      DEBUG << current_iterate << '\n';
       // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
       this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, tentative_multipliers,
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
@@ -105,6 +104,7 @@ namespace uno {
       if (norm_inf(view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables)) <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
          std::swap(tentative_multipliers, current_iterate.multipliers);
+         DEBUG << current_iterate << '\n';
          DEBUG << "The current iterate is an infeasible stationary point\n";
          return true;
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024 Charlie Vanaret
+// Copyright (c) 2018-2026 Charlie Vanaret
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include <functional>
@@ -90,31 +90,41 @@ namespace uno {
       return (this->current_phase == Phase::FEASIBILITY_RESTORATION);
    }
 
-   bool FeasibilityRestoration::test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const {
+   bool FeasibilityRestoration::test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) {
       DEBUG << "\nTesting the termination criteria of the feasibility problem at the current iterate\n";
       // compute the feasibility multipliers and the residuals, and test termination wrt the feasibility problem
       DEBUG2 << "x = " << current_iterate.primals << '\n';
-      DEBUG2 << "c(x) = " << current_evaluations.constraints << '\n';
-      Multipliers tentative_multipliers(current_iterate.multipliers);
-      this->feasibility_problem.compute_multipliers(tentative_multipliers, current_evaluations);
-      DEBUG2 << "Feasibility constraint multipliers: " << tentative_multipliers.constraints << '\n';
-      DEBUG2 << "Feasibility LB multipliers: " << tentative_multipliers.lower_bounds << '\n';
-      DEBUG2 << "Feasibility UB multipliers: " << tentative_multipliers.upper_bounds << '\n';
+      assert(current_evaluations.are_constraints_computed);
+
+      // initialize the feasibility multipliers
+      if (this->first_use_feasibility_multipliers) {
+         this->other_phase_multipliers.resize(this->feasibility_problem.number_variables,
+            this->feasibility_problem.number_constraints);
+         this->first_use_feasibility_multipliers = false;
+      }
+
+      this->feasibility_problem.compute_multipliers(this->other_phase_multipliers, current_evaluations);
+      DEBUG2 << "Feasibility constraint multipliers: " << this->other_phase_multipliers.constraints << '\n';
+      DEBUG2 << "Feasibility LB multipliers: " << this->other_phase_multipliers.lower_bounds << '\n';
+      DEBUG2 << "Feasibility UB multipliers: " << this->other_phase_multipliers.upper_bounds << '\n';
 
       // this->feasibility_problem.compute_residuals(current_iterate, current_evaluations);
-      this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, tentative_multipliers,
+      this->original_problem.model.evaluate_lagrangian_gradient(current_iterate.primals, this->other_phase_multipliers,
          0., current_evaluations, current_iterate.residuals.lagrangian_gradient);
       // TODO check that all duals are not 0
       DEBUG2 << "Lagrangian gradient: " << view(current_iterate.residuals.lagrangian_gradient, 0, this->original_problem.model.number_variables) << '\n';
       const double complementarity = this->original_problem.complementarity_error(current_iterate.primals,
-         current_evaluations.constraints, current_iterate.multipliers, 0., this->residual_norm);
+         current_evaluations.constraints, this->other_phase_multipliers, 0., this->residual_norm);
       DEBUG2 << "Complementarity: " << complementarity << '\n';
-      if (false && complementarity <= 1e-8) {
+      if (complementarity <= 1e-8) {
          current_iterate.status = SolutionStatus::INFEASIBLE_STATIONARY_POINT;
-         std::swap(tentative_multipliers, current_iterate.multipliers);
+         std::swap(this->other_phase_multipliers, current_iterate.multipliers);
          DEBUG << current_iterate << '\n';
          DEBUG << "The current iterate is an infeasible stationary point\n";
          return true;
+      }
+      else {
+         DEBUG << "The current iterate does not satisfy the infeasible stationary termination criteria\n";
       }
       return false;
    }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -33,7 +33,7 @@ namespace uno {
       const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
-      [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const override;
+      [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) override;
       void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
          WarmstartInformation& warmstart_information) override;
 
@@ -70,7 +70,7 @@ namespace uno {
       const bool switch_to_optimality_requires_linearized_feasibility;
       double reference_infeasibility{};
       Vector<double> reference_optimality_primals{};
-      bool first_switch_to_feasibility{true};
+      bool first_use_feasibility_multipliers{true};
 
       const Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -33,6 +33,7 @@ namespace uno {
       const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
+      [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const;
       void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
          WarmstartInformation& warmstart_information) override;
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -33,7 +33,7 @@ namespace uno {
       const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
-      [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const;
+      [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const override;
       void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
          WarmstartInformation& warmstart_information) override;
 

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -69,6 +69,10 @@ namespace uno {
       return false;
    }
 
+   bool NoRelaxation::test_infeasible_stationarity(Iterate& /*current_iterate*/, Evaluations& /*current_evaluations*/) const {
+      throw std::runtime_error("NoRelaxation::test_infeasible_stationarity should not be called");
+   }
+
    void NoRelaxation::switch_to_feasibility_problem(Statistics& /*statistics*/, Iterate& /*current_iterate*/,
          Evaluations& /*current_evaluations*/, WarmstartInformation& /*warmstart_information*/) {
       throw std::runtime_error("Switching to the feasibility problem should not happen");

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -69,7 +69,7 @@ namespace uno {
       return false;
    }
 
-   bool NoRelaxation::test_infeasible_stationarity(Iterate& /*current_iterate*/, Evaluations& /*current_evaluations*/) const {
+   bool NoRelaxation::test_infeasible_stationarity(Iterate& /*current_iterate*/, Evaluations& /*current_evaluations*/) {
       throw std::runtime_error("NoRelaxation::test_infeasible_stationarity should not be called");
    }
 

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -45,7 +45,7 @@ namespace uno {
       // statistics
       this->inequality_handling_method->initialize_statistics(statistics);
    }
-   
+
    const Direction& NoRelaxation::compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
       DEBUG << "Solving the subproblem\n";

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -45,9 +45,9 @@ namespace uno {
       // statistics
       this->inequality_handling_method->initialize_statistics(statistics);
    }
-
-   const Direction& NoRelaxation::compute_direction(Statistics& statistics, Iterate& current_iterate,
-         double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
+   
+   const Direction& NoRelaxation::compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
+         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
       DEBUG << "Solving the subproblem\n";
       const bool parameterization_updated = this->inequality_handling_method->update_parameterization(statistics,
          current_iterate);

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -23,8 +23,8 @@ namespace uno {
          EvaluationCache& evaluation_cache, Options& options) override;
 
       // direction computation
-      const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate,
-         double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
+      const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
+         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
       [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const override;
       void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -26,6 +26,7 @@ namespace uno {
       const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate,
          double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
+      [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const override;
       void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
          WarmstartInformation& warmstart_information) override;
 

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -26,7 +26,7 @@ namespace uno {
       const Direction& compute_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
-      [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) const override;
+      [[nodiscard]] bool test_infeasible_stationarity(Iterate& current_iterate, Evaluations& current_evaluations) override;
       void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
          WarmstartInformation& warmstart_information) override;
 

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -292,7 +292,8 @@ namespace uno {
       multipliers.constraints.fill(0.);
       multipliers.lower_bounds.fill(0.);
       multipliers.upper_bounds.fill(0.);
-      // first compute the constraint multipliers
+
+      // first compute the constraint multipliers of violated constraints
       for (size_t constraint_index: Range(this->model.number_constraints)) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
             multipliers.constraints[constraint_index] = this->constraint_violation_coefficient;
@@ -301,13 +302,27 @@ namespace uno {
             multipliers.constraints[constraint_index] = -this->constraint_violation_coefficient;
          }
       }
+
       // then the bound multipliers from the stationary equation -J^T y - z = 0 => z = -J^T y
       Vector<double> bound_multipliers(this->model.number_variables); // TODO preallocate
       current_evaluations.compute_jacobian_transposed_vector_product(this->model, multipliers.constraints.view(),
          bound_multipliers.view());
       bound_multipliers.scale(-1.);
+      // save the bound multipliers into "multipliers"
       for (size_t variable_index: Range(this->model.number_variables)) {
-         if (bound_multipliers[variable_index] >= 0.) {
+         // skip for unconstrained variables (the error should be counted in the stationarity residual)
+         if (is_infinite(this->variables_lower_bounds[variable_index]) && is_infinite(this->variables_upper_bounds[variable_index])) {
+            continue;
+         }
+         // check single-bounded variables
+         if (is_finite(this->variables_lower_bounds[variable_index]) && is_infinite(this->variables_upper_bounds[variable_index])) {
+            multipliers.lower_bounds[variable_index] = bound_multipliers[variable_index];
+         }
+         else if (is_finite(this->variables_upper_bounds[variable_index]) && is_infinite(this->variables_lower_bounds[variable_index])) {
+            multipliers.upper_bounds[variable_index] = bound_multipliers[variable_index];
+         }
+         // unbounded or doubly-bounded variables: trust the sign of the bound dual
+         else if (bound_multipliers[variable_index] >= 0.) {
             multipliers.lower_bounds[variable_index] = bound_multipliers[variable_index];
          }
          else {

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -290,7 +290,9 @@ namespace uno {
 
    void l1RelaxedProblem::approximate_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const {
       // constraint multipliers
+      std::cout << "approximate_multipliers 1\n";
       current_iterate.multipliers.constraints.fill(0.);
+      std::cout << "approximate_multipliers 2\n";
       for (size_t constraint_index: Range(this->model.number_constraints)) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
             current_iterate.multipliers.constraints[constraint_index] = this->constraint_violation_coefficient;
@@ -299,6 +301,7 @@ namespace uno {
             current_iterate.multipliers.constraints[constraint_index] = -this->constraint_violation_coefficient;
          }
       }
+      std::cout << "approximate_multipliers 3\n";
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.positive) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
             current_iterate.primals[elastic_index] = 0.;
@@ -313,7 +316,9 @@ namespace uno {
             current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
          }
       }
+      std::cout << "approximate_multipliers 4\n";
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.negative) {
+         std::cout << "[" << constraint_index << ", " << elastic_index << "]\n";
          if (this->get_constraints_upper_bounds()[constraint_index] < current_evaluations.constraints[constraint_index]) {
             current_iterate.primals[elastic_index] = 0.;
             current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
@@ -327,6 +332,7 @@ namespace uno {
             current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
          }
       }
+      std::cout << "approximate_multipliers 5\n";
    }
 
    SolutionStatus l1RelaxedProblem::check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -291,6 +291,8 @@ namespace uno {
    void l1RelaxedProblem::compute_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const {
       // constraint multipliers
       current_iterate.multipliers.constraints.fill(0.);
+      current_iterate.multipliers.lower_bounds.fill(0.);
+      current_iterate.multipliers.upper_bounds.fill(0.);
       for (size_t constraint_index: Range(this->model.number_constraints)) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
             current_iterate.multipliers.constraints[constraint_index] = this->constraint_violation_coefficient;

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -292,6 +292,7 @@ namespace uno {
       multipliers.constraints.fill(0.);
       multipliers.lower_bounds.fill(0.);
       multipliers.upper_bounds.fill(0.);
+      // first compute the constraint multipliers
       for (size_t constraint_index: Range(this->model.number_constraints)) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
             multipliers.constraints[constraint_index] = this->constraint_violation_coefficient;
@@ -300,6 +301,19 @@ namespace uno {
             multipliers.constraints[constraint_index] = -this->constraint_violation_coefficient;
          }
       }
+      // then the bound multipliers from the stationary equation -J^T y - z = 0 => z = -J^T y
+      Vector<double> bound_multipliers(this->model.number_variables); // TODO preallocate
+      current_evaluations.compute_jacobian_transposed_vector_product(this->model, multipliers.constraints.data(), bound_multipliers.data());
+      bound_multipliers.scale(-1.);
+      for (size_t variable_index: Range(this->model.number_variables)) {
+         if (bound_multipliers[variable_index] >= 0.) {
+            multipliers.lower_bounds[variable_index] = bound_multipliers[variable_index];
+         }
+         else {
+            multipliers.upper_bounds[variable_index] = bound_multipliers[variable_index];
+         }
+      }
+      // at this point, the stationary equation is satisfied. Complementarity may not.
    }
 
    void l1RelaxedProblem::compute_elastics(Iterate& current_iterate, const Evaluations& current_evaluations) const {

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -288,19 +288,21 @@ namespace uno {
       }
    }
 
-   void l1RelaxedProblem::compute_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const {
-      // constraint multipliers
-      current_iterate.multipliers.constraints.fill(0.);
-      current_iterate.multipliers.lower_bounds.fill(0.);
-      current_iterate.multipliers.upper_bounds.fill(0.);
+   void l1RelaxedProblem::compute_multipliers(Multipliers& multipliers, const Evaluations& current_evaluations) const {
+      multipliers.constraints.fill(0.);
+      multipliers.lower_bounds.fill(0.);
+      multipliers.upper_bounds.fill(0.);
       for (size_t constraint_index: Range(this->model.number_constraints)) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
-            current_iterate.multipliers.constraints[constraint_index] = this->constraint_violation_coefficient;
+            multipliers.constraints[constraint_index] = this->constraint_violation_coefficient;
          }
          else if (this->get_constraints_upper_bounds()[constraint_index] < current_evaluations.constraints[constraint_index]) {
-            current_iterate.multipliers.constraints[constraint_index] = -this->constraint_violation_coefficient;
+            multipliers.constraints[constraint_index] = -this->constraint_violation_coefficient;
          }
       }
+   }
+
+   void l1RelaxedProblem::compute_elastics(Iterate& current_iterate, const Evaluations& current_evaluations) const {
       // elastic variables: primals and bound multipliers
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.positive) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -303,7 +303,8 @@ namespace uno {
       }
       // then the bound multipliers from the stationary equation -J^T y - z = 0 => z = -J^T y
       Vector<double> bound_multipliers(this->model.number_variables); // TODO preallocate
-      current_evaluations.compute_jacobian_transposed_vector_product(this->model, multipliers.constraints.data(), bound_multipliers.data());
+      current_evaluations.compute_jacobian_transposed_vector_product(this->model, multipliers.constraints.view(),
+         bound_multipliers.view());
       bound_multipliers.scale(-1.);
       for (size_t variable_index: Range(this->model.number_variables)) {
          if (bound_multipliers[variable_index] >= 0.) {

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -288,6 +288,47 @@ namespace uno {
       }
    }
 
+   void l1RelaxedProblem::approximate_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const {
+      // constraint multipliers
+      current_iterate.multipliers.constraints.fill(0.);
+      for (size_t constraint_index: Range(this->model.number_constraints)) {
+         if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
+            current_iterate.multipliers.constraints[constraint_index] = this->constraint_violation_coefficient;
+         }
+         else if (this->get_constraints_upper_bounds()[constraint_index] < current_evaluations.constraints[constraint_index]) {
+            current_iterate.multipliers.constraints[constraint_index] = -this->constraint_violation_coefficient;
+         }
+      }
+      for (const auto [constraint_index, elastic_index]: this->elastic_variables.positive) {
+         if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
+            current_iterate.primals[elastic_index] = 0.;
+            current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
+         }
+         else if (this->get_constraints_upper_bounds()[constraint_index] < current_evaluations.constraints[constraint_index]) {
+            current_iterate.primals[elastic_index] = current_evaluations.constraints[constraint_index] - this->get_constraints_upper_bounds()[constraint_index];
+            current_iterate.multipliers.lower_bounds[elastic_index] = 0.;
+         }
+         else {
+            current_iterate.primals[elastic_index] = 0.;
+            current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
+         }
+      }
+      for (const auto [constraint_index, elastic_index]: this->elastic_variables.negative) {
+         if (this->get_constraints_upper_bounds()[constraint_index] < current_evaluations.constraints[constraint_index]) {
+            current_iterate.primals[elastic_index] = 0.;
+            current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
+         }
+         else if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
+            current_iterate.primals[elastic_index] = this->get_constraints_lower_bounds()[constraint_index] - current_evaluations.constraints[constraint_index];
+            current_iterate.multipliers.lower_bounds[elastic_index] = 0.;
+         }
+         else {
+            current_iterate.primals[elastic_index] = 0.;
+            current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
+         }
+      }
+   }
+
    SolutionStatus l1RelaxedProblem::check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,
          double dual_tolerance) const {
       // evaluate termination conditions based on optimality conditions

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -288,11 +288,9 @@ namespace uno {
       }
    }
 
-   void l1RelaxedProblem::approximate_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const {
+   void l1RelaxedProblem::compute_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const {
       // constraint multipliers
-      std::cout << "approximate_multipliers 1\n";
       current_iterate.multipliers.constraints.fill(0.);
-      std::cout << "approximate_multipliers 2\n";
       for (size_t constraint_index: Range(this->model.number_constraints)) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
             current_iterate.multipliers.constraints[constraint_index] = this->constraint_violation_coefficient;
@@ -301,7 +299,7 @@ namespace uno {
             current_iterate.multipliers.constraints[constraint_index] = -this->constraint_violation_coefficient;
          }
       }
-      std::cout << "approximate_multipliers 3\n";
+      // elastic variables: primals and bound multipliers
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.positive) {
          if (current_evaluations.constraints[constraint_index] < this->get_constraints_lower_bounds()[constraint_index]) {
             current_iterate.primals[elastic_index] = 0.;
@@ -316,9 +314,7 @@ namespace uno {
             current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
          }
       }
-      std::cout << "approximate_multipliers 4\n";
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.negative) {
-         std::cout << "[" << constraint_index << ", " << elastic_index << "]\n";
          if (this->get_constraints_upper_bounds()[constraint_index] < current_evaluations.constraints[constraint_index]) {
             current_iterate.primals[elastic_index] = 0.;
             current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
@@ -332,7 +328,6 @@ namespace uno {
             current_iterate.multipliers.lower_bounds[elastic_index] = 2.*this->constraint_violation_coefficient;
          }
       }
-      std::cout << "approximate_multipliers 5\n";
    }
 
    SolutionStatus l1RelaxedProblem::check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -63,7 +63,8 @@ namespace uno {
 
       [[nodiscard]] Inertia get_inertia() const override;
 
-      void compute_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const;
+      void compute_multipliers(Multipliers& multipliers, const Evaluations& current_evaluations) const;
+      void compute_elastics(Iterate& current_iterate, const Evaluations& current_evaluations) const;
       [[nodiscard]] SolutionStatus check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,
          double dual_tolerance) const override;
 

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -63,7 +63,7 @@ namespace uno {
 
       [[nodiscard]] Inertia get_inertia() const override;
 
-      void approximate_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const;
+      void compute_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const;
       [[nodiscard]] SolutionStatus check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,
          double dual_tolerance) const override;
 

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -63,6 +63,7 @@ namespace uno {
 
       [[nodiscard]] Inertia get_inertia() const override;
 
+      void approximate_multipliers(Iterate& current_iterate, const Evaluations& current_evaluations) const;
       [[nodiscard]] SolutionStatus check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,
          double dual_tolerance) const override;
 

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -77,6 +77,8 @@ namespace uno {
          throw std::runtime_error("Line search failed");
       }
 
+      // TODO call test_infeasible_stationarity
+
       // switch to solving the feasibility problem
       this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate,
          evaluation_cache.current_evaluations, warmstart_information);

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -77,9 +77,13 @@ namespace uno {
          throw std::runtime_error("Line search failed");
       }
 
-      // TODO call test_infeasible_stationarity
+      // test if we can terminate with a stationary infeasible point
+      if (this->constraint_relaxation_strategy->test_infeasible_stationarity(current_iterate, evaluation_cache.current_evaluations)) {
+         std::swap(current_iterate, trial_iterate);
+         return;
+      }
 
-      // switch to solving the feasibility problem
+      // otherwise, switch to solving the feasibility problem
       this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate,
          evaluation_cache.current_evaluations, warmstart_information);
       assert(this->constraint_relaxation_strategy->solving_feasibility_problem());

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -163,7 +163,7 @@ namespace uno {
       bool accept_iterate = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
          trial_iterate, direction, 1., true, evaluation_cache.current_evaluations, evaluation_cache.trial_evaluations,
          warmstart_information, user_callbacks);
-      GlobalizationMechanism::set_primal_statistics(statistics, model, trial_iterate, evaluation_cache.trial_evaluations);
+      set_primal_statistics(statistics, model, trial_iterate, evaluation_cache.trial_evaluations);
       if (accept_iterate) {
          // possibly increase the radius if trust region is active
          this->possibly_increase_radius(direction.norm);

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -59,8 +59,8 @@ namespace uno {
             this->set_TR_statistics(statistics, number_iterations);
 
             // compute the direction within the trust region
-            const Direction& direction = this->constraint_relaxation_strategy->compute_direction(statistics,
-               current_iterate, this->radius, evaluation_cache.current_evaluations, warmstart_information);
+            const Direction& direction = this->constraint_relaxation_strategy->compute_direction(statistics, current_iterate,
+               this->radius, evaluation_cache.current_evaluations, warmstart_information);
             if (direction.status == SubproblemStatus::INFEASIBLE) {
                if (model.number_constraints == 0) {
                   throw std::runtime_error("The model is unconstrained but the iterate is infeasible, should not happen");
@@ -71,7 +71,15 @@ namespace uno {
                statistics.set("Status", std::string("infeasible"));
                DEBUG << "/!\\ The subproblem is infeasible\n";
 
-               // solve the feasibility problem at the next TR iteration with the same radius
+               // test if we can terminate with a stationary infeasible point
+               if (this->constraint_relaxation_strategy->test_infeasible_stationarity(current_iterate,
+                     evaluation_cache.current_evaluations)) {
+                  std::swap(current_iterate, trial_iterate);
+                  return;
+               }
+
+               // otherwise, switch to the feasibility problem and solve the feasibility problem at the next TR iteration
+               // with the same radius
                this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate,
                   evaluation_cache.current_evaluations, warmstart_information);
                continue;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -323,13 +323,6 @@ namespace uno {
       DEBUG << "bound dual step length = " << direction.bound_dual_step_length << "\n\n";
    }
 
-   double PrimalDualInteriorPointProblem::dual_regularization_factor() const {
-      const double barrier_parameter = this->parameterization.get("barrier_parameter");
-      return std::pow(barrier_parameter, this->parameters.dual_regularization_exponent);
-   }
-
-   // protected member functions
-
    double PrimalDualInteriorPointProblem::push_variable_to_interior(double variable_value, double lower_bound, double upper_bound) const {
       const double range = upper_bound - lower_bound;
       const double perturbation_lb = std::min(this->parameters.push_variable_to_interior_k1 * std::max(1., std::abs(lower_bound)),
@@ -339,6 +332,11 @@ namespace uno {
       variable_value = std::max(variable_value, lower_bound + perturbation_lb);
       variable_value = std::min(variable_value, upper_bound - perturbation_ub);
       return variable_value;
+   }
+
+   double PrimalDualInteriorPointProblem::dual_regularization_factor() const {
+      const double barrier_parameter = this->parameterization.get("barrier_parameter");
+      return std::pow(barrier_parameter, this->parameters.dual_regularization_exponent);
    }
 
    void PrimalDualInteriorPointProblem::postprocess_iterate(Iterate& iterate) const {
@@ -384,6 +382,8 @@ namespace uno {
       }
    }
 
+   // progress measures
+
    void PrimalDualInteriorPointProblem::set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm norm) const {
       this->inner.set_infeasibility_measure(iterate, evaluations, norm);
    }
@@ -400,9 +400,6 @@ namespace uno {
       if (is_infinite(barrier_parameter)) {
          throw std::runtime_error("Barrier parameter is infinite");
       }
-
-      // if the primals are too close to their bounds, push the bounds away by a small fraction (Section 3.5)
-
 
       // add the contribution of the barrier terms
       double barrier_terms = 0.;

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -147,7 +147,7 @@ namespace uno {
    void Subproblem::assemble_augmented_rhs(const Iterate& current_iterate, Evaluations& evaluations, Vector<double>& rhs) const {
       rhs.fill(0.);
 
-      // -Jacobian^T-multipliers product
+      // -Jacobian^T multipliers product
       this->problem.compute_jacobian_transposed_vector_product(current_iterate.multipliers.constraints.view(),
          rhs.view(), evaluations);
       rhs.scale(-1.);

--- a/uno/ingredients/subproblem_solvers/IQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.cpp
@@ -28,7 +28,7 @@ namespace uno {
 
    void IQPSolver::compute_least_squares_multipliers(const Subproblem& /*subproblem*/, Iterate& /*iterate*/,
          Evaluations& /*evaluations*/, double /*multipliers_threshold*/) {
-      DEBUG << "The EQP solver does not compute least-squares multipliers, keeping existing multipliers";
+      DEBUG << "The IQP solver does not compute least-squares multipliers, keeping existing multipliers";
    }
 
    const Direction& IQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/optimization/Multipliers.cpp
+++ b/uno/optimization/Multipliers.cpp
@@ -15,6 +15,12 @@ namespace uno {
       this->upper_bounds.fill(0.);
    }
 
+   void Multipliers::resize(size_t number_variables, size_t number_constraints) {
+      this->constraints.resize(number_constraints);
+      this->lower_bounds.resize(number_variables);
+      this->upper_bounds.resize(number_variables);
+   }
+
    bool Multipliers::not_all_zero(size_t number_variables, double tolerance) const {
       // constraint multipliers
       for (double multiplier_j: this->constraints) {

--- a/uno/optimization/Multipliers.hpp
+++ b/uno/optimization/Multipliers.hpp
@@ -21,6 +21,7 @@ namespace uno {
       Multipliers& operator=(Multipliers&& other) noexcept = default;
 
       void reset();
+      void resize(size_t number_variables, size_t number_constraints);
       [[nodiscard]] bool not_all_zero(size_t number_variables, double tolerance) const;
    };
 } // namespace


### PR DESCRIPTION
Before switching to feasibility restoration, we:
- compute the feasibility multipliers for the violated constraints
- compute the stationarity error (the norm of the Lagrangian gradient) wrt the feasibility error

We thus catch "easy" stationary infeasible points. If the current iterate is not stationary infeasible, proceed with switching to feasibility restoration.