### PR TITLE
Test the `ipopt` preset on infeasible instances

### DIFF
--- a/.github/julia/runtests_uno_charlies_instances.jl
+++ b/.github/julia/runtests_uno_charlies_instances.jl
@@ -30,7 +30,7 @@ function test_hs015()
 
     optimize!(model)
 
-    tolerance = 1e-5
+    tolerance = 1e-3
     @assert abs(objective_value(model) - 306.5) <= tolerance
     @assert abs(value(x) - 0.5) <= tolerance
     @assert abs(value(y) - 2.) <= tolerance
@@ -54,7 +54,7 @@ function test_isolated()
 
     optimize!(model)
 
-    tolerance = 1e-5
+    tolerance = 1e-3
     @assert abs(objective_value(model) - 0.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 0.) <= tolerance
@@ -78,7 +78,7 @@ function test_nactive()
 
     optimize!(model)
 
-    tolerance = 1e-5
+    tolerance = 1e-3
     @assert abs(objective_value(model) - 0.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 0.) <= tolerance
@@ -100,7 +100,7 @@ function test_unique()
 
     optimize!(model)
 
-    tolerance = 1e-5
+    tolerance = 1e-3
     @assert abs(objective_value(model) - 1.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 1.) <= tolerance

--- a/.github/julia/runtests_uno_charlies_instances.jl
+++ b/.github/julia/runtests_uno_charlies_instances.jl
@@ -59,7 +59,7 @@ function test_isolated()
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 0.) <= tolerance
     (tolerance, dual_solution) = if preset == "ipopt"
-       (1000.*tolerance, [1000., 1000., 1000., 1000.]) # IPOPT scales the feasibility objective by 1000
+       (1000. * tolerance, [1000., 1000., 1000., 1000.]) # IPOPT scales the feasibility objective by 1000
     else
        (tolerance, [1., 1., 1., 1.])
     end
@@ -88,7 +88,7 @@ function test_nactive()
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 0.) <= tolerance
     (tolerance, dual_solution) = if preset == "ipopt"
-       (1000.*tolerance, [1000., 500., 0.]) # IPOPT scales the feasibility objective by 1000
+       (1000. * tolerance, [1000., 500., 0.]) # IPOPT scales the feasibility objective by 1000
     else
        (tolerance, [1., 0.5, 0.])
     end
@@ -115,7 +115,7 @@ function test_unique()
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 1.) <= tolerance
     (tolerance, dual_solution) = if preset == "ipopt"
-       (1000.*tolerance, [815.4845, 1000.]) # IPOPT scales the feasibility objective by 1000
+       (1000. * tolerance, [815.4845, 1000.]) # IPOPT scales the feasibility objective by 1000
     else
        (tolerance, [0.8154845, 1.])
     end

