### PR TITLE
Attach progress measures and predicted reductions to `OptimizationProblem` and subclasses

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -191,9 +191,11 @@ namespace uno {
    }
 
    void FeasibilityRestoration::switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate,
-         Evaluations& trial_evaluations) {
+         Evaluations& current_evaluations, Evaluations& trial_evaluations) {
       DEBUG << "Switching from restoration back to optimality phase\n";
       this->current_phase = Phase::OPTIMALITY;
+      this->inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
+      this->inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);
       this->globalization_strategy->notify_switch_to_optimality(current_iterate.progress);
 
       // swap the iterate's multipliers and the optimality multipliers maintained by the class, and possibly compute
@@ -234,7 +236,7 @@ namespace uno {
       // possibly go from restoration phase to optimality phase
       if (accept_iterate && this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(model,
             trial_iterate, direction, step_length, current_evaluations)) {
-         this->switch_back_to_optimality_phase(current_iterate, trial_iterate, trial_evaluations);
+         this->switch_back_to_optimality_phase(current_iterate, trial_iterate, current_evaluations, trial_evaluations);
          // set a cold start in the subproblem solver
          warmstart_information.whole_problem_changed();
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -71,7 +71,8 @@ namespace uno {
       Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information);
-      void switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate, Evaluations& trial_evaluations);
+      void switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate, Evaluations& current_evaluations,
+         Evaluations& trial_evaluations);
 
       [[nodiscard]] bool can_switch_to_optimality_phase(const Model& model, const Iterate& trial_iterate,
          const Direction& direction, double step_length, Evaluations& current_evaluations) const;

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -8,6 +8,7 @@
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
 #include "symbolic/ScalarMultiple.hpp"
+#include "symbolic/Sum.hpp"
 #include "tools/Infinity.hpp"
 #include "tools/Logger.hpp"
 
@@ -346,6 +347,21 @@ namespace uno {
       }
    }
 
+   // progress measures
+
+   void l1RelaxedProblem::set_infeasibility_measure(Iterate& iterate, Evaluations& /*evaluations*/, Norm /*norm*/) const {
+      iterate.progress.infeasibility = 0.;
+   }
+
+   void l1RelaxedProblem::set_objective_measure(Iterate& iterate, Evaluations& evaluations) const {
+      evaluations.evaluate_constraints(this->model, iterate.primals);
+      const double scaled_constraint_violation = this->constraint_violation_coefficient *
+         this->model.constraint_violation(evaluations.constraints, Norm::L1);
+      iterate.progress.objective = [=](double /*objective_multiplier*/) {
+         return scaled_constraint_violation;
+      };
+   }
+
    void l1RelaxedProblem::set_auxiliary_measure(Iterate& iterate) const {
       iterate.progress.auxiliary = 0.;
       // form the proximal term: zeta/2 ||D_R (x - x_R)||^2
@@ -359,6 +375,33 @@ namespace uno {
          proximal_term *= (this->proximal_coefficient / 2.);
          iterate.progress.auxiliary = proximal_term;
       }
+   }
+
+   // predicted reductions
+
+   double l1RelaxedProblem::compute_predicted_infeasibility_reduction(const Iterate& /*current_iterate*/,
+         const Vector<double>& /*primal_direction*/, double /*step_length*/, Norm /*norm*/, Evaluations& /*current_evaluations*/) const {
+      return 0.;
+   }
+
+   std::function<double(double)> l1RelaxedProblem::compute_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
+         double /*hessian_quadratic_form*/) const {
+      // predicted infeasibility reduction: "‖c(x)‖ - ‖c(x) + ∇c(x)^T (αd)‖"
+      current_evaluations.evaluate_constraints(this->model, current_iterate.primals);
+      current_evaluations.evaluate_jacobian(this->model, current_iterate.primals);
+
+      const double current_constraint_violation = this->model.constraint_violation(current_evaluations.constraints, Norm::L1);
+      // TODO preallocate
+      Vector<double> result(this->model.number_constraints);
+      current_evaluations.compute_jacobian_vector_product(this->model, primal_direction.data(), result.data());
+      const double trial_linearized_constraint_violation = this->model.constraint_violation(current_evaluations.constraints +
+         step_length * result, Norm::L1);
+      const double predicted_reduction = this->constraint_violation_coefficient * (current_constraint_violation -
+         trial_linearized_constraint_violation);
+      return [=](double /*objective_multiplier*/) {
+         return predicted_reduction;
+      };
    }
 
    double l1RelaxedProblem::compute_predicted_auxiliary_reduction(const Iterate& current_iterate,

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -68,7 +68,16 @@ namespace uno {
       void set_elastic_variable_values(Iterate& iterate, const std::function<void(Iterate&, size_t, size_t, double)>& elastic_setting_function) const;
 
       // progress measures
+      void set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm norm) const override;
+      void set_objective_measure(Iterate& iterate, Evaluations& evaluations) const override;
       void set_auxiliary_measure(Iterate& iterate) const override;
+
+      // predicted reductions
+      [[nodiscard]] double compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const override;
+      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
+         double hessian_quadratic_form) const override;
       [[nodiscard]] double compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
          const Vector<double>& primal_direction, double step_length) const override;
 

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
@@ -48,7 +48,7 @@ namespace uno {
          statistics.set("Objective", evaluations.objective);
       }
       if (model.is_constrained()) {
-         statistics.set("Infeas", iterate.progress.infeasibility);
+         statistics.set("Infeas", iterate.primal_feasibility);
       }
    }
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -496,14 +496,22 @@ namespace uno {
       }
    }
 
