### PR TITLE
Fixed `InteriorPointMethod::initialize_feasibility_problem`

### DIFF
--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -148,6 +148,7 @@ namespace uno {
       this->previous_barrier_parameter = this->barrier_parameter();
       const double new_barrier_parameter = std::max(this->barrier_parameter(), current_iterate.primal_feasibility);
       this->barrier_parameter_update_strategy.set_barrier_parameter(new_barrier_parameter);
+      this->parameterization.set("barrier_parameter", this->barrier_parameter());
       DEBUG << "Barrier parameter mu temporarily updated to " << this->barrier_parameter() << '\n';
    }
 


### PR DESCRIPTION
Fixed `InteriorPointMethod::initialize_feasibility_problem`: refresh the parameterization with the new barrier parameter.