--- a/.github/julia/runtests_uno_charlies_instances.jl
+++ b/.github/julia/runtests_uno_charlies_instances.jl
@@ -14,7 +14,7 @@ length(ARGS) == 1 || error("The preset is missing or you supplied more than one 
 preset = ARGS[1]
 println("Solving with preset ", preset)
 
-Optimizer_Uno_filtersqp() = Optimizer(["logger=INFO", "preset=$preset", "QP_solver=BQPD", "linear_solver=MUMPS", "max_iterations=10000"])
+Optimizer_Uno_filtersqp() = Optimizer(["logger=INFO", "preset=$preset", "print_solution=true", "QP_solver=BQPD", "linear_solver=MUMPS", "max_iterations=10000"])
 
 function test_hs015()
     model = Model(() -> Optimizer_Uno_filtersqp())
@@ -58,10 +58,15 @@ function test_isolated()
     @assert abs(objective_value(model) - 0.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 0.) <= tolerance
-    @assert abs(dual(c1) - 1.) <= tolerance
-    @assert abs(dual(c2) - 1.) <= tolerance
-    @assert abs(dual(c3) - 1.) <= tolerance
-    @assert abs(dual(c4) - 1.) <= tolerance
+    (tolerance, dual_solution) = if preset == "ipopt"
+       (1000.*tolerance, [1000., 1000., 1000., 1000.]) # IPOPT scales the feasibility objective by 1000
+    else
+       (tolerance, [1., 1., 1., 1.])
+    end
+    @assert abs(dual(c1) - dual_solution[1]) <= tolerance
+    @assert abs(dual(c2) - dual_solution[2]) <= tolerance
+    @assert abs(dual(c3) - dual_solution[3]) <= tolerance
+    @assert abs(dual(c4) - dual_solution[4]) <= tolerance
 end
 
 function test_nactive()
@@ -82,9 +87,14 @@ function test_nactive()
     @assert abs(objective_value(model) - 0.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 0.) <= tolerance
-    @assert abs(dual(c1) - 1.) <= tolerance
-    @assert abs(dual(c2) - 0.5) <= tolerance
-    @assert abs(dual(c3) - 0.) <= tolerance
+    (tolerance, dual_solution) = if preset == "ipopt"
+       (1000.*tolerance, [1000., 500., 0.]) # IPOPT scales the feasibility objective by 1000
+    else
+       (tolerance, [1., 0.5, 0.])
+    end
+    @assert abs(dual(c1) - dual_solution[1]) <= tolerance
+    @assert abs(dual(c2) - dual_solution[2]) <= tolerance
+    @assert abs(dual(c3) - dual_solution[3]) <= tolerance
 end
 
 function test_unique()
@@ -104,8 +114,13 @@ function test_unique()
     @assert abs(objective_value(model) - 1.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 1.) <= tolerance
-    @assert abs(dual(c1) - 0.8154845) <= tolerance
-    @assert abs(dual(c2) - 1.) <= tolerance
+    (tolerance, dual_solution) = if preset == "ipopt"
+       (1000.*tolerance, [815.4845, 1000.]) # IPOPT scales the feasibility objective by 1000
+    else
+       (tolerance, [0.8154845, 1.])
+    end
+    @assert abs(dual(c1) - dual_solution[1]) <= tolerance
+    @assert abs(dual(c2) - dual_solution[2]) <= tolerance
 end
 
 test_hs015()

--- a/.github/julia/runtests_uno_charlies_instances.jl
+++ b/.github/julia/runtests_uno_charlies_instances.jl
@@ -9,7 +9,12 @@ function Optimizer(options)
     return AmplNLWriter.Optimizer(Uno_jll.amplexe, options)
 end
 
-Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=filtersqp", "QP_solver=BQPD", "max_iterations=10000", "unbounded_objective_threshold=-1e15"])
+# this script is parameterized by the preset passed as command line argument (e.g., runtests_charlies_instances.jl filtersqp)
+length(ARGS) == 1 || error("The preset is missing or you supplied more than one command line arguments")
+preset = ARGS[1]
+println("Solving with preset ", preset)
+
+Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=$preset", "QP_solver=BQPD", "linear_solver=MUMPS", "max_iterations=10000"])
 
 function test_hs015()
     model = Model(() -> Optimizer_Uno_filtersqp())

--- a/.github/julia/runtests_uno_charlies_instances.jl
+++ b/.github/julia/runtests_uno_charlies_instances.jl
@@ -14,7 +14,7 @@ length(ARGS) == 1 || error("The preset is missing or you supplied more than one 
 preset = ARGS[1]
 println("Solving with preset ", preset)
 
-Optimizer_Uno_filtersqp() = Optimizer(["logger=SILENT", "preset=$preset", "QP_solver=BQPD", "linear_solver=MUMPS", "max_iterations=10000"])
+Optimizer_Uno_filtersqp() = Optimizer(["logger=INFO", "preset=$preset", "QP_solver=BQPD", "linear_solver=MUMPS", "max_iterations=10000"])
 
 function test_hs015()
     model = Model(() -> Optimizer_Uno_filtersqp())

--- a/.github/julia/runtests_uno_charlies_instances.jl
+++ b/.github/julia/runtests_uno_charlies_instances.jl
@@ -30,7 +30,7 @@ function test_hs015()
 
     optimize!(model)
 
-    tolerance = 1e-6
+    tolerance = 1e-5
     @assert abs(objective_value(model) - 306.5) <= tolerance
     @assert abs(value(x) - 0.5) <= tolerance
     @assert abs(value(y) - 2.) <= tolerance
@@ -54,7 +54,7 @@ function test_isolated()
 
     optimize!(model)
 
-    tolerance = 1e-6
+    tolerance = 1e-5
     @assert abs(objective_value(model) - 0.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 0.) <= tolerance
@@ -78,7 +78,7 @@ function test_nactive()
 
     optimize!(model)
 
-    tolerance = 1e-6
+    tolerance = 1e-5
     @assert abs(objective_value(model) - 0.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 0.) <= tolerance
@@ -100,7 +100,7 @@ function test_unique()
 
     optimize!(model)
 
-    tolerance = 1e-6
+    tolerance = 1e-5
     @assert abs(objective_value(model) - 1.) <= tolerance
     @assert abs(value(x[1]) - 0.) <= tolerance
     @assert abs(value(x[2]) - 1.) <= tolerance

--- a/.github/workflows/julia-tests-ubuntu.yml
+++ b/.github/workflows/julia-tests-ubuntu.yml
@@ -94,9 +94,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        UNO_TEST: [uno_filterslp_bqpd, uno_filterslp_highs, uno_filtersqp_bqpd_charlies_instances,
-                   uno_filtersqp_bqpd, uno_filtersqp_highs, uno_filtersqp_bqpd_identity, uno_filtersqp_bqpd_lsr1,
-                   uno_filtersqp_bqpd_regularization_tr, uno_filtersqp_bqpd_regularization_ls, uno_filtersqp_bqpd_ls_lbfgs]
+        UNO_TEST: [uno_filterslp_bqpd, uno_filterslp_highs, uno_filtersqp_bqpd, uno_filtersqp_highs,
+                   uno_filtersqp_bqpd_identity, uno_filtersqp_bqpd_lsr1, uno_filtersqp_bqpd_regularization_tr,
+                   uno_filtersqp_bqpd_regularization_ls, uno_filtersqp_bqpd_ls_lbfgs]
         include:
           - UNO_TEST: uno_ipopt
             ARGS: MUMPS
@@ -122,6 +122,10 @@ jobs:
             ARGS: MUMPS
           - UNO_TEST: uno_unconstrained_lbfgs
             ARGS: SSIDS
+          - UNO_TEST: uno_charlies_instances
+            ARGS: filtersqp
+          - UNO_TEST: uno_charlies_instances
+            ARGS: ipopt
 
     steps:
       - uses: actions/checkout@v4

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -244,7 +244,7 @@ namespace uno {
       const size_t number_subproblems_solved = (this->globalization_mechanism != nullptr) ?
          this->globalization_mechanism->get_number_subproblems_solved() : 0;
       return {model.number_variables, model.number_constraints, model.base_indexing, optimization_status, solution.status,
-         evaluations.objective, solution.primal_feasibility, solution.residuals.stationarity,
+         evaluations.objective, solution.primal_infeasibility, solution.residuals.stationarity,
          solution.residuals.complementarity, solution.primals, solution.multipliers.constraints,
          solution.multipliers.lower_bounds, solution.multipliers.upper_bounds, evaluations.constraints, major_iterations,
          timer.get_duration(), model.number_model_objective_evaluations(), model.number_model_constraints_evaluations(),

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -244,7 +244,7 @@ namespace uno {
       const size_t number_subproblems_solved = (this->globalization_mechanism != nullptr) ?
          this->globalization_mechanism->get_number_subproblems_solved() : 0;
       return {model.number_variables, model.number_constraints, model.base_indexing, optimization_status, solution.status,
-         evaluations.objective, solution.progress.infeasibility, solution.residuals.stationarity,
+         evaluations.objective, solution.primal_feasibility, solution.residuals.stationarity,
          solution.residuals.complementarity, solution.primals, solution.multipliers.constraints,
          solution.multipliers.lower_bounds, solution.multipliers.upper_bounds, evaluations.constraints, major_iterations,
          timer.get_duration(), model.number_model_objective_evaluations(), model.number_model_constraints_evaluations(),

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -47,7 +47,7 @@ namespace uno {
 
       // primal feasibility/constraint violation of the model
       evaluations.evaluate_constraints(problem.model, iterate.primals);
-      iterate.primal_feasibility = problem.model.constraint_violation(evaluations.constraints, this->residual_norm);
+      iterate.primal_infeasibility = problem.model.constraint_violation(evaluations.constraints, this->residual_norm);
 
       // complementarity error
       constexpr double shift_value = 0.;

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -85,7 +85,7 @@ namespace uno {
       if (norm_inf(view(iterate.primals, 0, problem.get_number_original_variables())) > this->diverging_iterate_threshold) {
          return SolutionStatus::DIVERGING_ITERATE;
       }
-      if (iterate.primal_feasibility <= this->primal_tolerance && evaluations.is_objective_computed &&
+      if (iterate.primal_infeasibility <= this->primal_tolerance && evaluations.is_objective_computed &&
             evaluations.objective < this->unbounded_objective_threshold) {
          return SolutionStatus::UNBOUNDED_OBJECTIVE;
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -99,7 +99,7 @@ namespace uno {
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
 
       // save the current point (infeasibility and primals) upon switching
-      this->reference_infeasibility = current_iterate.primal_feasibility;
+      this->reference_infeasibility = current_iterate.primal_infeasibility;
       this->reference_optimality_primals = current_iterate.primals;
       this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -292,7 +292,7 @@ namespace uno {
          double dual_tolerance) const {
       // evaluate termination conditions based on optimality conditions
       const bool feasibility_stationarity = (current_iterate.residuals.stationarity <= dual_tolerance);
-      const bool primal_feasibility = (current_iterate.primal_feasibility <= primal_tolerance);
+      const bool primal_feasibility = (current_iterate.primal_infeasibility <= primal_tolerance);
       const bool feasibility_complementarity = (current_iterate.residuals.complementarity <= dual_tolerance);
       const bool no_trivial_duals = current_iterate.multipliers.not_all_zero(this->model.number_variables, dual_tolerance);
 

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -291,19 +291,19 @@ namespace uno {
    SolutionStatus l1RelaxedProblem::check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,
          double dual_tolerance) const {
       // evaluate termination conditions based on optimality conditions
-      const bool feasibility_stationarity = (current_iterate.residuals.stationarity <= dual_tolerance);
       const bool primal_feasibility = (current_iterate.primal_infeasibility <= primal_tolerance);
+      const bool feasibility_stationarity = (current_iterate.residuals.stationarity <= dual_tolerance);
       const bool feasibility_complementarity = (current_iterate.residuals.complementarity <= dual_tolerance);
       const bool no_trivial_duals = current_iterate.multipliers.not_all_zero(this->model.number_variables, dual_tolerance);
 
       DEBUG << "\nTermination criteria for primal-dual tolerances = (" << primal_tolerance << ", " << dual_tolerance << "):\n";
-      DEBUG << "Primal feasibility: " << std::boolalpha << primal_feasibility << '\n';
+      DEBUG << "Primal infeasibility: " << std::boolalpha << primal_feasibility << '\n';
       DEBUG << "Feasibility stationarity: " << std::boolalpha << feasibility_stationarity << '\n';
       DEBUG << "Feasibility complementarity: " << std::boolalpha << feasibility_complementarity << '\n';
       DEBUG << "Not all zero multipliers: " << std::boolalpha << no_trivial_duals << "\n\n";
 
-      if (this->model.is_constrained() && feasibility_stationarity && !primal_feasibility && feasibility_complementarity &&
-            no_trivial_duals) {
+      if (this->model.is_constrained() && !primal_feasibility && feasibility_stationarity && feasibility_complementarity
+            && no_trivial_duals) {
          // no primal feasibility, stationary point of constraint violation
          return SolutionStatus::INFEASIBLE_STATIONARY_POINT;
       }

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -198,7 +198,7 @@ namespace uno {
             return false;
          }
       }
-      if (current_iterate.primal_feasibility > 1e-4) { // TODO add option
+      if (current_iterate.primal_infeasibility > 1e-4) { // TODO add option
          return false;
       }
       return true;

--- a/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
+++ b/uno/ingredients/globalization_mechanisms/GlobalizationMechanism.cpp
@@ -48,7 +48,7 @@ namespace uno {
          statistics.set("Objective", evaluations.objective);
       }
       if (model.is_constrained()) {
-         statistics.set("Infeas", iterate.primal_feasibility);
+         statistics.set("Infeas", iterate.primal_infeasibility);
       }
    }
 

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
@@ -119,7 +119,7 @@ namespace uno {
 
    bool WaechterFilterMethod::is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double reference_infeasibility) const {
       // use the infeasibility in the residual norm here (inf norm for IPOPT implementation)
-      return trial_iterate.primal_feasibility <= this->sufficient_infeasibility_decrease_factor * reference_infeasibility &&
+      return trial_iterate.primal_infeasibility <= this->sufficient_infeasibility_decrease_factor * reference_infeasibility &&
          this->filter->filter_acceptable(trial_iterate.progress.infeasibility, unconstrained_merit_function(trial_iterate.progress));
    }
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/BarrierParameterUpdateStrategy.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/BarrierParameterUpdateStrategy.hpp
@@ -66,7 +66,7 @@ namespace uno {
          const Iterate& current_iterate, const DualResiduals& residuals) {
       // primal-dual errors
       const double scaled_stationarity = residuals.stationarity / residuals.stationarity_scaling;
-      const double primal_feasibility = (problem.get_objective_multiplier() == 0.) ? 0. : current_iterate.primal_feasibility;
+      const double primal_feasibility = (problem.get_objective_multiplier() == 0.) ? 0. : current_iterate.primal_infeasibility;
       double primal_dual_error = std::max({
          scaled_stationarity,
          primal_feasibility,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -147,7 +147,7 @@ namespace uno {
 
       // temporarily update the objective multiplier
       this->previous_barrier_parameter = this->barrier_parameter();
-      const double new_barrier_parameter = std::max(this->barrier_parameter(), current_iterate.primal_feasibility);
+      const double new_barrier_parameter = std::max(this->barrier_parameter(), current_iterate.primal_infeasibility);
       this->barrier_parameter_update_strategy.set_barrier_parameter(new_barrier_parameter);
       this->parameterization.set("barrier_parameter", this->barrier_parameter());
       DEBUG << "Barrier parameter mu temporarily updated to " << this->barrier_parameter() << '\n';

--- a/uno/optimization/Iterate.cpp
+++ b/uno/optimization/Iterate.cpp
@@ -25,11 +25,12 @@ namespace uno {
       stream << "            " << symbols::top_pipe << " Constraint: " << iterate.multipliers.constraints << '\n';
       stream << "Multipliers " << symbols::pipe << " Lower bound: " << iterate.multipliers.lower_bounds << '\n';
       stream << "            " << symbols::bottom_pipe << " Upper bound: " << iterate.multipliers.upper_bounds << '\n';
-      stream << "Primal feasibility: " << iterate.primal_infeasibility << '\n';
 
-      stream << "          " << symbols::top_pipe << " Stationarity: " << iterate.residuals.stationarity << '\n';
-      stream << "Residuals " << symbols::pipe << " Complementarity: " << iterate.residuals.complementarity << '\n';
-      stream << "          " << symbols::bottom_pipe << " Lagrangian gradient: " << iterate.residuals.lagrangian_gradient << '\n';
+      stream << "          " << symbols::top_pipe << " Primal infeasibility: " << iterate.primal_infeasibility << '\n';
+      stream << "Residuals " << symbols::pipe << " Stationarity: " << iterate.residuals.stationarity << '\n';
+      stream << "          " << symbols::bottom_pipe << " Complementarity: " << iterate.residuals.complementarity << '\n';
+
+      stream << "Lagrangian gradient: " << iterate.residuals.lagrangian_gradient << '\n';
 
       stream << "                  " << symbols::top_pipe << " Infeasibility: " << iterate.progress.infeasibility << '\n';
       stream << "Progress measures " << symbols::pipe << " Optimality: " << iterate.progress.objective(1.) << '\n';

--- a/uno/optimization/Iterate.cpp
+++ b/uno/optimization/Iterate.cpp
@@ -25,7 +25,7 @@ namespace uno {
       stream << "            " << symbols::top_pipe << " Constraint: " << iterate.multipliers.constraints << '\n';
       stream << "Multipliers " << symbols::pipe << " Lower bound: " << iterate.multipliers.lower_bounds << '\n';
       stream << "            " << symbols::bottom_pipe << " Upper bound: " << iterate.multipliers.upper_bounds << '\n';
-      stream << "Primal feasibility: " << iterate.primal_feasibility << '\n';
+      stream << "Primal feasibility: " << iterate.primal_infeasibility << '\n';
 
       stream << "          " << symbols::top_pipe << " Stationarity: " << iterate.residuals.stationarity << '\n';
       stream << "Residuals " << symbols::pipe << " Complementarity: " << iterate.residuals.complementarity << '\n';

--- a/uno/optimization/Iterate.hpp
+++ b/uno/optimization/Iterate.hpp
@@ -19,7 +19,7 @@ namespace uno {
       double objective_multiplier{1.};
 
       // primal-dual residuals
-      double primal_feasibility{INF<double>};
+      double primal_infeasibility{INF<double>};
       DualResiduals residuals;
 
       // measures of progress (infeasibility, objective, auxiliary)

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -246,7 +246,7 @@ namespace uno {
          double dual_tolerance) const {
       // evaluate termination conditions based on optimality conditions
       const bool stationarity = (current_iterate.residuals.stationarity / current_iterate.residuals.stationarity_scaling <= dual_tolerance);
-      const bool primal_feasibility = (current_iterate.primal_feasibility <= primal_tolerance);
+      const bool primal_feasibility = (current_iterate.primal_infeasibility <= primal_tolerance);
       const bool complementarity = (current_iterate.residuals.complementarity / current_iterate.residuals.complementarity_scaling <= dual_tolerance);
 
       DEBUG << "\nTermination criteria for primal-dual tolerances = (" << primal_tolerance << ", " << dual_tolerance << "):\n";

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -245,16 +245,16 @@ namespace uno {
    SolutionStatus OptimizationProblem::check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,
          double dual_tolerance) const {
       // evaluate termination conditions based on optimality conditions
-      const bool stationarity = (current_iterate.residuals.stationarity / current_iterate.residuals.stationarity_scaling <= dual_tolerance);
       const bool primal_feasibility = (current_iterate.primal_infeasibility <= primal_tolerance);
+      const bool stationarity = (current_iterate.residuals.stationarity / current_iterate.residuals.stationarity_scaling <= dual_tolerance);
       const bool complementarity = (current_iterate.residuals.complementarity / current_iterate.residuals.complementarity_scaling <= dual_tolerance);
 
       DEBUG << "\nTermination criteria for primal-dual tolerances = (" << primal_tolerance << ", " << dual_tolerance << "):\n";
+      DEBUG << "Primal infeasibility: " << std::boolalpha << primal_feasibility << '\n';
       DEBUG << "Stationarity: " << std::boolalpha << stationarity << '\n';
-      DEBUG << "Primal feasibility: " << std::boolalpha << primal_feasibility << '\n';
       DEBUG << "Complementarity: " << std::boolalpha << complementarity << '\n';
 
-      if (stationarity && primal_feasibility && 0. < current_iterate.objective_multiplier && complementarity) {
+      if (primal_feasibility && stationarity && 0. < current_iterate.objective_multiplier && complementarity) {
          // feasible regular stationary point
          return SolutionStatus::FEASIBLE_KKT_POINT;
       }

--- a/uno/optimization/Result.cpp
+++ b/uno/optimization/Result.cpp
@@ -14,10 +14,9 @@ namespace uno {
       DISCRETE << "Solution status:\t\t\t" << solution_status_to_message(this->solution_status) << '\n';
 
       DISCRETE << "Objective value:\t\t\t" << std::defaultfloat << std::setprecision(7) << this->solution_objective << '\n';
-      DISCRETE << "Primal feasibility:\t\t\t" << this->solution_primal_feasibility << '\n';
 
-      DISCRETE << symbols::top_pipe << " Stationarity residual:\t\t" << this->solution_stationarity << '\n';
-      DISCRETE << symbols::pipe << " Primal feasibility:\t\t\t" << this->solution_primal_feasibility << '\n';
+      DISCRETE << symbols::top_pipe << " Primal infeasibility:\t\t\t" << this->solution_primal_feasibility << '\n';
+      DISCRETE << symbols::pipe << " Stationarity residual:\t\t" << this->solution_stationarity << '\n';
       DISCRETE << symbols::bottom_pipe << " Complementarity residual:\t\t" << this->solution_complementarity << '\n';
 
       if (print_primal_dual_solution) {


### PR DESCRIPTION
Thanks to https://github.com/cvanaret/Uno/pull/898, the `ipopt` preset now solves the infeasible instances `isolated`, `nactive` and `unique` (see [Infeasibility detection and SQP methods for nonlinear optimization](https://epubs.siam.org/doi/abs/10.1137/080738222)). These were already tested for the `filtersqp` preset in `runtests_filtersqp_bqpd_charlies_instances.yml`.

- renamed into `runtests_charlies_instances.yml`
- parameterized with preset
- test `filtersqp` and `ipopt` presets