### PR TITLE
Enable MC64 scaling in MA57 for Mittelmann benchmark

### DIFF
--- a/.github/workflows/mittelmann-benchmark.yml
+++ b/.github/workflows/mittelmann-benchmark.yml
@@ -78,6 +78,7 @@ jobs:
           DIR="${{ env.SCRATCH }}/Mittelmann"
           # 10 minutes
           TIMELIMIT=600
+          OPTION_FILE="uno_mittelmann.opt"
 
           mapfile -t INSTANCES < <(find "$DIR" -type f -name '*.nl' | sort)
           if [ "${#INSTANCES[@]}" -eq 0 ]; then
@@ -98,7 +99,7 @@ jobs:
             # Uno enforces time_limit=$TIMELIMIT itself; the outer `timeout` is only a
             # safety net in case a run gets stuck past its own limit.
             echo "Solving ${name}"
-            timeout $((TIMELIMIT + 30)) "$UNO" "$nl" preset=ipopt time_limit="$TIMELIMIT" > "$log" 2>&1 || true
+            timeout $((TIMELIMIT + 30)) "$UNO" "$nl" option_file="$OPTION_FILE" time_limit="$TIMELIMIT" > "$log" 2>&1 || true
             end=$(date +%s.%N)
             secs=$(awk "BEGIN{printf \"%.2f\", ${end} - ${start}}")
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -215,3 +215,9 @@ If not provided, the solver is chosen automatically from the available solvers (
 | Option                | Possible values         | Default     | Description                                                   |
 | :---                  | :---                    | :---        |:--------------------------------------------------------------|
 | `BQPD_kmax_heuristic` | `filtersqp`, `minotaur` | `filtersqp` | Heuristic used to pick upper bound on nullspace size (`kmax`) |
+
+## MA57 options
+
+| Option             | Type   | Default  | Description                                |
+| :---               | :---   | :---     |:-------------------------------------------|
+| `MA57_use_scaling` | `bool` | `false`  | Whether the MA57 scaling (MC64) is enabled |

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.cpp
@@ -15,8 +15,7 @@
 namespace uno {
    PrimalDualInertiaCorrection::PrimalDualInertiaCorrection(const Options& options):
          InertiaCorrectionStrategy(),
-         optional_linear_solver_name(options.get_string("linear_solver")),
-         libhsl_path(options.get_string_optional("libhsl_path").value_or("")),
+         options(options),
          regularization_failure_threshold(options.get_double("regularization_failure_threshold")),
          primal_regularization_initial_factor(options.get_double("primal_regularization_initial_factor")),
          dual_regularization_fraction(options.get_double("dual_regularization_fraction")),
@@ -35,7 +34,7 @@ namespace uno {
          const Inertia& expected_inertia, View<double> hessian_values) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
-         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
+         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->options);
          this->optional_linear_solver->get_linear_system().initialize_augmented_system(subproblem);
          this->optional_linear_solver->initialize_memory();
          this->optional_linear_solver->do_symbolic_analysis();
@@ -56,7 +55,7 @@ namespace uno {
          double dual_regularization_parameter, const Inertia& expected_inertia, View<double> primal_inertia_correction_block,
          View<double> dual_inertia_correction_block) {
       if (this->optional_linear_solver == nullptr) {
-         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
+         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->options);
          this->optional_linear_solver->get_linear_system().initialize_augmented_system(subproblem);
          this->optional_linear_solver->initialize_memory();
          this->optional_linear_solver->do_symbolic_analysis();

--- a/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalDualInertiaCorrection.hpp
@@ -36,8 +36,7 @@ namespace uno {
       [[nodiscard]] std::string get_name() const override;
 
    protected:
-      const std::string& optional_linear_solver_name;
-      const std::string libhsl_path;
+      const Options& options;
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> optional_linear_solver{};
       double primal_regularization{0.};
       double dual_regularization{0.};

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.cpp
@@ -14,8 +14,7 @@
 namespace uno {
    PrimalInertiaCorrection::PrimalInertiaCorrection(const Options& options):
          InertiaCorrectionStrategy(),
-         optional_linear_solver_name(options.get_string("linear_solver")),
-         libhsl_path(options.get_string_optional("libhsl_path").value_or("")),
+         options(options),
          regularization_initial_factor(options.get_double("primal_regularization_initial_factor")),
          regularization_increase_factor(options.get_double("regularization_increase_factor")),
          regularization_failure_threshold(options.get_double("regularization_failure_threshold")) {
@@ -30,7 +29,7 @@ namespace uno {
          const Inertia& expected_inertia, View<double> hessian_values) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
-         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
+         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->options);
          this->optional_linear_solver->get_linear_system().initialize_hessian(subproblem);
          this->optional_linear_solver->initialize_memory();
          this->optional_linear_solver->do_symbolic_analysis();
@@ -89,7 +88,7 @@ namespace uno {
          View<double> dual_inertia_correction_block) {
       // pick the member linear solver
       if (this->optional_linear_solver == nullptr) {
-         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->optional_linear_solver_name, this->libhsl_path);
+         this->optional_linear_solver = SymmetricIndefiniteLinearSolverFactory::create(this->options);
          this->optional_linear_solver->get_linear_system().initialize_hessian(subproblem);
          this->optional_linear_solver->initialize_memory();
          this->optional_linear_solver->do_symbolic_analysis();

--- a/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.hpp
+++ b/uno/ingredients/inertia_correction_strategies/PrimalInertiaCorrection.hpp
@@ -37,8 +37,7 @@ namespace uno {
       [[nodiscard]] std::string get_name() const override;
 
    protected:
-      const std::string& optional_linear_solver_name;
-      const std::string libhsl_path;
+      const Options& options;
       std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> optional_linear_solver{};
       double regularization_factor{0.};
       const double regularization_initial_factor{};

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -16,8 +16,7 @@
 namespace uno {
    EQPSolver::EQPSolver(const Options& options):
          SubproblemSolver(),
-         linear_solver(SymmetricIndefiniteLinearSolverFactory::create(options.get_string("linear_solver"),
-            options.get_string_optional("libhsl_path").value_or(""))) {
+         linear_solver(SymmetricIndefiniteLinearSolverFactory::create(options)) {
    }
 
    void EQPSolver::initialize_memory(const Subproblem& subproblem) {

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -98,7 +98,7 @@ namespace uno {
       INFO << "Running MA57\n";
    }
 
-   MA57Solver::MA57Solver(): DirectSymmetricIndefiniteLinearSolver() {
+   MA57Solver::MA57Solver(bool use_scaling): DirectSymmetricIndefiniteLinearSolver(), use_scaling(use_scaling) {
 #ifdef HSL_RUNTIME_LOADING
       if (!ma57_symbols_available()) {
          throw std::runtime_error("Uno: the MA57 solver was requested but the HSL library could not be loaded at "
@@ -113,7 +113,7 @@ namespace uno {
       MA57_ICNTL(7) = 1; // numerical pivoting (uses threshold in CNTL(1))
       MA57_ICNTL(11) = 16; // block size used by the Level 3 BLAS
       MA57_ICNTL(12) = 16; // assembly tree
-      //MA57_ICNTL(15) = MA57Settings::mc64_scaling; // MC64 scaling (disabled)
+      MA57_ICNTL(15) = use_scaling ? 1 : 0; // MC64 scaling
       MA57_ICNTL(16) = 0; // small entries removed (disabled)
       MA57_CNTL(1) = MA57Settings::pivoting_threshold; // pivoting threshold
    }

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -115,7 +115,7 @@ namespace uno {
       MA57_ICNTL(12) = 16; // assembly tree
       //MA57_ICNTL(15) = MA57Settings::mc64_scaling; // MC64 scaling (disabled)
       MA57_ICNTL(16) = 0; // small entries removed (disabled)
-      //MA57_CNTL(1) = MA57Settings::pivoting_threshold; // pivoting threshold
+      MA57_CNTL(1) = MA57Settings::pivoting_threshold; // pivoting threshold
    }
 
    void MA57Solver::initialize_memory() {

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.cpp
@@ -113,9 +113,9 @@ namespace uno {
       MA57_ICNTL(7) = 1; // numerical pivoting (uses threshold in CNTL(1))
       MA57_ICNTL(11) = 16; // block size used by the Level 3 BLAS
       MA57_ICNTL(12) = 16; // assembly tree
-      MA57_ICNTL(15) = MA57Settings::mc64_scaling; // MC64 scaling (disabled)
+      //MA57_ICNTL(15) = MA57Settings::mc64_scaling; // MC64 scaling (disabled)
       MA57_ICNTL(16) = 0; // small entries removed (disabled)
-      MA57_CNTL(1) = MA57Settings::pivoting_threshold; // pivoting threshold
+      //MA57_CNTL(1) = MA57Settings::pivoting_threshold; // pivoting threshold
    }
 
    void MA57Solver::initialize_memory() {

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
@@ -13,7 +13,6 @@
 namespace uno {
    // settings taken from IPOPT
    struct MA57Settings {
-      static constexpr int mc64_scaling = 0;
       static constexpr double pivoting_threshold = 1e-8;
       static constexpr double allocation_safety_factor = 1.05;
    };
@@ -49,7 +48,7 @@ namespace uno {
 
    class MA57Solver : public DirectSymmetricIndefiniteLinearSolver<double> {
    public:
-      MA57Solver();
+      MA57Solver(bool use_scaling);
       ~MA57Solver() override = default;
 
       void initialize_memory() override;
@@ -70,6 +69,7 @@ namespace uno {
    private:
       MA57Workspace workspace{};
       COOLinearSystem linear_system{Indexing::Fortran_indexing};
+      const bool use_scaling;
 
       bool analysis_performed{false};
       bool factorization_performed{false};

--- a/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
+++ b/uno/ingredients/subproblem_solvers/MA57/MA57Solver.hpp
@@ -48,7 +48,7 @@ namespace uno {
 
    class MA57Solver : public DirectSymmetricIndefiniteLinearSolver<double> {
    public:
-      MA57Solver(bool use_scaling);
+      MA57Solver(bool use_scaling = false); // no scaling by default
       ~MA57Solver() override = default;
 
       void initialize_memory() override;

--- a/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.cpp
+++ b/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.cpp
@@ -6,6 +6,7 @@
 #include "SymmetricIndefiniteLinearSolverFactory.hpp"
 #include "DirectSymmetricIndefiniteLinearSolver.hpp"
 #include "linear_algebra/Vector.hpp"
+#include "options/Options.hpp"
 
 #if defined(HAS_HSL) || defined(HAS_MA57)
 #include "ingredients/subproblem_solvers/MA57/MA57Solver.hpp"
@@ -41,10 +42,11 @@ namespace uno {
 
 namespace uno {
    std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> SymmetricIndefiniteLinearSolverFactory::create(
-         const std::string& linear_solver, [[maybe_unused]] const std::string& libhsl_path) {
+         const Options& options) {
+      const auto& linear_solver = options.get_string("linear_solver");
 #ifdef HSL_RUNTIME_LOADING
       // honor the requested HSL library name before LIBHSL_isfunctional() triggers the (cached) load
-      load_hsl_library(libhsl_path);
+      load_hsl_library(options.get_string_optional("libhsl_path").value_or(""));
 #endif
 #if defined(HAS_HSL) || defined(HAS_MA57)
       if (linear_solver == "MA57"
@@ -52,7 +54,7 @@ namespace uno {
          && LIBHSL_isfunctional()
    #endif
             ) {
-         return std::make_unique<MA57Solver>();
+         return std::make_unique<MA57Solver>(options.get_bool("MA57_use_scaling"));
       }
 #endif
 

--- a/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.hpp
+++ b/uno/ingredients/subproblem_solvers/SymmetricIndefiniteLinearSolverFactory.hpp
@@ -12,12 +12,12 @@ namespace uno {
    // forward declaration
    template <class ElementType>
    class DirectSymmetricIndefiniteLinearSolver;
+   class Options;
 
    class SymmetricIndefiniteLinearSolverFactory {
    public:
       // libhsl_path: runtime HSL library name for MA27/MA57 (empty = platform default libhsl.<ext>)
-      static std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> create(const std::string& linear_solver,
-         const std::string& libhsl_path = "");
+      static std::unique_ptr<DirectSymmetricIndefiniteLinearSolver<double>> create(const Options& options);
 
       // return the list of available solvers
       static std::vector<std::string> available_solvers();

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -20,8 +20,7 @@ namespace uno {
    WoodburyEQPSolver::WoodburyEQPSolver(const DirectQuasiNewtonHessian& hessian_model, const Options& options):
          SubproblemSolver(),
          hessian_model(hessian_model),
-         linear_solver(SymmetricIndefiniteLinearSolverFactory::create(options.get_string("linear_solver"),
-            options.get_string_optional("libhsl_path").value_or(""))) {
+         linear_solver(SymmetricIndefiniteLinearSolverFactory::create(options)) {
       assert(!this->hessian_model.has_hessian_matrix());
    }
 

--- a/uno/options/DefaultOptions.cpp
+++ b/uno/options/DefaultOptions.cpp
@@ -166,6 +166,9 @@ namespace uno {
 
       /** BQPD options **/
       options.set_string("BQPD_kmax_heuristic", "filtersqp");
+
+      /** MA57 options **/
+      options.set_bool("MA57_use_scaling", false);
    }
 
    // determine default subproblem solvers, based on the available external dependencies

--- a/uno/options/Options.cpp
+++ b/uno/options/Options.cpp
@@ -108,6 +108,7 @@ namespace uno {
       {"SOC_max_iterations", OptionType::INTEGER},
       {"SOC_infeasibility_fraction", OptionType::DOUBLE},
       {"libhsl_path", OptionType::STRING},
+      {"MA57_use_scaling", OptionType::BOOL},
    };
 
    // setters

--- a/uno_default.opt
+++ b/uno_default.opt
@@ -226,3 +226,7 @@ least_square_multiplier_max_norm 1e3
 ## BQPD options
 # Heuristic used to pick upper bound on nullspace size (kmax) (filtersqp|minotaur)
 BQPD_kmax_heuristic filtersqp
+
+## MA57 options
+# Whether the MA57 scaling (MC64) is enabled (true|false)
+MA57_use_scaling false

--- a/uno_mittelmann.opt
+++ b/uno_mittelmann.opt
@@ -1,0 +1,2 @@
+preset ipopt
+MA57_use_scaling true


### PR DESCRIPTION
MA57's MC64 scaling is expensive, but the barrier solver becomes more robust over the whole benchmark.