### PR TITLE
Fixed switch back to optimality phase

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -98,8 +98,8 @@ namespace uno {
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
 
-      // save the current point (progress and primals) upon switching
-      this->reference_optimality_progress = current_iterate.progress;
+      // save the current point (infeasibility and primals) upon switching
+      this->reference_infeasibility = current_iterate.primal_feasibility;
       this->reference_optimality_primals = current_iterate.primals;
       this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
@@ -183,10 +183,10 @@ namespace uno {
       return direction;
    }
 
-   bool FeasibilityRestoration::can_switch_to_optimality_phase(const Model& model, const Iterate& trial_iterate,
-         const Direction& direction, double step_length, Evaluations& current_evaluations) const {
-      if (this->globalization_strategy->is_infeasibility_sufficiently_reduced(this->reference_optimality_progress,
-            trial_iterate.progress)) {
+   bool FeasibilityRestoration::can_switch_to_optimality_phase(const Model& model, Iterate& trial_iterate,
+         const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
+      this->inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);
+      if (this->globalization_strategy->is_infeasibility_sufficiently_reduced(trial_iterate, this->reference_infeasibility)) {
          if (!this->switch_to_optimality_requires_linearized_feasibility) {
             return true;
          }
@@ -196,8 +196,13 @@ namespace uno {
          current_evaluations.compute_jacobian_vector_product(model, direction.primals.view(), result.view());
          const double trial_linearized_constraint_violation = model.constraint_violation(current_evaluations.constraints +
             step_length * result, this->residual_norm);
-         return (trial_linearized_constraint_violation <= this->linear_feasibility_tolerance);
+         const bool switch_back = (trial_linearized_constraint_violation <= this->linear_feasibility_tolerance);
+         if (!switch_back) {
+            this->feasibility_inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);
+         }
+         return switch_back;
       }
+      this->feasibility_inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);
       return false;
    }
 
@@ -246,7 +251,7 @@ namespace uno {
 
       // possibly go from restoration phase to optimality phase
       if (accept_iterate && this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(model,
-            trial_iterate, direction, step_length, current_evaluations)) {
+            trial_iterate, direction, step_length, current_evaluations, trial_evaluations)) {
          this->switch_back_to_optimality_phase(current_iterate, trial_iterate, current_evaluations, trial_evaluations);
          // set a cold start in the subproblem solver
          warmstart_information.whole_problem_changed();

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -67,7 +67,7 @@ namespace uno {
       Multipliers other_phase_multipliers;
       const double linear_feasibility_tolerance;
       const bool switch_to_optimality_requires_linearized_feasibility;
-      ProgressMeasures reference_optimality_progress{};
+      double reference_infeasibility{};
       Vector<double> reference_optimality_primals{};
       bool first_switch_to_feasibility{true};
 
@@ -77,8 +77,8 @@ namespace uno {
       void switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate, Evaluations& current_evaluations,
          Evaluations& trial_evaluations);
 
-      [[nodiscard]] bool can_switch_to_optimality_phase(const Model& model, const Iterate& trial_iterate,
-         const Direction& direction, double step_length, Evaluations& current_evaluations) const;
+      [[nodiscard]] bool can_switch_to_optimality_phase(const Model& model, Iterate& trial_iterate,
+         const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const;
    };
 } // namespace
 

--- a/uno/ingredients/globalization_strategies/GlobalizationStrategy.hpp
+++ b/uno/ingredients/globalization_strategies/GlobalizationStrategy.hpp
@@ -21,8 +21,8 @@ namespace uno {
       virtual void initialize(Statistics& statistics, const Iterate& initial_iterate) = 0;
       [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
          const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) = 0;
-      [[nodiscard]] virtual bool is_infeasibility_sufficiently_reduced(const ProgressMeasures& reference_progress,
-         const ProgressMeasures& trial_progress) const = 0;
+      [[nodiscard]] virtual bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
+         double reference_infeasibility) const = 0;
 
       virtual void reset() = 0;
 

--- a/uno/ingredients/globalization_strategies/MeritFunction.cpp
+++ b/uno/ingredients/globalization_strategies/MeritFunction.cpp
@@ -3,6 +3,7 @@
 
 #include "MeritFunction.hpp"
 #include "ProgressMeasures.hpp"
+#include "optimization/Iterate.hpp"
 #include "options/Options.hpp"
 #include "tools/Logger.hpp"
 #include "tools/Statistics.hpp"
@@ -48,9 +49,9 @@ namespace uno {
       return accept;
    }
 
-   bool MeritFunction::is_infeasibility_sufficiently_reduced(const ProgressMeasures& /*current_progress*/, const ProgressMeasures& trial_progress) const {
+   bool MeritFunction::is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double /*reference_infeasibility*/) const {
       // if the trial infeasibility sufficiently decreases the best known infeasibility
-      return (trial_progress.infeasibility <= this->sufficient_infeasibility_decrease_ratio * this->smallest_known_infeasibility);
+      return (trial_iterate.progress.infeasibility <= this->sufficient_infeasibility_decrease_ratio * this->smallest_known_infeasibility);
    }
 
    void MeritFunction::reset() {

--- a/uno/ingredients/globalization_strategies/MeritFunction.hpp
+++ b/uno/ingredients/globalization_strategies/MeritFunction.hpp
@@ -16,7 +16,7 @@ namespace uno {
       void initialize(Statistics& statistics, const Iterate& initial_iterate) override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
             const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) override;
-      [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const ProgressMeasures& current_progress, const ProgressMeasures& trial_progress) const override;
+      [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double reference_infeasibility) const override;
       void reset() override;
       void notify_switch_to_feasibility(const ProgressMeasures& current_progress) override;
       void notify_switch_to_optimality(const ProgressMeasures& current_progress) override;

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
@@ -4,6 +4,7 @@
 #include "FletcherFilterMethod.hpp"
 #include "filters/Filter.hpp"
 #include "ingredients/globalization_strategies/ProgressMeasures.hpp"
+#include "optimization/Iterate.hpp"
 #include "tools/Logger.hpp"
 #include "tools/Statistics.hpp"
 #include "tools/Symbols.hpp"
@@ -67,10 +68,11 @@ namespace uno {
       return accept;
    }
 
-   bool FletcherFilterMethod::is_infeasibility_sufficiently_reduced(const ProgressMeasures& /*reference_progress*/,
-         const ProgressMeasures& trial_progress) const {
+   bool FletcherFilterMethod::is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
+      double /*reference_infeasibility*/) const {
       // if the trial infeasibility improves upon the best known infeasibility
-      return this->filter->infeasibility_sufficient_reduction(this->filter->get_smallest_infeasibility(), trial_progress.infeasibility);
+      return this->filter->infeasibility_sufficient_reduction(this->filter->get_smallest_infeasibility(),
+         trial_iterate.progress.infeasibility);
    }
 
    std::string FletcherFilterMethod::get_name() const {

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.hpp
@@ -14,8 +14,8 @@ namespace uno {
 
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
          const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) override;
-      [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const ProgressMeasures& reference_progress,
-         const ProgressMeasures& trial_progress) const override;
+      [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
+         double reference_infeasibility) const override;
 
       [[nodiscard]] std::string get_name() const override;
    };

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
@@ -117,10 +117,12 @@ namespace uno {
       return true;
    }
 
-   bool WaechterFilterMethod::is_infeasibility_sufficiently_reduced(const ProgressMeasures& reference_progress,
-         const ProgressMeasures& trial_progress) const {
-      return trial_progress.infeasibility <= this->sufficient_infeasibility_decrease_factor * reference_progress.infeasibility &&
-         this->filter->filter_acceptable(trial_progress.infeasibility, FilterMethod::unconstrained_merit_function(trial_progress));
+   bool WaechterFilterMethod::is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double reference_infeasibility) const {
+      std::cout << "WaechterFilterMethod::is_infeasibility_sufficiently_reduced: " << trial_iterate.primal_feasibility <<
+         " < 0.9*" << reference_infeasibility << '\n';
+      // use the infeasibility in the residual norm here (inf norm for IPOPT implementation)
+      return trial_iterate.primal_feasibility <= this->sufficient_infeasibility_decrease_factor * reference_infeasibility &&
+         this->filter->filter_acceptable(trial_iterate.progress.infeasibility, unconstrained_merit_function(trial_iterate.progress));
    }
 
    std::string WaechterFilterMethod::get_name() const {

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.hpp
@@ -16,8 +16,8 @@ namespace uno {
       void initialize(Statistics& statistics, const Iterate& initial_iterate) override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
          const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) override;
-      [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const ProgressMeasures& reference_progress,
-         const ProgressMeasures& trial_progress) const override;
+      [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
+         double reference_infeasibility) const override;
 
       [[nodiscard]] std::string get_name() const override;
 

--- a/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.cpp
@@ -96,9 +96,9 @@ namespace uno {
       return accept;
    }
 
-   bool FunnelMethod::is_infeasibility_sufficiently_reduced(const ProgressMeasures& reference_progress, const ProgressMeasures& trial_progress) const {
-      return this->funnel.acceptable(trial_progress.infeasibility) &&
-         trial_progress.infeasibility <= this->parameters.beta * reference_progress.infeasibility;
+   bool FunnelMethod::is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double reference_infeasibility) const {
+      return this->funnel.acceptable(trial_iterate.progress.infeasibility) &&
+         trial_iterate.progress.infeasibility <= this->parameters.beta * reference_infeasibility;
    }
 
    void FunnelMethod::reset() {

--- a/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.hpp
@@ -28,8 +28,7 @@ namespace uno {
       void initialize(Statistics& statistics, const Iterate& initial_iterate) override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
          const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) override;
-      [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const ProgressMeasures& reference_progress,
-         const ProgressMeasures& trial_progress) const override;
+      [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double reference_infeasibility) const override;
       void reset() override;
       void notify_switch_to_feasibility(const ProgressMeasures& current_progress_measures) override;
       void notify_switch_to_optimality(const ProgressMeasures& current_progress_measures) override;

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -85,7 +85,7 @@ namespace uno {
          subproblem.number_variables + subproblem.number_constraints);
       if (norm_inf(least_squares_multipliers) <= multipliers_threshold) {
          iterate.multipliers.constraints = least_squares_multipliers;
-         DEBUG << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
+         DEBUG2 << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
       }
       else {
          DEBUG << "Least-squares multipliers too large\n";
@@ -179,7 +179,7 @@ namespace uno {
       }
       // flip sign
       rhs_constraints.scale(-1.);
-      DEBUG << "SOC RHS: " << linear_system.rhs << '\n';
+      DEBUG2 << "SOC RHS: " << linear_system.rhs << '\n';
 
       // solve the linear system
       this->linear_solver->solve_indefinite_system(linear_system.solution.data());

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -88,7 +88,7 @@ namespace uno {
          subproblem.number_variables + subproblem.number_constraints);
       if (norm_inf(least_squares_multipliers) <= multipliers_threshold) {
          iterate.multipliers.constraints = least_squares_multipliers;
-         DEBUG << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
+         DEBUG2 << "Least-squares multipliers set to " << least_squares_multipliers << '\n';
       }
       else {
          DEBUG << "Least-squares multipliers too large\n";
@@ -180,7 +180,7 @@ namespace uno {
    // protected members
 
    void WoodburyEQPSolver::compute_low_rank_correction(const Subproblem& subproblem, Vector<double>& b) const {
-      DEBUG << "b = " << b << '\n';
+      DEBUG2 << "b = " << b << '\n';
       const size_t correction_rank = this->hessian_model.get_correction_rank();
       DEBUG << "Correction rank: " << correction_rank << '\n';
       if (0 < correction_rank) {


### PR DESCRIPTION
- [x] IPOPT uses the inf norm (aka residual norm) in the condition to switch back to optimality phase, not the l1 norm (aka progress norm). This is less restrictive and allows a switch back in Mittelmann's `corkscrw` instance.
- [x] Test filter acceptability wrt the original problem, not the restoration problem. The progress measures used to be out of sync, this is fixed with an ugly reevaluation in `FeasibilityRestoration::can_switch_to_optimality_phase` (good enough for now).