### PR TITLE
[CI] Update to HiGHS v1.15.1 and MUMPS v5.9.1

### DIFF
--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -132,6 +132,12 @@ meson install -C builddir
 # Compile HiGHS
 cd $WORKSPACE/srcdir/HiGHS
 
+# Patch v1.15.1 (see https://github.com/JuliaPackaging/Yggdrasil/tree/master/H/HiGHS/bundled/patches)
+# fix-cli11.patch
+sed -i 's/(*opt)/opt->count() > 0/' extern/cli11/CLI11.hpp
+# fix-destroy.patch
+sed -i 's/Highs::resetGlobalScheduler(true);//' highs/interfaces/highs_c_api.cpp
+
 mkdir build
 cd build
 cmake .. \

--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -13,9 +13,9 @@ sources = [
     # SPRAL v2025.9.18
     GitSource("https://github.com/ralna/spral.git",
               "80bc843ac3847d4a783a0e11213715a70175aee6"),
-    # MUMPS v5.9.0
-    ArchiveSource("https://mumps-solver.org/MUMPS_5.9.0.tar.gz",
-                  "02c6efdb91749ec0f82351d40f3f860547272a1eb1d899126a4265b4d6bcc4ca"),
+# MUMPS v5.9.1
+ArchiveSource("https://mumps-solver.org/MUMPS_5.9.1.tar.gz",
+"659c9b57646b5a003ac618baa1faf9dd2044e46c732b3daaccbc7158003e1b46"),
     # HiGHS v1.15.1
     GitSource("https://github.com/ERGO-Code/HiGHS.git",
               "04024d701f79feb8e2f18bc3df0dffc04ef05088"),

--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -13,9 +13,9 @@ sources = [
     # SPRAL v2025.9.18
     GitSource("https://github.com/ralna/spral.git",
               "80bc843ac3847d4a783a0e11213715a70175aee6"),
-# MUMPS v5.9.1
-ArchiveSource("https://mumps-solver.org/MUMPS_5.9.1.tar.gz",
-"659c9b57646b5a003ac618baa1faf9dd2044e46c732b3daaccbc7158003e1b46"),
+    # MUMPS v5.9.1
+    ArchiveSource("https://mumps-solver.org/MUMPS_5.9.1.tar.gz",
+                  "659c9b57646b5a003ac618baa1faf9dd2044e46c732b3daaccbc7158003e1b46"),
     # HiGHS v1.15.1
     GitSource("https://github.com/ERGO-Code/HiGHS.git",
               "04024d701f79feb8e2f18bc3df0dffc04ef05088"),
@@ -46,7 +46,7 @@ fi
 cd ${prefix}
 cp -rL share/licenses deps/licenses
 mkdir deps/licenses/MUMPS
-cp $WORKSPACE/srcdir/MUMPS_5.9.0/LICENSE deps/licenses/MUMPS/LICENSE
+cp $WORKSPACE/srcdir/MUMPS_5.9.1/LICENSE deps/licenses/MUMPS/LICENSE
 mkdir deps/licenses/spral
 cp $WORKSPACE/srcdir/spral/LICENCE deps/licenses/spral/LICENCE
 chmod -R u=rwx deps

--- a/.github/julia/build_tarballs_release.jl
+++ b/.github/julia/build_tarballs_release.jl
@@ -16,9 +16,9 @@ sources = [
     # MUMPS v5.9.0
     ArchiveSource("https://mumps-solver.org/MUMPS_5.9.0.tar.gz",
                   "02c6efdb91749ec0f82351d40f3f860547272a1eb1d899126a4265b4d6bcc4ca"),
-    # HiGHS v1.15.0
+    # HiGHS v1.15.1
     GitSource("https://github.com/ERGO-Code/HiGHS.git",
-              "83960019015b0d5152df73110ff142f328edcfd2"),
+              "04024d701f79feb8e2f18bc3df0dffc04ef05088"),
     # Hwloc v2.13.0
     ArchiveSource("https://download.open-mpi.org/release/hwloc/v2.13/hwloc-2.13.0.tar.bz2",
                   "52e936afb6ebd80f171f763fcf14f7b1f5ce98b125af5dd2f328b873b1fd0dab"),
@@ -242,6 +242,6 @@ build_tarballs(
     products,
     dependencies;
     julia_compat = "1.6",
-    preferred_gcc_version = v"10.2.0",
+    preferred_gcc_version = v"11",
     clang_use_lld=false,
 )

--- a/.github/julia/build_tarballs_utils.jl
+++ b/.github/julia/build_tarballs_utils.jl
@@ -5,7 +5,7 @@
 using BinaryBuilder, Pkg
 
 name = "UnoUtils"
-version = v"2026.8.21"
+version = v"2026.8.24"
 
 # Collection of sources
 sources = [
@@ -214,7 +214,7 @@ cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=OFF \
     -DZLIB=OFF \
-    -DHIPO=ON \
+    -DHIPO=OFF \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_TESTING=OFF \
     -DBUILD_CXX_EXE=OFF \

--- a/.github/julia/build_tarballs_utils.jl
+++ b/.github/julia/build_tarballs_utils.jl
@@ -5,7 +5,7 @@
 using BinaryBuilder, Pkg
 
 name = "UnoUtils"
-version = v"2026.7.2"
+version = v"2026.8.21"
 
 # Collection of sources
 sources = [
@@ -28,12 +28,12 @@ sources = [
     # OpenBLAS v0.3.31
     # ArchiveSource("https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.31/OpenBLAS-0.3.31.tar.gz",
     #               "6dd2a63ac9d32643b7cc636eab57bf4e57d0ed1fff926dfbc5d3d97f2d2be3a6"),
-    # MUMPS v5.9.0
-    ArchiveSource("https://mumps-solver.org/MUMPS_5.9.0.tar.gz",
-                  "02c6efdb91749ec0f82351d40f3f860547272a1eb1d899126a4265b4d6bcc4ca"),
-    # HiGHS v1.15.0
+    # MUMPS v5.9.1
+    ArchiveSource("https://mumps-solver.org/MUMPS_5.9.1.tar.gz",
+                  "659c9b57646b5a003ac618baa1faf9dd2044e46c732b3daaccbc7158003e1b46"),
+    # HiGHS v1.15.1
     GitSource("https://github.com/ERGO-Code/HiGHS.git",
-              "83960019015b0d5152df73110ff142f328edcfd2"),
+              "04024d701f79feb8e2f18bc3df0dffc04ef05088"),
     # SPRAL v2025.9.18
     GitSource("https://github.com/ralna/spral.git",
               "80bc843ac3847d4a783a0e11213715a70175aee6"),
@@ -62,6 +62,10 @@ if [ $target = "x86_64-w64-mingw32" ] || [ $target = "i686-w64-mingw32" ]; then
     atomic_patch -p1 $WORKSPACE/srcdir/0004-Fix-GKLIB_PATH-default-for-out-of-tree-builds.patch
 fi
 atomic_patch -p1 $WORKSPACE/srcdir/005-add-ifndefs.patch
+
+# fix CMake version
+sed -i 's/VERSION 2.8/VERSION 3.5/' CMakeLists.txt
+
 mkdir -p build
 cd build
 cmake .. \
@@ -195,6 +199,13 @@ meson install -C builddir
 
 ## ----- Compile HiGHS -----
 cd $WORKSPACE/srcdir/HiGHS
+
+# Patch v1.15.1 (see https://github.com/JuliaPackaging/Yggdrasil/tree/master/H/HiGHS/bundled/patches)
+# fix-cli11.patch
+sed -i 's/(*opt)/opt->count() > 0/' extern/cli11/CLI11.hpp
+# fix-destroy.patch
+sed -i 's/Highs::resetGlobalScheduler(true);//' highs/interfaces/highs_c_api.cpp
+
 mkdir build
 cd build
 cmake .. \

--- a/.github/julia/build_tarballs_yggdrasil.jl
+++ b/.github/julia/build_tarballs_yggdrasil.jl
@@ -97,7 +97,7 @@ products = [
 
 dependencies = [
     BuildDependency(PackageSpec(name="BQPD_jll", uuid="1325ac01-0a49-589f-8355-43321054aaab")),
-    Dependency(PackageSpec(name="HiGHS_jll", uuid="8fd58aa0-07eb-5a78-9b36-339c94fd15ea"), compat="=1.15.0"),
+    Dependency(PackageSpec(name="HiGHS_jll", uuid="8fd58aa0-07eb-5a78-9b36-339c94fd15ea"), compat="=1.15.1"),
     Dependency(PackageSpec(name="HSL_jll", uuid="017b0a0e-03f4-516a-9b91-836bbd1904dd")),
     Dependency(PackageSpec(name="METIS_jll", uuid="d00139f3-1899-568f-a2f0-47f597d42d70")),
     Dependency(PackageSpec(name="ASL_jll", uuid="ae81ac8f-d209-56e5-92de-9978fef736f9"), compat="0.1.3"),

--- a/.github/julia/build_tarballs_yggdrasil.jl
+++ b/.github/julia/build_tarballs_yggdrasil.jl
@@ -124,6 +124,6 @@ build_tarballs(
     products,
     dependencies;
     julia_compat = "1.9",
-    preferred_gcc_version = v"10.2.0",
+    preferred_gcc_version = v"11",
     clang_use_lld=false,
 )

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -38,8 +38,8 @@ curl -L -o BQPD.tar.gz "$ASSET_URL"
 tar -xzf BQPD.tar.gz
 pwd
 
-# download UnoUtils: MUMPS (+ METIS, BLAS and LAPACK)
-VERSION="2026.7.2"
+# download UnoUtils: MUMPS (+ METIS, BLAS and LAPACK) and HiGHS
+VERSION="2026.8.21"
 REPO="https://github.com/amontoison/UnoUtils_jll.jl/releases/download/UnoUtils-v${VERSION}%2B0"
 ASSET_NAME="UnoUtils.v${VERSION}.${ARCH}-${OS}-libgfortran5-cxx11.tar.gz"
 ASSET_URL="${REPO}/${ASSET_NAME}"
@@ -68,6 +68,12 @@ if [[ "$OS" == "w64-mingw32" && "${UNO_TOOLCHAIN:-mingw}" == "mingw" ]]; then
 	echo "Downloading: ${ASSET_URL}"
 	curl -fL -o "${BUILD_ROOT}/HiGHS-src.tar.gz" "$ASSET_URL"
 	tar -xzf "${BUILD_ROOT}/HiGHS-src.tar.gz" -C "${BUILD_ROOT}/HiGHS" --strip-components=1
+
+	# Patch v1.15.1 (see https://github.com/JuliaPackaging/Yggdrasil/tree/master/H/HiGHS/bundled/patches)
+	# fix-cli11.patch
+	sed -i 's/(*opt)/opt->count() > 0/' "${BUILD_ROOT}/HiGHS/extern/cli11/CLI11.hpp"
+	# fix-destroy.patch
+	sed -i 's/Highs::resetGlobalScheduler(true);//' "${BUILD_ROOT}/HiGHS/highs/interfaces/highs_c_api.cpp"
 
 	# Build HiGHS with the SAME compiler the consuming workflow links with.
 	# A mismatch here is what produces the __emutls_v._ZSt*__once_call* and

--- a/dependencies/scripts/download_dependencies.sh
+++ b/dependencies/scripts/download_dependencies.sh
@@ -39,7 +39,7 @@ tar -xzf BQPD.tar.gz
 pwd
 
 # download UnoUtils: MUMPS (+ METIS, BLAS and LAPACK) and HiGHS
-VERSION="2026.8.21"
+VERSION="2026.8.24"
 REPO="https://github.com/amontoison/UnoUtils_jll.jl/releases/download/UnoUtils-v${VERSION}%2B0"
 ASSET_NAME="UnoUtils.v${VERSION}.${ARCH}-${OS}-libgfortran5-cxx11.tar.gz"
 ASSET_URL="${REPO}/${ASSET_NAME}"
@@ -105,7 +105,7 @@ if [[ "$OS" == "w64-mingw32" && "${UNO_TOOLCHAIN:-mingw}" == "mingw" ]]; then
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=OFF \
 		-DZLIB=OFF \
-		-DHIPO=ON \
+		-DHIPO=OFF \
 		-DBUILD_EXAMPLES=OFF \
 		-DBUILD_TESTING=OFF \
 		-DBUILD_CXX_EXE=OFF \


### PR DESCRIPTION
- [x] Bumped HiGHS_jll compat to 1.15.1. MUMPS' compat is already OK
- [x] Updated to HiGHS 1.15.1 in `build_tarballs_release.jl`
- [x] Updated to MUMPS 5.9.1 in `build_tarballs_release.jl`
- [x] Apply HiGHS patch manually in `build_tarballs_release.jl`
- [x] Updated Project.toml to HiGHS 1.15.1 on self-hosted runners. MUMPS' compat is already OK
- [x] Set `preferred_gcc_version` to 11
- [x] Updated UnoUtils with HiGHS 1.15.1 and MUMPS 5.9.1
- [x] Apply HiGHS patch manually in `build_tarballs_utils.jl`

See https://github.com/JuliaPackaging/Yggdrasil/issues/14503

We're leaving out HiPO for now.