+   void PrimalDualInteriorPointProblem::set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm norm) const {
+      this->inner.set_infeasibility_measure(iterate, evaluations, norm);
+   }
+
+   void PrimalDualInteriorPointProblem::set_objective_measure(Iterate& iterate, Evaluations& evaluations) const {
+      this->inner.set_objective_measure(iterate, evaluations);
+   }
+
    void PrimalDualInteriorPointProblem::set_auxiliary_measure(Iterate& iterate) const {
+      // start with the auxiliary measure of the initial problem
+      this->inner.set_auxiliary_measure(iterate);
+
       const double barrier_parameter = this->parameterization.get("barrier_parameter");
       if (is_infinite(barrier_parameter)) {
          throw std::runtime_error("Barrier parameter is infinite");
       }
-
-      // start with the auxiliary measure of the initial problem
-      this->inner.set_auxiliary_measure(iterate);
 
       // add the contribution of the barrier terms
       double barrier_terms = 0.;
@@ -529,6 +537,21 @@ namespace uno {
          throw std::runtime_error("The auxiliary measure is not an number.");
       }
       iterate.progress.auxiliary += barrier_terms;
+   }
+
+   // predicted reductions
+
+   double PrimalDualInteriorPointProblem::compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const {
+      return this->inner.compute_predicted_infeasibility_reduction(current_iterate, primal_direction, step_length, norm,
+         current_evaluations);
+   }
+
+   std::function<double(double)> PrimalDualInteriorPointProblem::compute_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
+         double hessian_quadratic_form) const {
+      return this->inner.compute_predicted_objective_reduction(current_iterate, primal_direction, step_length,
+         current_evaluations, hessian_quadratic_form);
    }
 
    double PrimalDualInteriorPointProblem::compute_predicted_auxiliary_reduction(const Iterate& current_iterate,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.hpp
@@ -71,7 +71,16 @@ namespace uno {
       void postprocess_iterate(Iterate& iterate) const override;
 
       // progress measures
+      void set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm norm) const override;
+      void set_objective_measure(Iterate& iterate, Evaluations& evaluations) const override;
       void set_auxiliary_measure(Iterate& iterate) const override;
+
+      // predicted reductions
+      [[nodiscard]] double compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const override;
+      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
+         double hessian_quadratic_form) const override;
       [[nodiscard]] double compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
          const Vector<double>& primal_direction, double step_length) const override;
 

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -264,44 +264,14 @@ namespace uno {
       return this->problem.dual_regularization_factor();
    }
 
