### PR TITLE
Allow the user to set the model name

### DIFF
--- a/docs/interfaces/python.md
+++ b/docs/interfaces/python.md
@@ -28,6 +28,10 @@ model = unopy.Model(problem_type, number_variables, base_indexing)
 ```
 
 The following optional elements can be added or set to the model separately:
+- a name for the model (used in Uno's logs and outputs):
+```python
+model.set_name(name)
+```
 - lower bounds for the variables:
 ```python
 model.set_variables_lower_bounds(variables_lower_bounds)

--- a/interfaces/C/README.md
+++ b/interfaces/C/README.md
@@ -24,6 +24,10 @@ void* model = uno_create_unconstrained_model(problem_type, number_variables, bas
 ```
 
 The following optional elements can be added or set to the model separately:
+- a name for the model (used in Uno's logs and outputs):
+```c
+uno_set_model_name(model, name)
+```
 - lower bounds for the variables:
 ```c
 uno_set_variables_lower_bounds(model, variables_lower_bounds)

--- a/interfaces/C/Uno_C_API.cpp
+++ b/interfaces/C/Uno_C_API.cpp
@@ -35,7 +35,8 @@ using CUserModel = UserModel<uno_objective_callback, uno_objective_gradient_call
 class UnoModel: public Model {
 public:
    explicit UnoModel(const CUserModel& user_model):
-         Model("C model", static_cast<size_t>(user_model.number_variables), static_cast<size_t>(user_model.number_constraints),
+         Model(user_model.name.empty() ? "C model" : user_model.name,
+            static_cast<size_t>(user_model.number_variables), static_cast<size_t>(user_model.number_constraints),
             static_cast<double>(user_model.optimization_sense), static_cast<double>(user_model.lagrangian_sign_convention),
             user_model.base_indexing),
          user_model(user_model),
@@ -487,6 +488,16 @@ void* uno_create_unconstrained_model(const char* problem_type, uno_int number_va
       user_model->initial_primal_iterate[variable_index] = 0.;
    }
    return user_model;
+}
+
+bool uno_set_model_name(void* model, const char* name) {
+   if (model == nullptr) {
+      WARNING << "Please specify a valid model."  << std::endl;
+      return false;
+   }
+   CUserModel* user_model = static_cast<CUserModel*>(model);
+   user_model->name = (name != nullptr) ? name : "";
+   return true;
 }
 
 bool uno_set_variables_lower_bounds(void* model, const double* variables_lower_bounds) {

--- a/interfaces/C/Uno_C_API.h
+++ b/interfaces/C/Uno_C_API.h
@@ -164,6 +164,12 @@ extern "C" {
    void* uno_create_unconstrained_model(const char* problem_type, uno_int number_variables, uno_int base_indexing);
 
    // [optional]
+   // sets the name of a given model (used e.g. in logs and KKT system dumps).
+   // an empty name falls back to the interface default.
+   // returns true if it succeeded, false otherwise.
+   bool uno_set_model_name(void* model, const char* name);
+
+   // [optional]
    // sets the variables lower bounds of a given model.
    // takes as inputs an array of lower bounds of size "number_variables".
    // returns true if it succeeded, false otherwise.

--- a/interfaces/C/example/example_hs015.c
+++ b/interfaces/C/example/example_hs015.c
@@ -136,6 +136,7 @@ int main() {
 
    void* model = uno_create_model(UNO_PROBLEM_NONLINEAR, number_variables, variables_lower_bounds,
       variables_upper_bounds, base_indexing);
+   uno_set_model_name(model, "hs015");
    uno_set_objective(model, optimization_sense, objective_function, objective_gradient);
    uno_set_constraints(model, number_constraints, constraint_functions,
       constraints_lower_bounds, constraints_upper_bounds, number_jacobian_nonzeros,

--- a/interfaces/Fortran/README.md
+++ b/interfaces/Fortran/README.md
@@ -74,6 +74,12 @@ model = uno_create_unconstrained_model(problem_type, number_variables, &
 ```
 
 The following optional elements can be added or set to the model separately:
+* a name for the model (used in Uno's logs and outputs):
+```fortran
+logical(c_bool) :: success
+success = uno_set_model_name(model, name)
+```
+
 * lower bounds for the variables:
 ```fortran
 logical(c_bool) :: success

--- a/interfaces/Fortran/example_uno.f90
+++ b/interfaces/Fortran/example_uno.f90
@@ -94,6 +94,7 @@ program example_uno
     !---------------------------------------------------
     model = uno_create_model(problem_type, number_variables, variables_lower_bounds, variables_upper_bounds, base_indexing)
 
+    success = uno_set_model_name(model, "hs015")
     success = uno_set_objective(model, optimization_sense, objective, gradient)
     success = uno_set_constraints(model, number_constraints, constraints, constraints_lower_bounds, constraints_upper_bounds, &
                                   number_jacobian_nonzeros, jacobian_row_indices, jacobian_column_indices, jacobian)

--- a/interfaces/Fortran/uno_fortran.f90
+++ b/interfaces/Fortran/uno_fortran.f90
@@ -84,6 +84,37 @@ function uno_create_unconstrained_model(problem_type, number_variables, base_ind
 end function uno_create_unconstrained_model
 
 !---------------------------------------------
+! uno_set_model_name
+!---------------------------------------------
+function uno_set_model_name(model, name) result(success)
+   type(c_ptr), value :: model
+   character(len=*) :: name
+   logical(c_bool) :: success
+   character(c_char), allocatable :: name_c(:)
+   integer :: i, n
+
+   interface
+      function uno_set_model_name_c(model, name) &
+         result(success) &
+         bind(C, name="uno_set_model_name")
+         import :: c_ptr, c_char, c_bool
+         type(c_ptr), value :: model
+         character(c_char) :: name(*)
+         logical(c_bool) :: success
+      end function uno_set_model_name_c
+   end interface
+
+   n = len_trim(name)
+   allocate(name_c(n+1))
+   do i = 1, n
+      name_c(i) = name(i:i)
+   end do
+   name_c(n+1) = c_null_char
+   success = uno_set_model_name_c(model, name_c)
+   deallocate(name_c)
+end function uno_set_model_name
+
+!---------------------------------------------
 ! uno_set_solver_integer_option
 !---------------------------------------------
 function uno_set_solver_integer_option(solver, option_name, option_value) result(success)

--- a/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl
+++ b/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl
@@ -1482,6 +1482,9 @@ function _setup_inner(model::Optimizer)::UnoSolver.Model
         model,
         'L',
         1,
+        nothing,
+        nothing,
+        model.name,
     )
     model.needs_new_inner = false
     return model.inner

--- a/interfaces/Julia/ext/UnoSolverNLPModelsExt/UnoSolverNLPModelsExt.jl
+++ b/interfaces/Julia/ext/UnoSolverNLPModelsExt/UnoSolverNLPModelsExt.jl
@@ -95,6 +95,7 @@ function UnoSolver.uno_model(nlp::AbstractNLPModel{Float64, Vector{Float64}})
     1,
     nlp.meta.x0,
     nlp.meta.y0,
+    nlp.meta.name,
   )
   return model
 end

--- a/interfaces/Julia/src/C_wrapper.jl
+++ b/interfaces/Julia/src/C_wrapper.jl
@@ -245,6 +245,7 @@ function uno_model(
   lagrangian_sign::Int=1,
   x0::Union{Vector{Float64},Nothing}=nothing,
   y0::Union{Vector{Float64},Nothing}=nothing,
+  name::AbstractString="",
 )
   @assert nvar == length(lvar) == length(uvar)
   @assert ncon == length(lcon) == length(ucon)
@@ -260,6 +261,7 @@ function uno_model(
   base_indexing = Cint(1)  # Fortran-style indexing
   c_model = uno_create_model(problem_type, Cint(nvar), lvar, uvar, base_indexing)
   (c_model == C_NULL) && error("Failed to construct Uno model for some unknown reason.")
+  isempty(name) || uno_set_model_name(c_model, name)
   model = Model(c_model, nvar, ncon, eval_objective, eval_constraints, eval_gradient,
                 eval_jacobian, eval_hessian, eval_Jv, eval_Jtv, eval_Hv, user_model)
 

--- a/interfaces/Julia/src/libuno.jl
+++ b/interfaces/Julia/src/libuno.jl
@@ -60,6 +60,10 @@ function uno_create_unconstrained_model(problem_type, number_variables, base_ind
                                                  base_indexing::Int32)::Ptr{Cvoid}
 end
 
+function uno_set_model_name(model, name)
+    @ccall libuno.uno_set_model_name(model::Ptr{Cvoid}, name::Cstring)::Bool
+end
+
 function uno_set_variables_lower_bounds(model, variables_lower_bounds)
     @ccall libuno.uno_set_variables_lower_bounds(model::Ptr{Cvoid},
                                                  variables_lower_bounds::Ptr{Cdouble})::Bool

--- a/interfaces/Python/cpp_classes/PythonModel.cpp
+++ b/interfaces/Python/cpp_classes/PythonModel.cpp
@@ -12,7 +12,8 @@
 
 namespace uno {
    PythonModel::PythonModel(const PythonUserModel& user_model):
-      Model("Python model", static_cast<size_t>(user_model.number_variables), static_cast<size_t>(user_model.number_constraints),
+      Model(user_model.name.empty() ? "Python model" : user_model.name,
+         static_cast<size_t>(user_model.number_variables), static_cast<size_t>(user_model.number_constraints),
          static_cast<double>(user_model.optimization_sense), static_cast<double>(user_model.lagrangian_sign_convention), 0),
          user_model(user_model),
          nonlinear_constraints(this->number_constraints),

--- a/interfaces/Python/example/example_hs015.py
+++ b/interfaces/Python/example/example_hs015.py
@@ -73,6 +73,7 @@ if __name__ == '__main__':
 	x0 = [-2., 1.]
 
 	model = unopy.Model(problem_type, number_variables, base_indexing)
+	model.set_name("hs015")
 	model.set_variables_lower_bounds(variables_lower_bounds)
 	model.set_variables_upper_bounds(variables_upper_bounds)
 	model.set_objective(optimization_sense, objective, objective_gradient)

--- a/interfaces/Python/python_modules/Model.cpp
+++ b/interfaces/Python/python_modules/Model.cpp
@@ -35,6 +35,10 @@ namespace uno {
       }), "Constructor")
 
       // methods
+      .def("set_name", [](PythonUserModel& user_model, const std::string& name) {
+         user_model.name = name;
+      })
+
       .def("set_variables_lower_bounds", [](PythonUserModel& user_model, std::vector<double> variables_lower_bounds) {
          if (static_cast<uno_int>(variables_lower_bounds.size()) != user_model.number_variables) {
             throw std::invalid_argument("Dimension mismatch in variables_lower_bounds.");

--- a/interfaces/UserModel.hpp
+++ b/interfaces/UserModel.hpp
@@ -6,6 +6,7 @@
 
 #include <cstring>
 #include <optional>
+#include <string>
 #include <vector>
 #include "C/Uno_C_API.h"
 #include "linear_algebra/Vector.hpp"
@@ -41,6 +42,7 @@ namespace uno {
 
       ProblemType problem_type; // non-const, may be overridden based on the number of Hessian nonzeros
       const uno_int base_indexing; // 0 for C-style indexing, 1 for Fortran-style indexing
+      std::string name{}; // model name (used e.g. in logs and KKT system dumps); empty falls back to the interface default
 
       // variables
       const uno_int number_variables;


### PR DESCRIPTION
Add a `name` field to `UserModel` and expose it through the interfaces:
- C API: `uno_set_model_name` (also reachable from Julia and Fortran);
- Python: `Model.set_name`;
- Julia: the `uno_model` builder gains a `name` argument, and the `NLPModels.jl` and `MathOptInterface.jl` extensions forward `nlp.meta.name` / the MOI model name automatically;
- Fortran / Julia bindings regenerated from the C header.

An empty name falls back to the previous interface defaults (`"C model"` / `"Python model"`), so behavior is unchanged unless a name is set.

Useful for logs, error messages, and the KKT system dumps, whose file names embed the model name.