### PR TITLE
Fixed quasi-Newton update guards

### DIFF
--- a/uno/ingredients/hessian_models/quasi_newton/QuasiNewtonHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/QuasiNewtonHessian.cpp
@@ -80,8 +80,8 @@ namespace uno {
       this->S.column(newest_slot) = this->latest_s;
       this->Y.column(newest_slot) = this->latest_y;
       DEBUG << "Committed (s, y) at slot " << newest_slot << " (" << this->number_entries_in_memory << " entries in memory)\n";
-      DEBUG << "> S: " << this->S;
-      DEBUG << "> Y: " << this->Y;
+      DEBUG << "> S: " << this->S << '\n';
+      DEBUG << "> Y: " << this->Y << '\n';
       return newest_slot;
    }
 

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LBFGSHessian.cpp
@@ -45,13 +45,12 @@ namespace uno {
       // compute the candidate pair (s, y) WITHOUT modifying the memory yet, so that a skipped update is a true no-op
       this->compute_candidate_pair(current_iterate, trial_iterate, current_evaluations, trial_evaluations);
 
-      // safeguard: if dot(sk, yk) is too small relative to sk and yk, skip the update
+      // safeguard: if dot(sk, yk) is too small relative to sk, skip the update
       // TODO compare against Procedure 18.2 (Damped BFGS Updating) from Numerical Optimization
       const double norm_sk = norm_2(this->latest_s);
-      const double norm_yk = norm_2(this->latest_y);
       const double sTy = dot(this->latest_s, this->latest_y);
       // tolerance is √(machine epsilon)
-      if (sTy <= std::sqrt(std::numeric_limits<double>::epsilon()) * norm_sk * norm_yk) {
+      if (sTy <= std::sqrt(std::numeric_limits<double>::epsilon()) * norm_sk) {
          DEBUG << "dot(sk, yk) is too small, skipping the update\n";
          ++this->consecutive_skips;
          if (this->consecutive_skips >= this->max_skips_before_reset) {

--- a/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/direct/LSR1Hessian.cpp
@@ -36,18 +36,8 @@ namespace uno {
       // compute the candidate pair (s, y) WITHOUT modifying the memory yet
       this->compute_candidate_pair(current_iterate, trial_iterate, current_evaluations, trial_evaluations);
 
-      // safeguard: if dot(sk, yk) is too small relative to sk and yk, skip the update
-      const double norm_sk = norm_2(this->latest_s);
-      const double norm_yk = norm_2(this->latest_y);
-      // tolerance is √(machine epsilon)
-      if (dot(this->latest_s, this->latest_y) < std::sqrt(std::numeric_limits<double>::epsilon()) * norm_sk * norm_yk) {
-         DEBUG << "dot(sk, yk) is too small, skipping the update\n";
-      }
-      else {
-         // the curvature test passed; the candidate is validated (N factorization) and committed lazily in
-         // recompute_hessian_representation, before its next use. It may still be rejected there if N is singular.
-         this->hessian_recomputation_required = true;
-      }
+      // the candidate may still be rejected if N is singular
+      this->hessian_recomputation_required = true;
       statistics.set("|SR1|", this->number_entries_in_memory);
    }
 

--- a/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
+++ b/uno/ingredients/hessian_models/quasi_newton/inverse/InverseLBFGSHessian.cpp
@@ -51,12 +51,11 @@ namespace uno {
       // compute the candidate pair (s, y) WITHOUT modifying the memory yet
       this->compute_candidate_pair(current_iterate, trial_iterate, current_evaluations, trial_evaluations);
 
-      // safeguard: if dot(sk, yk) is too small relative to sk and yk, skip the update
+      // safeguard: if dot(sk, yk) is too small relative to sk, skip the update
       const double norm_sk = norm_2(this->latest_s);
-      const double norm_yk = norm_2(this->latest_y);
       const double sTy = dot(this->latest_s, this->latest_y);
       // tolerance is √(machine epsilon)
-      if (sTy <= std::sqrt(std::numeric_limits<double>::epsilon()) * norm_sk * norm_yk) {
+      if (sTy <= std::sqrt(std::numeric_limits<double>::epsilon()) * norm_sk) {
          DEBUG << "dot(sk, yk) is too small, skipping the update\n";
       }
       else {


### PR DESCRIPTION
- Fixed update guard for L-BFGS and inverse L-BFGS: use the Rayleigh quotient (sᵀy ≤ √ε · sᵀs)
- Removed curvature test in L-SR1 (candidate rejected when N is singular)