### PR TITLE
Use previous Hessian if its evaluation fails

### DIFF
--- a/interfaces/AMPL/AMPLModel.cpp
+++ b/interfaces/AMPL/AMPLModel.cpp
@@ -223,7 +223,6 @@ namespace uno {
       }
       this->asl->i.err_jmp_ = save;      // restore, always
       if (failed) {
-         std::cout << "Hessian eval error\n";
          throw HessianEvaluationError();
       }
    }

--- a/interfaces/AMPL/AMPLModel.cpp
+++ b/interfaces/AMPL/AMPLModel.cpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cassert>
+#include <csetjmp>
 #include <stdexcept>
 #include "AMPLModel.hpp"
 #include "optimization/EvaluationErrors.hpp"
@@ -13,7 +14,7 @@
 #include "Uno.hpp"
 
 namespace uno {
-   ASL* generate_asl(const std::string &file_name) {
+   ASL* generate_asl(const std::string& file_name) {
       ASL* asl = ASL_alloc(ASL_read_pfgh);
       if (asl == nullptr) {
          throw std::runtime_error("The ASL could not be allocated");
@@ -212,9 +213,19 @@ namespace uno {
 
    void AMPLModel::evaluate_lagrangian_hessian(const Vector<double>& /*x*/, double objective_multiplier, const Vector<double>& multipliers,
          View<double> hessian_values) const {
-      objective_multiplier *= this->optimization_sense;
-      this->asl->p.Sphes(this->asl, nullptr, hessian_values.data(), -1, &objective_multiplier, const_cast<double*>(multipliers.data()));
-      ++this->number_model_evaluations.hessian;
+      Jmp_buf b, *save = this->asl->i.err_jmp_;
+      this->asl->i.err_jmp_ = &b;
+      const bool failed = (setjmp(b.jb) != 0);
+      if (!failed) {
+         objective_multiplier *= this->optimization_sense;
+         this->asl->p.Sphes(this->asl, nullptr, hessian_values.data(), -1, &objective_multiplier, const_cast<double*>(multipliers.data()));
+         ++this->number_model_evaluations.hessian;
+      }
+      this->asl->i.err_jmp_ = save;      // restore, always
+      if (failed) {
+         std::cout << "Hessian eval error\n";
+         throw HessianEvaluationError();
+      }
    }
 
    void AMPLModel::compute_jacobian_vector_product(const double* /*x*/, const double* /*vector*/, double* /*result*/) const {

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
@@ -10,11 +10,9 @@
 #include "linear_algebra/Indexing.hpp"
 #include "linear_algebra/Vector.hpp"
 #include "linear_algebra/View.hpp"
-#include "optimization/EvaluationErrors.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "symbolic/Range.hpp"
-#include "tools/Logger.hpp"
 
 namespace uno {
    #define BIG 1e30
@@ -66,7 +64,7 @@ namespace uno {
          this->hessian_row_indices.resize(number_hessian_nonzeros);
          this->hessian_column_indices.resize(number_hessian_nonzeros);
          this->hessian_values.resize(number_hessian_nonzeros);
-         this->hessian_buffer.resize(number_hessian_nonzeros);
+         this->hessian_buffer.initialize(number_hessian_nonzeros);
       }
    }
 
@@ -104,16 +102,7 @@ namespace uno {
          }
          // evaluate + regularize the explicit Hessian once per iterate
          if (this->hessian_evaluation_required) {
-            // try to evaluate the Hessian. Upon failure, keep the previous one
-            try {
-               subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
-               // success: copy the new Hessian into the workspace
-               this->hessian_values = this->hessian_buffer;
-            }
-            catch (const HessianEvaluationError&) {
-               // keep the existing Hessian in hessian
-               DEBUG << "The Hessian could not be evaluated by BQPD, using the previous one\n";
-            }
+            this->hessian_buffer.evaluate_hessian(statistics, subproblem, current_iterate, this->hessian_values.view());
             subproblem.regularize_lagrangian_hessian(statistics, this->hessian_values.view());
             this->hessian_evaluation_required = false;
          }

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.cpp
@@ -10,9 +10,11 @@
 #include "linear_algebra/Indexing.hpp"
 #include "linear_algebra/Vector.hpp"
 #include "linear_algebra/View.hpp"
+#include "optimization/EvaluationErrors.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "symbolic/Range.hpp"
+#include "tools/Logger.hpp"
 
 namespace uno {
    #define BIG 1e30
@@ -64,6 +66,7 @@ namespace uno {
          this->hessian_row_indices.resize(number_hessian_nonzeros);
          this->hessian_column_indices.resize(number_hessian_nonzeros);
          this->hessian_values.resize(number_hessian_nonzeros);
+         this->hessian_buffer.resize(number_hessian_nonzeros);
       }
    }
 
@@ -101,7 +104,16 @@ namespace uno {
          }
          // evaluate + regularize the explicit Hessian once per iterate
          if (this->hessian_evaluation_required) {
-            subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_values.view());
+            // try to evaluate the Hessian. Upon failure, keep the previous one
+            try {
+               subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
+               // success: copy the new Hessian into the workspace
+               this->hessian_values = this->hessian_buffer;
+            }
+            catch (const HessianEvaluationError&) {
+               // keep the existing Hessian in hessian
+               DEBUG << "The Hessian could not be evaluated by BQPD, using the previous one\n";
+            }
             subproblem.regularize_lagrangian_hessian(statistics, this->hessian_values.view());
             this->hessian_evaluation_required = false;
          }

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.hpp
@@ -9,6 +9,7 @@
 #include "ingredients/subproblem_solvers/QuadraticProgram.hpp"
 #include "ingredients/subproblem_solvers/SolverWorkspace.hpp"
 #include "linear_algebra/Vector.hpp"
+#include "optimization/HessianBuffer.hpp"
 
 namespace uno {
    // forward declarations
@@ -75,7 +76,7 @@ namespace uno {
       Vector<uno_int> hessian_row_indices{};
       Vector<uno_int> hessian_column_indices{};
       Vector<double> hessian_values{}; // workspace
-      Vector<double> hessian_buffer{}; // buffer used to evaluate the Hessian. Upon success, copy into the workspace
+      HessianBuffer hessian_buffer{}; // buffer used to evaluate the Hessian
       bool hessian_evaluation_required{false};
       mutable Vector<double> hessian_vector_product{};
 

--- a/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.hpp
+++ b/uno/ingredients/subproblem_solvers/BQPD/BQPDQuadraticProgram.hpp
@@ -74,7 +74,8 @@ namespace uno {
       // COO Hessian
       Vector<uno_int> hessian_row_indices{};
       Vector<uno_int> hessian_column_indices{};
-      Vector<double> hessian_values{};
+      Vector<double> hessian_values{}; // workspace
+      Vector<double> hessian_buffer{}; // buffer used to evaluate the Hessian. Upon success, copy into the workspace
       bool hessian_evaluation_required{false};
       mutable Vector<double> hessian_vector_product{};
 

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -7,7 +7,6 @@
 #include "LinearSystem.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "optimization/Direction.hpp"
-#include "optimization/EvaluationErrors.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
@@ -26,7 +25,7 @@ namespace uno {
          throw std::runtime_error("The subproblem does not have an explicit Hessian matrix and cannot be solved with a direct linear solver");
       }
       this->direction = Direction(subproblem.number_variables, subproblem.number_constraints);
-      this->hessian_buffer.resize(subproblem.number_hessian_nonzeros());
+      this->hessian_buffer.initialize(subproblem.number_hessian_nonzeros());
       // access the linear system of the linear solver
       auto& linear_system = this->linear_solver->get_linear_system();
       linear_system.initialize_augmented_system(subproblem);
@@ -118,15 +117,7 @@ namespace uno {
          View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
 
          // try to evaluate the Hessian. Upon failure, keep the previous one
-         try {
-            subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
-            // success: copy the new Hessian into the linear system
-            hessian = this->hessian_buffer;
-         }
-         catch (const HessianEvaluationError&) {
-            // keep the existing Hessian in hessian
-            DEBUG << "The Hessian could not be evaluated by the EQP solver, using the previous one\n";
-         }
+         this->hessian_buffer.evaluate_hessian(statistics, subproblem, current_iterate, hessian);
          subproblem.evaluate_jacobian(current_iterate, jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -7,6 +7,7 @@
 #include "LinearSystem.hpp"
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/EvaluationErrors.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
@@ -25,6 +26,7 @@ namespace uno {
          throw std::runtime_error("The subproblem does not have an explicit Hessian matrix and cannot be solved with a direct linear solver");
       }
       this->direction = Direction(subproblem.number_variables, subproblem.number_constraints);
+      this->hessian_buffer.resize(subproblem.number_hessian_nonzeros());
       // access the linear system of the linear solver
       auto& linear_system = this->linear_solver->get_linear_system();
       linear_system.initialize_augmented_system(subproblem);
@@ -115,7 +117,16 @@ namespace uno {
          View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
          View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
 
-         subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, hessian);
+         // try to evaluate the Hessian. Upon failure, keep the previous one
+         try {
+            subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
+            // success: copy the new Hessian into the linear system
+            hessian = this->hessian_buffer;
+         }
+         catch (const HessianEvaluationError&) {
+            // keep the existing Hessian in hessian
+            DEBUG << "The Hessian could not be evaluated by the EQP solver, using the previous one\n";
+         }
          subproblem.evaluate_jacobian(current_iterate, jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all

--- a/uno/ingredients/subproblem_solvers/EQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.hpp
@@ -38,6 +38,7 @@ namespace uno {
       Direction direction;
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> linear_solver;
       bool analysis_performed{false};
+      Vector<double> hessian_buffer; // buffer used to evaluate the Hessian. Upon success, copy into the linear system
 
       bool SOC_initialized{false};
       Direction direction_SOC;

--- a/uno/ingredients/subproblem_solvers/EQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include "SubproblemSolver.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/HessianBuffer.hpp"
 
 namespace uno {
    // forward declarations
@@ -38,7 +39,7 @@ namespace uno {
       Direction direction;
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> linear_solver;
       bool analysis_performed{false};
-      Vector<double> hessian_buffer; // buffer used to evaluate the Hessian. Upon success, copy into the linear system
+      HessianBuffer hessian_buffer; // buffer used to evaluate the Hessian
 
       bool SOC_initialized{false};
       Direction direction_SOC;

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
@@ -5,9 +5,11 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "linear_algebra/Indexing.hpp"
 #include "linear_algebra/Vector.hpp"
+#include "optimization/EvaluationErrors.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "symbolic/Range.hpp"
+#include "tools/Logger.hpp"
 
 namespace uno {
    void HiGHSQuadraticProgram::initialize_memory(const Subproblem& subproblem) {
@@ -129,6 +131,7 @@ namespace uno {
       this->hessian_row_indices.resize(number_regularized_hessian_nonzeros);
       this->hessian_column_indices.resize(number_regularized_hessian_nonzeros);
       this->hessian_values.resize(number_regularized_hessian_nonzeros);
+      this->hessian_buffer.resize(number_regularized_hessian_nonzeros);
       subproblem.compute_regularized_hessian_sparsity(this->hessian_row_indices.data(),
          this->hessian_column_indices.data(), Indexing::C_indexing);
       // convert COO -> HiGHS' lower-triangular CSC layout
@@ -189,7 +192,16 @@ namespace uno {
          subproblem.problem.evaluate_constraints(current_iterate, this->constraints.data(), current_evaluations);
          this->evaluate_jacobian(subproblem.problem, current_iterate.primals, current_evaluations);
          // evaluate the Hessian and regularize it
-         subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_values.view());
+         // try to evaluate the Hessian. Upon failure, keep the previous one
+         try {
+            subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
+            // success: copy the new Hessian into the workspace
+            this->hessian_values = this->hessian_buffer;
+         }
+         catch (const HessianEvaluationError&) {
+            // keep the existing Hessian in hessian
+            DEBUG << "The Hessian could not be evaluated by BQPD, using the previous one\n";
+         }
          // copy the Hessian with permutation into this->model.hessian_.value_
          this->scatter_hessian_values();
          View hessian(this->model.hessian_.value_.data(), subproblem.number_regularized_hessian_nonzeros());

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.cpp
@@ -5,11 +5,9 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "linear_algebra/Indexing.hpp"
 #include "linear_algebra/Vector.hpp"
-#include "optimization/EvaluationErrors.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
 #include "symbolic/Range.hpp"
-#include "tools/Logger.hpp"
 
 namespace uno {
    void HiGHSQuadraticProgram::initialize_memory(const Subproblem& subproblem) {
@@ -131,7 +129,7 @@ namespace uno {
       this->hessian_row_indices.resize(number_regularized_hessian_nonzeros);
       this->hessian_column_indices.resize(number_regularized_hessian_nonzeros);
       this->hessian_values.resize(number_regularized_hessian_nonzeros);
-      this->hessian_buffer.resize(number_regularized_hessian_nonzeros);
+      this->hessian_buffer.initialize(number_regularized_hessian_nonzeros);
       subproblem.compute_regularized_hessian_sparsity(this->hessian_row_indices.data(),
          this->hessian_column_indices.data(), Indexing::C_indexing);
       // convert COO -> HiGHS' lower-triangular CSC layout
@@ -192,18 +190,8 @@ namespace uno {
          subproblem.problem.evaluate_constraints(current_iterate, this->constraints.data(), current_evaluations);
          this->evaluate_jacobian(subproblem.problem, current_iterate.primals, current_evaluations);
          // evaluate the Hessian and regularize it
-         // try to evaluate the Hessian. Upon failure, keep the previous one
-         try {
-            subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
-            // success: copy the new Hessian into the workspace
-            this->hessian_values = this->hessian_buffer;
-         }
-         catch (const HessianEvaluationError&) {
-            // keep the existing Hessian in hessian
-            DEBUG << "The Hessian could not be evaluated by BQPD, using the previous one\n";
-         }
-         // copy the Hessian with permutation into this->model.hessian_.value_
-         this->scatter_hessian_values();
+         this->hessian_buffer.evaluate_hessian(statistics, subproblem, current_iterate, this->hessian_values.view());
+         this->scatter_hessian_values(); // copy the Hessian with permutation into this->model.hessian_.value_
          View hessian(this->model.hessian_.value_.data(), subproblem.number_regularized_hessian_nonzeros());
          subproblem.regularize_lagrangian_hessian(statistics, hessian);
       }

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.hpp
@@ -8,6 +8,7 @@
 #include "ingredients/subproblem_solvers/QuadraticProgram.hpp"
 #include "ingredients/subproblem_solvers/SolverWorkspace.hpp"
 #include "linear_algebra/Vector.hpp"
+#include "optimization/HessianBuffer.hpp"
 
 namespace uno {
    // forward declarations
@@ -50,7 +51,7 @@ namespace uno {
       Vector<uno_int> hessian_row_indices{};
       Vector<uno_int> hessian_column_indices{};
       Vector<double> hessian_values{}; // workspace
-      Vector<double> hessian_buffer{}; // buffer used to evaluate the Hessian. Upon success, copy into the workspace
+      HessianBuffer hessian_buffer{}; // buffer used to evaluate the Hessian
       Vector<size_t> hessian_permutation_vector{};
 
    protected:

--- a/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.hpp
+++ b/uno/ingredients/subproblem_solvers/HiGHS/HiGHSQuadraticProgram.hpp
@@ -49,7 +49,8 @@ namespace uno {
       // Lagrangian Hessian in COO format
       Vector<uno_int> hessian_row_indices{};
       Vector<uno_int> hessian_column_indices{};
-      Vector<double> hessian_values{};
+      Vector<double> hessian_values{}; // workspace
+      Vector<double> hessian_buffer{}; // buffer used to evaluate the Hessian. Upon success, copy into the workspace
       Vector<size_t> hessian_permutation_vector{};
 
    protected:

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -9,7 +9,6 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
-#include "optimization/EvaluationErrors.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
@@ -28,7 +27,7 @@ namespace uno {
 
    void WoodburyEQPSolver::initialize_memory(const Subproblem& subproblem) {
       this->direction = Direction(subproblem.number_variables, subproblem.number_constraints);
-      this->hessian_buffer.resize(subproblem.number_hessian_nonzeros());
+      this->hessian_buffer.initialize(subproblem.number_hessian_nonzeros());
       // access the linear system of the linear solver
       auto& linear_system = this->linear_solver->get_linear_system();
       linear_system.initialize_augmented_system(subproblem);
@@ -120,16 +119,7 @@ namespace uno {
          View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
          View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
 
-         // try to evaluate the Hessian. Upon failure, keep the previous one
-         try {
-            subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
-            // success: copy the new Hessian into the linear system
-            hessian = this->hessian_buffer;
-         }
-         catch (const HessianEvaluationError&) {
-            // keep the existing Hessian in hessian
-            DEBUG << "The Hessian could not be evaluated by the Woodbury EQP solver, using the previous one\n";
-         }
+         this->hessian_buffer.evaluate_hessian(statistics, subproblem, current_iterate, hessian);
          subproblem.evaluate_jacobian(current_iterate, jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -9,6 +9,7 @@
 #include "ingredients/subproblem/Subproblem.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/EvaluationErrors.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
 #include "optimization/WarmstartInformation.hpp"
@@ -27,6 +28,7 @@ namespace uno {
 
    void WoodburyEQPSolver::initialize_memory(const Subproblem& subproblem) {
       this->direction = Direction(subproblem.number_variables, subproblem.number_constraints);
+      this->hessian_buffer.resize(subproblem.number_hessian_nonzeros());
       // access the linear system of the linear solver
       auto& linear_system = this->linear_solver->get_linear_system();
       linear_system.initialize_augmented_system(subproblem);
@@ -118,7 +120,16 @@ namespace uno {
          View jacobian(primal_inertia_correction.end(), number_jacobian_nonzeros);
          View dual_inertia_correction(jacobian.end(), number_dual_inertia_correction_nonzeros);
 
-         subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, hessian);
+         // try to evaluate the Hessian. Upon failure, keep the previous one
+         try {
+            subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
+            // success: copy the new Hessian into the linear system
+            hessian = this->hessian_buffer;
+         }
+         catch (const HessianEvaluationError&) {
+            // keep the existing Hessian in hessian
+            DEBUG << "The Hessian could not be evaluated by the Woodbury EQP solver, using the previous one\n";
+         }
          subproblem.evaluate_jacobian(current_iterate, jacobian, current_evaluations);
 
          // perform the symbolic analysis once and for all

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
@@ -8,6 +8,7 @@
 #include "DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "SubproblemSolver.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/HessianBuffer.hpp"
 
 namespace uno {
    // forward declarations
@@ -55,7 +56,7 @@ namespace uno {
       const DirectQuasiNewtonHessian& hessian_model;
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> linear_solver;
       bool analysis_performed{false};
-      Vector<double> hessian_buffer; // buffer used to evaluate the Hessian. Upon success, copy into the linear system
+      HessianBuffer hessian_buffer; // buffer used to evaluate the Hessian
 
       void compute_low_rank_correction(const Subproblem& subproblem, Vector<double>& b) const;
       [[nodiscard]] static bool solve_dense_indefinite_system(DenseMatrix<double>& T, const Vector<double>& c, Vector<double>& d);

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
@@ -55,6 +55,7 @@ namespace uno {
       const DirectQuasiNewtonHessian& hessian_model;
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> linear_solver;
       bool analysis_performed{false};
+      Vector<double> hessian_buffer; // buffer used to evaluate the Hessian. Upon success, copy into the linear system
 
       void compute_low_rank_correction(const Subproblem& subproblem, Vector<double>& b) const;
       [[nodiscard]] static bool solve_dense_indefinite_system(DenseMatrix<double>& T, const Vector<double>& c, Vector<double>& d);

--- a/uno/optimization/HessianBuffer.cpp
+++ b/uno/optimization/HessianBuffer.cpp
@@ -18,7 +18,7 @@ namespace uno {
       // try to evaluate the Hessian. Upon failure, keep the previous one
       try {
          subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
-         // success: copy the new Hessian into the linear system
+         // success: copy the new Hessian into the Hessian values
          hessian_values = this->hessian_buffer;
       }
       catch (const HessianEvaluationError&) {

--- a/uno/optimization/HessianBuffer.cpp
+++ b/uno/optimization/HessianBuffer.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#include "HessianBuffer.hpp"
+#include "ingredients/subproblem/Subproblem.hpp"
+#include "optimization/EvaluationErrors.hpp"
+#include "tools/Logger.hpp"
+
+namespace uno {
+   void HessianBuffer::initialize(size_t number_hessian_nonzeros) {
+      this->hessian_buffer.resize(number_hessian_nonzeros);
+   }
+
+   void HessianBuffer::evaluate_hessian(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         View<double> hessian_values) {
+      assert(this->hessian_buffer.size() == hessian_values.size());
+
+      // try to evaluate the Hessian. Upon failure, keep the previous one
+      try {
+         subproblem.evaluate_lagrangian_hessian(statistics, current_iterate, this->hessian_buffer.view());
+         // success: copy the new Hessian into the linear system
+         hessian_values = this->hessian_buffer;
+      }
+      catch (const HessianEvaluationError&) {
+         if (this->first_evaluation) {
+            hessian_values.fill(1.);
+            DEBUG << "The initial Hessian could not be evaluated, using the identity\n";
+         }
+         else {
+            // keep the existing Hessian
+            DEBUG << "The Hessian could not be evaluated, using the previous one\n";
+         }
+      }
+      this->first_evaluation = false;
+   }
+} // namespace

--- a/uno/optimization/HessianBuffer.hpp
+++ b/uno/optimization/HessianBuffer.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_HESSIANBUFFER_H
+#define UNO_HESSIANBUFFER_H
+
+#include "linear_algebra/Vector.hpp"
+
+namespace uno {
+   // forward declarations
+   class Iterate;
+   class Statistics;
+   class Subproblem;
+
+   class HessianBuffer {
+   public:
+      HessianBuffer() = default;
+      ~HessianBuffer() = default;
+
+      void initialize(size_t number_hessian_nonzeros);
+      void evaluate_hessian(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+         View<double> hessian_values);
+
+   protected:
+      Vector<double> hessian_buffer{};
+      bool first_evaluation{true};
+   };
+} // namespace
+
+#endif // UNO_HESSIANBUFFER_H


### PR DESCRIPTION
Use previous Hessian if evaluation fails.
The Hessian is evaluated in a buffer and copied to the actual workspace upon success. Upon failure, the previous Hessian is used.
If the initial Hessian cannot be evaluated, we revert to using the identity.