### PR TITLE
Fixed `get_dual_regularization_constraints` in `l1RelaxedProblem` and `PrimalDualInteriorPointProblem`

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -28,6 +28,7 @@ namespace uno {
          number_elastic_variables(this->elastic_variables.size()),
          objective_multiplier(objective_multiplier),
          constraint_violation_coefficient(constraint_violation_coefficient),
+         dual_regularization_constraints(this->number_constraints),
          variables_lower_bounds(this->number_variables, 0.),
          variables_upper_bounds(this->number_variables, INF<double>),
          jacobian_row_indices(this->model.number_jacobian_nonzeros() + this->elastic_variables.size()),

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -89,7 +89,7 @@ namespace uno {
       const double constraint_violation_coefficient;
       double proximal_coefficient{0.};
       double* proximal_center{};
-      const IntegerRange dual_regularization_constraints{0};
+      const IntegerRange dual_regularization_constraints;
 
       std::vector<double> variables_lower_bounds;
       std::vector<double> variables_upper_bounds;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -296,13 +296,7 @@ namespace uno {
    }
 
    const Collection<size_t>& PrimalDualInteriorPointProblem::get_dual_regularization_constraints() const {
-      if (this->inner.get_dual_regularization_constraints().empty()) {
-         // this is an indication that the constraints (if there is any) were already regularized in a previous
-         // reformulation (e.g. l1 relaxation). In that case, we stick to an empty set
-         return this->inner.get_dual_regularization_constraints();
-      }
-      // otherwise, we pick the set of equality constraints, since the inequality constraints have slacks
-      return this->inner.get_equality_constraints();
+      return this->inner.get_dual_regularization_constraints();
    }
 
    Inertia PrimalDualInteriorPointProblem::get_inertia() const {


### PR DESCRIPTION
Dual inertia correction should be applied to *all* constraints. Slacks and elastics guarantee a structural full rank Jacobian, but as these variables approach their bounds, the barrier entries may mess up the estimated inertia.