### PR TITLE
Fix `Subproblem::number_primal_inertia_correction_nonzeros` for Hessian regularization

### DIFF
--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -247,8 +247,10 @@ namespace uno {
    }
 
    size_t Subproblem::number_primal_inertia_correction_nonzeros() const {
-      // always allocate the full block (see compute_regularized_augmented_matrix_sparsity())
-      return this->number_variables;
+      if (!this->hessian_model.is_positive_definite() && this->performs_primal_regularization()) {
+         return this->get_primal_regularization_variables().size();
+      }
+      return 0;
    }
 
    size_t Subproblem::number_dual_inertia_correction_nonzeros() const {

--- a/uno/ingredients/subproblem_solvers/COOLinearSystem.cpp
+++ b/uno/ingredients/subproblem_solvers/COOLinearSystem.cpp
@@ -26,13 +26,13 @@ namespace uno {
 
    void COOLinearSystem::initialize_augmented_system(const Subproblem& subproblem) {
       const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
+      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_variables; // full block
       const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
-      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
       const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
       // augmented system
       this->dimension = subproblem.number_variables + subproblem.number_constraints;
-      this->number_nonzeros = number_hessian_nonzeros + number_jacobian_nonzeros + number_primal_inertia_correction_nonzeros +
-         number_dual_inertia_correction_nonzeros;
+      this->number_nonzeros = number_hessian_nonzeros + number_primal_inertia_correction_nonzeros + number_jacobian_nonzeros
+         + number_dual_inertia_correction_nonzeros;
       this->matrix_row_indices.resize(this->number_nonzeros);
       this->matrix_column_indices.resize(this->number_nonzeros);
       // compute the COO sparse representation

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -44,7 +44,7 @@ namespace uno {
 
       // set up the linear system
       const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_variables; // full block
       const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
       const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
       View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);
@@ -107,7 +107,7 @@ namespace uno {
       if (warmstart_information.new_iterate) {
          // assemble the augmented matrix
          const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-         const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+         const size_t number_primal_inertia_correction_nonzeros = subproblem.number_variables; // full block
          const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
          const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
          View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -47,7 +47,7 @@ namespace uno {
 
       // set up the linear system
       const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+      const size_t number_primal_inertia_correction_nonzeros = subproblem.number_variables; // full block
       const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
       const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
       View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);
@@ -110,7 +110,7 @@ namespace uno {
       if (warmstart_information.new_iterate) {
          // assemble the augmented matrix with only the diagonal part of the quasi-Newton Hessian
          const size_t number_hessian_nonzeros = subproblem.number_hessian_nonzeros();
-         const size_t number_primal_inertia_correction_nonzeros = subproblem.number_primal_inertia_correction_nonzeros();
+         const size_t number_primal_inertia_correction_nonzeros = subproblem.number_variables; // full block
          const size_t number_jacobian_nonzeros = subproblem.number_jacobian_nonzeros();
          const size_t number_dual_inertia_correction_nonzeros = subproblem.number_dual_inertia_correction_nonzeros();
          View hessian(linear_system.matrix_values.data(), number_hessian_nonzeros);


### PR DESCRIPTION
Fix `Subproblem::number_primal_inertia_correction_nonzeros` for Hessian regularization. For augmented systems, the full block (size n) is always allocated.