### PR TITLE
Do not overwrite the original direction during the SOC loop

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -35,8 +35,8 @@ namespace uno {
          EvaluationCache& evaluation_cache, Options& options) = 0;
 
       // direction computation
-      virtual Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
-         Evaluations& current_evaluations, WarmstartInformation& warmstart_information) = 0;
+      virtual const Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
+         double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) = 0;
       [[nodiscard]] virtual bool solving_feasibility_problem() const = 0;
       virtual void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
          WarmstartInformation& warmstart_information) = 0;

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -64,7 +64,7 @@ namespace uno {
       statistics.set("Phase", "OPT");
    }
 
-   Direction& FeasibilityRestoration::compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
+   const Direction& FeasibilityRestoration::compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
          double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
 
       // if we are in the optimality phase, solve the optimality problem
@@ -72,7 +72,7 @@ namespace uno {
          DEBUG << "Solving the optimality subproblem\n";
          statistics.set("Phase", "OPT");
          this->initial_point.fill(0.);
-         Direction& optimality_direction = this->solve_subproblem(statistics, *this->inequality_handling_method,
+         const Direction& optimality_direction = this->solve_subproblem(statistics, *this->inequality_handling_method,
             *this->globalization_strategy, current_iterate, trust_region_radius, current_evaluations, warmstart_information);
          if (optimality_direction.status == SubproblemStatus::INFEASIBLE) {
             // switch to the feasibility problem, starting from the current direction
@@ -91,7 +91,7 @@ namespace uno {
       DEBUG << "Solving the feasibility subproblem\n";
       statistics.set("Phase", "FEAS");
       // note: failure of regularization should not happen here, since the feasibility Jacobian has full rank
-      Direction& feasibility_direction = this->solve_subproblem(statistics, *this->feasibility_inequality_handling_method,
+      const Direction& feasibility_direction = this->solve_subproblem(statistics, *this->feasibility_inequality_handling_method,
          this->feasibility_globalization_strategy, current_iterate, trust_region_radius, current_evaluations,
          warmstart_information);
       return feasibility_direction;
@@ -155,7 +155,7 @@ namespace uno {
       }
    }
 
-   Direction& FeasibilityRestoration::solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
+   const Direction& FeasibilityRestoration::solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
       // if the problem definition changed, reset the globalization strategy and recompute the current auxiliary measure
@@ -164,8 +164,8 @@ namespace uno {
          inequality_handling_method.evaluate_progress_measures(current_iterate, current_evaluations); // TODO auxiliary
       }
 
-      Direction& direction = inequality_handling_method.solve(statistics, current_iterate, trust_region_radius, this->initial_point,
-         current_evaluations, warmstart_information);
+      const Direction& direction = inequality_handling_method.solve(statistics, current_iterate, trust_region_radius,
+         this->initial_point, current_evaluations, warmstart_information);
       ++this->number_subproblems_solved;
       this->initial_point.fill(0.);
       DEBUG3 << direction << '\n';

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -30,7 +30,7 @@ namespace uno {
          EvaluationCache& evaluation_cache, Options& options) override;
 
       // direction computation
-      Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
+      const Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
       void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,
@@ -68,7 +68,7 @@ namespace uno {
       Vector<double> reference_optimality_primals{};
       bool first_switch_to_feasibility{true};
 
-      Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
+      const Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information);
       void switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate, Evaluations& current_evaluations,

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -46,7 +46,7 @@ namespace uno {
       this->inequality_handling_method->initialize_statistics(statistics);
    }
 
-   Direction& NoRelaxation::compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
+   const Direction& NoRelaxation::compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
          double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
       DEBUG << "Solving the subproblem\n";
       const bool parameterization_updated = this->inequality_handling_method->update_parameterization(statistics,
@@ -58,7 +58,7 @@ namespace uno {
       }
 
       this->initial_point.fill(0.);
-      Direction& direction = this->inequality_handling_method->solve(statistics, current_iterate, trust_region_radius,
+      const Direction& direction = this->inequality_handling_method->solve(statistics, current_iterate, trust_region_radius,
          this->initial_point, current_evaluations, warmstart_information);
       DEBUG3 << direction << '\n';
       warmstart_information.no_changes();

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -23,7 +23,7 @@ namespace uno {
          EvaluationCache& evaluation_cache, Options& options) override;
 
       // direction computation
-      Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
+      const Direction& compute_feasible_direction(Statistics& statistics, Iterate& current_iterate,
          double trust_region_radius, Evaluations& current_evaluations, WarmstartInformation& warmstart_information) override;
       [[nodiscard]] bool solving_feasibility_problem() const override;
       void switch_to_feasibility_problem(Statistics& statistics, Iterate& current_iterate, Evaluations& current_evaluations,

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -223,7 +223,6 @@ namespace uno {
             if (is_acceptable) {
                // terminate the SOCs and the backtracking
                SOC_termination = true;
-               direction = direction_SOC;
                DEBUG << "SOC direction acceptable " << '\n';
             }
             else if (SOC_iteration >= this->SOC_max_iterations ||

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -45,7 +45,7 @@ namespace uno {
 
       // compute a feasible direction
       try {
-         Direction& direction = this->constraint_relaxation_strategy->compute_feasible_direction(statistics, current_iterate,
+         const Direction& direction = this->constraint_relaxation_strategy->compute_feasible_direction(statistics, current_iterate,
             INF<double>, evaluation_cache.current_evaluations, warmstart_information);
          BacktrackingLineSearch::check_unboundedness(direction);
          const bool backtracking_success = this->backtrack_along_direction(statistics, model, current_iterate, trial_iterate,
@@ -70,8 +70,8 @@ namespace uno {
       this->constraint_relaxation_strategy->switch_to_feasibility_problem(statistics, current_iterate,
          evaluation_cache.current_evaluations, warmstart_information);
       assert(this->constraint_relaxation_strategy->solving_feasibility_problem());
-      Direction& direction = this->constraint_relaxation_strategy->compute_feasible_direction(statistics, current_iterate,
-         INF<double>, evaluation_cache.current_evaluations, warmstart_information);
+      const Direction& direction = this->constraint_relaxation_strategy->compute_feasible_direction(statistics,
+         current_iterate, INF<double>, evaluation_cache.current_evaluations, warmstart_information);
       check_unboundedness(direction);
       const bool backtracking_success = this->backtrack_along_direction(statistics, model, current_iterate,
          trial_iterate, direction, evaluation_cache, warmstart_information, user_callbacks);
@@ -100,8 +100,8 @@ namespace uno {
    // go a fraction along the direction by finding an acceptable step length
    // returns true upon success, false upon failure
    bool BacktrackingLineSearch::backtrack_along_direction(Statistics& statistics, const Model& model, Iterate& current_iterate,
-         Iterate& trial_iterate, Direction& direction, EvaluationCache& evaluation_cache, WarmstartInformation& warmstart_information,
-         UserCallbacks& user_callbacks) {
+         Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
+         WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) {
       double step_length = 1.;
       bool termination = false;
       size_t number_iterations = 0;
@@ -191,7 +191,7 @@ namespace uno {
    }
 
    bool BacktrackingLineSearch::compute_second_order_directions(Statistics& statistics, const Model& model,
-         Iterate& current_iterate, Iterate& trial_iterate, Direction& direction, EvaluationCache& evaluation_cache,
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) {
       // enter second-order corrections
       DEBUG << "\nEntering second-order corrections\n";

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
@@ -39,11 +39,11 @@ namespace uno {
       void assemble_trial_iterate(const Model& model, Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
          double step_length) const;
       [[nodiscard]] bool backtrack_along_direction(Statistics& statistics, const Model& model, Iterate& current_iterate,
-         Iterate& trial_iterate, Direction& direction, EvaluationCache& evaluation_cache, WarmstartInformation& warmstart_information,
-         UserCallbacks& user_callbacks);
+         Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
+         WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks);
       [[nodiscard]] static bool is_tiny_direction(const Iterate& current_iterate, const Direction& direction);
       [[nodiscard]] bool compute_second_order_directions(Statistics& statistics, const Model& model, Iterate& current_iterate,
-         Iterate& trial_iterate, Direction& direction, EvaluationCache& evaluation_cache,
+         Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks);
       [[nodiscard]] double decrease_step_length(double step_length) const;
       static void check_unboundedness(const Direction& direction);

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -59,8 +59,8 @@ namespace uno {
             this->set_TR_statistics(statistics, number_iterations);
 
             // compute the direction within the trust region
-            Direction& direction = this->constraint_relaxation_strategy->compute_feasible_direction(statistics, current_iterate,
-               this->radius, evaluation_cache.current_evaluations, warmstart_information);
+            const Direction& direction = this->constraint_relaxation_strategy->compute_feasible_direction(statistics,
+               current_iterate, this->radius, evaluation_cache.current_evaluations, warmstart_information);
             statistics.set("||Step||", direction.norm);
 
             // deal with errors in the subproblem

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.hpp
@@ -30,8 +30,8 @@ namespace uno {
       const double primal_tolerance;
 
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const Model& model, Iterate& current_iterate,
-         Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache, WarmstartInformation& warmstart_information,
-         UserCallbacks& user_callbacks);
+         Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
+         WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks);
       void possibly_increase_radius(double step_norm);
       void decrease_radius(double step_norm);
       void decrease_radius();

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -32,8 +32,9 @@ namespace uno {
       virtual void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const = 0;
       virtual void initialize_statistics(Statistics& statistics) = 0;
       [[nodiscard]] virtual bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) = 0;
-      [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
-         const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) = 0;
+      [[nodiscard]] virtual const Direction& solve(Statistics& statistics, const Iterate& current_iterate,
+         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
+         const WarmstartInformation& warmstart_information) = 0;
 
       virtual void initialize_feasibility_problem(Iterate& current_iterate) = 0;
       virtual void set_elastic_variable_values(const l1RelaxedProblem& problem, Iterate& current_iterate, Evaluations& evaluations) = 0;

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -36,12 +36,10 @@ namespace uno {
       return false;
    }
 
-   Direction& NoInequalityReformulation::solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
+   const Direction& NoInequalityReformulation::solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
          const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) {
-      Direction& direction = this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius,
+      return this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius,
          initial_point, current_evaluations, warmstart_information);
-      direction.norm = norm_inf(view(direction.primals, 0, this->problem.get_number_original_variables()));
-      return direction;
    }
 
    void NoInequalityReformulation::initialize_feasibility_problem(Iterate& /*current_iterate*/) {

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
@@ -26,7 +26,7 @@ namespace uno {
       void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
       void initialize_statistics(Statistics& statistics) override;
       [[nodiscard]] bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) override;
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
+      [[nodiscard]] const Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
          const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
 
       void initialize_feasibility_problem(Iterate& current_iterate) override;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -30,7 +30,7 @@ namespace uno {
       void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
       void initialize_statistics(Statistics& statistics) override;
       [[nodiscard]] bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) override;
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
+      [[nodiscard]] const Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
          const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
 
       void initialize_feasibility_problem(Iterate& current_iterate) override;
@@ -131,13 +131,11 @@ namespace uno {
    }
 
    template <typename BarrierProblem>
-   Direction& InteriorPointMethod<BarrierProblem>::solve(Statistics& statistics, const Iterate& current_iterate,
+   const Direction& InteriorPointMethod<BarrierProblem>::solve(Statistics& statistics, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
-      Direction& direction = this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius,
+      return this->subproblem_solver->solve(statistics, *this->subproblem, current_iterate, trust_region_radius,
          initial_point, current_evaluations, warmstart_information);
-      direction.norm = norm_inf(view(direction.primals, 0, this->barrier_problem.get_number_original_variables()));
-      return direction;
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
@@ -25,7 +25,7 @@ namespace uno {
       DEBUG << "The box LP solver does not compute least-squares multipliers, keeping existing multipliers";
    }
 
-   Direction& BoxLPSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
+   const Direction& BoxLPSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& /*warmstart_information*/) {
       if (0 < subproblem.number_constraints) {
@@ -63,6 +63,7 @@ namespace uno {
          }
          this->direction.subproblem_objective += this->workspace.objective_gradient[variable_index] * this->direction.primals[variable_index];
       }
+      direction.norm = norm_inf(view(direction.primals, 0, subproblem.problem.get_number_original_variables()));
       return this->direction;
    }
 

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
@@ -33,7 +33,7 @@ namespace uno {
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+      [[nodiscard]] const Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) override;
 

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -92,7 +92,7 @@ namespace uno {
       }
    }
 
-   Direction& EQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+   const Direction& EQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
       if (is_finite(trust_region_radius)) {
@@ -143,6 +143,7 @@ namespace uno {
          // assemble the full primal-dual direction
          subproblem.assemble_primal_dual_direction(current_iterate, linear_system.solution, this->direction);
       }
+      direction.norm = norm_inf(view(direction.primals, 0, subproblem.problem.get_number_original_variables()));
       return this->direction;
    }
 

--- a/uno/ingredients/subproblem_solvers/EQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.hpp
@@ -24,7 +24,7 @@ namespace uno {
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+      [[nodiscard]] const Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) override;
 

--- a/uno/ingredients/subproblem_solvers/IQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.cpp
@@ -31,7 +31,7 @@ namespace uno {
       DEBUG << "The EQP solver does not compute least-squares multipliers, keeping existing multipliers";
    }
 
-   Direction& IQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+   const Direction& IQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
       this->direction.reset();
@@ -44,6 +44,7 @@ namespace uno {
 
       // compute the dual direction
       compute_dual_direction(subproblem, current_iterate, this->direction.multipliers);
+      direction.norm = norm_inf(view(direction.primals, 0, subproblem.problem.get_number_original_variables()));
       return this->direction;
    }
 

--- a/uno/ingredients/subproblem_solvers/IQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.hpp
@@ -30,7 +30,7 @@ namespace uno {
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+      [[nodiscard]] const Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) override;
 

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
@@ -30,7 +30,7 @@ namespace uno {
       DEBUG << "The inverse Newton solver does not compute least-squares multipliers, keeping existing multipliers";
    }
 
-   Direction& InverseNewtonSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
+   const Direction& InverseNewtonSolver::solve(Statistics& /*statistics*/, const Subproblem& subproblem, const Iterate& current_iterate,
          [[maybe_unused]] double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& /*warmstart_information*/) {
       assert(is_infinite(trust_region_radius));
@@ -43,6 +43,7 @@ namespace uno {
       // compute the Newton step d = -H⁻¹ g
       this->hessian_model.compute_inverse_hessian_vector_product(current_iterate.primals.data(),
          this->rhs.data(), this->direction.primals.data());
+      direction.norm = norm_inf(view(direction.primals, 0, subproblem.problem.get_number_original_variables()));
       return this->direction;
    }
 

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
@@ -35,7 +35,7 @@ namespace uno {
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+      [[nodiscard]] const Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) override;
 

--- a/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
@@ -27,9 +27,9 @@ namespace uno {
       virtual void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) = 0;
 
-      [[nodiscard]] virtual Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
-         double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
-         const WarmstartInformation& warmstart_information) = 0;
+      [[nodiscard]] virtual const Direction& solve(Statistics& statistics, const Subproblem& subproblem,
+         const Iterate& current_iterate, double trust_region_radius, const Vector<double>& initial_point,
+         Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) = 0;
 
       [[nodiscard]] virtual bool has_second_order_corrections() const = 0;
       virtual const Direction& compute_second_order_correction(const Subproblem& subproblem, const Iterate& current_iterate,

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -95,7 +95,7 @@ namespace uno {
       }
    }
 
-   Direction& WoodburyEQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+   const Direction& WoodburyEQPSolver::solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& /*initial_point*/, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) {
       if (is_finite(trust_region_radius)) {
@@ -150,6 +150,7 @@ namespace uno {
          // assemble the full primal-dual direction
          subproblem.assemble_primal_dual_direction(current_iterate, solution_diagonal_part, this->direction);
       }
+      direction.norm = norm_inf(view(direction.primals, 0, subproblem.problem.get_number_original_variables()));
       return this->direction;
    }
 

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
@@ -40,7 +40,7 @@ namespace uno {
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 
-      [[nodiscard]] Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
+      [[nodiscard]] const Direction& solve(Statistics& statistics, const Subproblem& subproblem, const Iterate& current_iterate,
          double trust_region_radius, const Vector<double>& initial_point, Evaluations& current_evaluations,
          const WarmstartInformation& warmstart_information) override;
 


### PR DESCRIPTION
The original direction need not be overwritten by the SOC direction. What's needed as an output of the function is the trial iterate.