-   // local models of progress measures
-   double Subproblem::compute_predicted_infeasibility_reduction(const Model& model, const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const {
-      // predicted infeasibility reduction: "‖c(x)‖ - ‖c(x) + ∇c(x)^T (αd)‖"
-      current_evaluations.evaluate_constraints(model, current_iterate.primals);
-      current_evaluations.evaluate_jacobian(model, current_iterate.primals);
-
-      const double current_constraint_violation = model.constraint_violation(current_evaluations.constraints, norm);
-      // TODO preallocate
-      Vector<double> result(model.number_constraints);
-      current_evaluations.compute_jacobian_vector_product(model, primal_direction.data(), result.data());
-      const double trial_linearized_constraint_violation = model.constraint_violation(current_evaluations.constraints +
-         step_length * result, norm);
-      return current_constraint_violation - trial_linearized_constraint_violation;
-   }
-
-   std::function<double(double)> Subproblem::compute_predicted_objective_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, const Evaluations& current_evaluations,
-         const SolverWorkspace& solver_workspace) const {
-      // predicted objective reduction: "-∇f(x)^T (αd) - α^2/2 d^T H d"
-      const double directional_derivative = dot(view(primal_direction, 0, this->problem.model.number_variables), current_evaluations.objective_gradient);
-      // if the regularized Hessian is positive definite (as it usually is in line-search methods), we can compute the
-      // predicted reduction with only first-order information (the directional derivative)
-      const bool is_regularized_hessian_positive_definite = this->hessian_model.is_positive_definite() || this->performs_primal_regularization();
-      const double quadratic_term = is_regularized_hessian_positive_definite ? 0. :
-         solver_workspace.compute_hessian_quadratic_form(*this, current_iterate, primal_direction);
-      return [=](double objective_multiplier) {
-         return step_length * (-objective_multiplier*directional_derivative) - step_length*step_length/2. * quadratic_term;
-      };
-   }
+   // predicted reductions
 
    ProgressMeasures Subproblem::compute_predicted_reductions(const Iterate& current_iterate, const Direction& direction,
          double step_length, Norm norm, Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const {
       return {
-         this->compute_predicted_infeasibility_reduction(this->problem.model, current_iterate, direction.primals, step_length,
-            norm, current_evaluations),
-         this->compute_predicted_objective_reduction(current_iterate, direction.primals, step_length, current_evaluations,
-            solver_workspace),
+         this->problem.compute_predicted_infeasibility_reduction(current_iterate, direction.primals, step_length, norm, current_evaluations),
+         this->problem.compute_predicted_objective_reduction(current_iterate, direction.primals, step_length, current_evaluations,
+            solver_workspace.compute_hessian_quadratic_form(*this, current_iterate, direction.primals)),
          this->problem.compute_predicted_auxiliary_reduction(current_iterate, direction.primals, step_length)
       };
    }

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -80,11 +80,6 @@ namespace uno {
       [[nodiscard]] double dual_regularization_factor() const;
 
       // local models of progress measures
-      [[nodiscard]] double compute_predicted_infeasibility_reduction(const Model& model, const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const;
-      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, const Evaluations& current_evaluations,
-         const SolverWorkspace& solver_workspace) const;
       [[nodiscard]] ProgressMeasures compute_predicted_reductions(const Iterate& current_iterate, const Direction& direction,
          double step_length, Norm norm, Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const;
 

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -38,7 +38,7 @@ namespace uno {
 
    void EQPSolver::compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) {
-      INFO << "Computing least-squares multipliers at initial point\n";
+      DEBUG << "Computing least-squares multipliers\n";
 
       // compute least-square multipliers
       auto& linear_system = this->linear_solver->get_linear_system();
@@ -78,7 +78,7 @@ namespace uno {
       }
 
       // solve the linear system
-      DEBUG << "KKT matrix values: " << linear_system.matrix_values << '\n';
+      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << '\n';
       this->linear_solver->solve_indefinite_system(linear_system.solution.data());
 
       // set the constraint multipliers if their norm is reasonable
@@ -136,7 +136,7 @@ namespace uno {
       }
 
       // solve the linear system
-      DEBUG << "KKT matrix values: " << linear_system.matrix_values << '\n';
+      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << '\n';
       this->linear_solver->solve_indefinite_system(linear_system.solution.data());
       if (this->linear_solver->matrix_is_singular()) {
          this->direction.status = SubproblemStatus::INFEASIBLE;

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -41,7 +41,7 @@ namespace uno {
 
    void WoodburyEQPSolver::compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate,
          Evaluations& evaluations, double multipliers_threshold) {
-      INFO << "Computing least-squares multipliers at initial point\n";
+      DEBUG << "Computing least-squares multipliers\n";
 
       // compute least-square multipliers
       auto& linear_system = this->linear_solver->get_linear_system();
@@ -81,7 +81,7 @@ namespace uno {
       }
 
       // solve the linear system
-      DEBUG << "KKT matrix values: " << linear_system.matrix_values << '\n';
+      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << '\n';
       this->linear_solver->solve_indefinite_system(linear_system.solution.data());
 
       // set the constraint multipliers if their norm is reasonable
@@ -139,7 +139,7 @@ namespace uno {
 
       // solve the linear system with only the diagonal part and store the result in solution_diagonal_part
       Vector<double> solution_diagonal_part(subproblem.number_variables + subproblem.number_constraints);
-      DEBUG << "KKT matrix values: " << linear_system.matrix_values << '\n';
+      DEBUG3 << "KKT matrix values: " << linear_system.matrix_values << '\n';
       this->linear_solver->solve_indefinite_system(solution_diagonal_part.data());
       if (this->linear_solver->matrix_is_singular()) {
          this->direction.status = SubproblemStatus::INFEASIBLE;

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -4,12 +4,11 @@
 #include "OptimizationProblem.hpp"
 #include "ingredients/hessian_models/HessianModel.hpp"
 #include "ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp"
-#include "linear_algebra/MatrixOrder.hpp"
-#include "linear_algebra/View.hpp"
-#include "model/Model.hpp"
 #include "optimization/Direction.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
+#include "symbolic/ScalarMultiple.hpp"
+#include "symbolic/Sum.hpp"
 #include "symbolic/UnaryNegation.hpp"
 #include "tools/Logger.hpp"
 
@@ -258,7 +257,8 @@ namespace uno {
       return SolutionStatus::NOT_OPTIMAL;
    }
 
-   // infeasibility measure: constraint violation
+   // progress measures
+
    void OptimizationProblem::set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm norm) const {
       evaluations.evaluate_constraints(this->model, iterate.primals);
       iterate.progress.infeasibility = this->model.constraint_violation(evaluations.constraints, norm);
@@ -275,6 +275,34 @@ namespace uno {
 
    void OptimizationProblem::set_auxiliary_measure(Iterate& iterate) const {
       iterate.progress.auxiliary = 0.;
+   }
+
+   // predicted reductions
+
+   double OptimizationProblem::compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const {
+      // predicted infeasibility reduction: "‖c(x)‖ - ‖c(x) + ∇c(x)^T (αd)‖"
+      current_evaluations.evaluate_constraints(this->model, current_iterate.primals);
+      current_evaluations.evaluate_jacobian(this->model, current_iterate.primals);
+
+      const double current_constraint_violation = this->model.constraint_violation(current_evaluations.constraints, norm);
+      // TODO preallocate
+      Vector<double> result(this->model.number_constraints);
+      current_evaluations.compute_jacobian_vector_product(this->model, primal_direction.data(), result.data());
+      const double trial_linearized_constraint_violation = this->model.constraint_violation(current_evaluations.constraints +
+         step_length * result, norm);
+      return current_constraint_violation - trial_linearized_constraint_violation;
+   }
+
+   std::function<double(double)> OptimizationProblem::compute_predicted_objective_reduction(const Iterate& /*current_iterate*/,
+         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
+         double hessian_quadratic_form) const {
+      // predicted objective reduction: "-∇f(x)^T (αd) - α^2/2 d^T H d"
+      const double directional_derivative = dot(view(primal_direction, 0, this->model.number_variables),
+         current_evaluations.objective_gradient);
+      return [=](double objective_multiplier) {
+         return step_length * (-objective_multiplier*directional_derivative) - step_length*step_length/2. * hessian_quadratic_form;
+      };
    }
 
    double OptimizationProblem::compute_predicted_auxiliary_reduction(const Iterate& /*current_iterate*/,

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -4,6 +4,7 @@
 #ifndef UNO_OPTIMIZATIONPROBLEM_H
 #define UNO_OPTIMIZATIONPROBLEM_H
 
+#include <functional>
 #include <memory>
 #include <vector>
 #include "ingredients/inertia_correction_strategies/Inertia.hpp"
@@ -103,6 +104,13 @@ namespace uno {
       virtual void set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm norm) const;
       virtual void set_objective_measure(Iterate& iterate, Evaluations& evaluations) const;
       virtual void set_auxiliary_measure(Iterate& iterate) const;
+
+      // predicted reductions
+      [[nodiscard]] virtual double compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const;
+      [[nodiscard]] virtual std::function<double(double)> compute_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
+         double hessian_quadratic_form) const;
       [[nodiscard]] virtual double compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
          const Vector<double>& primal_direction, double step_length) const;
 


### PR DESCRIPTION
Attach progress measures and predicted reductions to `OptimizationProblem` and subclasses, instead of the `Subproblem`. Now each reformulation can assemble their own progress measures + corresponding predicted reductions.