### PR TITLE
IPM fixes

### DIFF
--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -48,8 +48,7 @@ namespace uno {
       // reformulate the model if:
       // - the user wants an interior-point method with log barrier function
       // - the model has bound constraints or inequality constraints
-      if (options.get_string("inequality_handling_method") == "interior_point" && options.get_string("barrier_function") == "log" &&
-            (model.has_bound_constraints() || model.has_inequality_constraints())) {
+      if (options.get_string("inequality_handling_method") == "interior_point" && options.get_string("barrier_function") == "log") {
          // move the fixed variables to the set of general constraints
          const FixedBoundsConstraintsModel fixed_bound_model(model);
          // if an equality-constrained problem is required (e.g. interior points or AL), reformulate the model with slacks

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -218,11 +218,11 @@ namespace uno {
 
       // swap the iterate's multipliers and the optimality multipliers maintained by the class, and possibly compute
       // least-squares multipliers for the original problem
-      std::swap(current_iterate.multipliers, this->other_phase_multipliers);
+      std::swap(trial_iterate.multipliers, this->other_phase_multipliers);
       // this->inequality_handling_method->compute_least_squares_multipliers(trial_iterate, trial_evaluations);
-      current_iterate.multipliers.constraints.fill(0.);
-      current_iterate.multipliers.lower_bounds.fill(1.); // TODO compute based on the linearized complementarity equation
-      current_iterate.multipliers.upper_bounds.fill(-1.);
+      trial_iterate.multipliers.constraints.fill(0.);
+      //trial_iterate.multipliers.lower_bounds.fill(1.); // TODO compute based on the linearized complementarity equation
+      //trial_iterate.multipliers.upper_bounds.fill(-1.);
 
       current_iterate.set_number_variables(this->original_problem.number_variables);
       trial_iterate.set_number_variables(this->original_problem.number_variables);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -115,13 +115,15 @@ namespace uno {
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
 
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
-      this->feasibility_problem.set_proximal_coefficient(this->feasibility_inequality_handling_method->proximal_coefficient());
+      const double proximal_coefficient = this->feasibility_inequality_handling_method->proximal_coefficient();
+      this->feasibility_problem.set_proximal_coefficient(proximal_coefficient);
+      DEBUG << "Proximal coefficient set to " << proximal_coefficient << '\n';
       this->feasibility_inequality_handling_method->set_elastic_variable_values(this->feasibility_problem, current_iterate,
          current_evaluations);
       // re-evaluate the progress measures at the current iterate
       this->feasibility_inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
 
-      DEBUG2 << "Current iterate to start feasibility restoration:\n" << current_iterate << '\n';
+      DEBUG2 << "\nCurrent iterate to start feasibility restoration:\n" << current_iterate << '\n';
 
       if (Logger::level == INFO) statistics.print_current_line();
       warmstart_information.whole_problem_changed();

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -195,7 +195,7 @@ namespace uno {
          // compute the linearized constraint violation
          // TODO preallocate
          Vector<double> result(model.number_constraints);
-         current_evaluations.compute_jacobian_vector_product(model, direction.primals.view(), result.view());
+         current_evaluations.compute_jacobian_vector_product(model, view(direction.primals, 0, model.number_variables), result.view());
          const double trial_linearized_constraint_violation = model.constraint_violation(current_evaluations.constraints +
             step_length * result, this->residual_norm);
          const bool switch_back = (trial_linearized_constraint_violation <= this->linear_feasibility_tolerance);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -221,7 +221,7 @@ namespace uno {
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
       // this->inequality_handling_method->compute_least_squares_multipliers(trial_iterate, trial_evaluations);
       current_iterate.multipliers.constraints.fill(0.);
-      current_iterate.multipliers.lower_bounds.fill(1.);
+      current_iterate.multipliers.lower_bounds.fill(1.); // TODO compute based on the linearized complementarity equation
       current_iterate.multipliers.upper_bounds.fill(-1.);
 
       current_iterate.set_number_variables(this->original_problem.number_variables);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -219,6 +219,8 @@ namespace uno {
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
       // this->inequality_handling_method->compute_least_squares_multipliers(trial_iterate, trial_evaluations);
       current_iterate.multipliers.constraints.fill(0.);
+      current_iterate.multipliers.lower_bounds.fill(1.);
+      current_iterate.multipliers.upper_bounds.fill(-1.);
 
       current_iterate.set_number_variables(this->original_problem.number_variables);
       trial_iterate.set_number_variables(this->original_problem.number_variables);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -101,7 +101,6 @@ namespace uno {
       // save the current point (infeasibility and primals) upon switching
       this->reference_infeasibility = current_iterate.primal_infeasibility;
       this->reference_optimality_primals = current_iterate.primals;
-      this->feasibility_problem.set_proximal_coefficient(this->inequality_handling_method->proximal_coefficient());
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
 
       current_iterate.set_number_variables(this->feasibility_problem.number_variables);
@@ -116,6 +115,7 @@ namespace uno {
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
 
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
+      this->feasibility_problem.set_proximal_coefficient(this->feasibility_inequality_handling_method->proximal_coefficient());
       this->feasibility_inequality_handling_method->set_elastic_variable_values(this->feasibility_problem, current_iterate,
          current_evaluations);
       // re-evaluate the progress measures at the current iterate

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -164,22 +164,26 @@ namespace uno {
             termination = true;
          }
          // from here on, the trial iterate is rejected
-         else if (step_length >= this->minimum_step_length) {
+         else {
             step_length = this->decrease_step_length(step_length);
-            evaluation_cache.trial_evaluations.reset();
-         }
-         else { // minimum_step_length reached
-            DEBUG << "The line search step length is smaller than " << this->minimum_step_length << '\n';
-            // check if we can terminate at a first-order point
-            if (trial_iterate.status != SolutionStatus::NOT_OPTIMAL) {
-               statistics.set("Status", "accepted (small step length)");
-               termination = true;
+            if (step_length * direction.primal_dual_step_length >= this->minimum_step_length) {
+               // keep going
+               evaluation_cache.trial_evaluations.reset();
             }
             else {
-               // switch to solving the feasibility problem
-               statistics.set("Status", "small step length");
-               evaluation_cache.trial_evaluations.reset();
-               return false;
+               // minimum_step_length reached
+               DEBUG << "The line search step length is smaller than " << this->minimum_step_length << '\n';
+               // check if we can terminate at a first-order point
+               if (trial_iterate.status != SolutionStatus::NOT_OPTIMAL) {
+                  statistics.set("Status", "accepted (small step length)");
+                  termination = true;
+               }
+               else {
+                  // switch to solving the feasibility problem
+                  statistics.set("Status", "small step length");
+                  evaluation_cache.trial_evaluations.reset();
+                  return false;
+               }
             }
          }
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -178,7 +178,10 @@ namespace uno {
       // (mu_over_rho - jacobian_coefficient*this->barrier_constraints[j] + std::sqrt(radical))/2.
       // where jacobian_coefficient = -1 for p, +1 for n
       // Note: IPOPT uses a '+' sign because they define the Lagrangian as f(x) + \lambda^T c(x)
+      std::cout << "Current x = " << view(iterate.primals.data(), 2) << '\n';
+      evaluations.are_constraints_computed = false;
       evaluations.evaluate_constraints(feasibility_problem.model, iterate.primals);
+      std::cout << "CONSTRAINT VALUES: " << evaluations.constraints << '\n';
       const double mu = this->barrier_parameter();
       const auto elastic_setting_function = [&](Iterate& iterate, size_t constraint_index, size_t elastic_index, double jacobian_coefficient) {
          // precomputations
@@ -199,6 +202,7 @@ namespace uno {
          }
       };
       feasibility_problem.set_elastic_variable_values(iterate, elastic_setting_function);
+      //throw std::runtime_error("STOP HERE");
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -178,10 +178,8 @@ namespace uno {
       // (mu_over_rho - jacobian_coefficient*this->barrier_constraints[j] + std::sqrt(radical))/2.
       // where jacobian_coefficient = -1 for p, +1 for n
       // Note: IPOPT uses a '+' sign because they define the Lagrangian as f(x) + \lambda^T c(x)
-      std::cout << "Current x = " << view(iterate.primals.data(), 2) << '\n';
       evaluations.are_constraints_computed = false;
       evaluations.evaluate_constraints(feasibility_problem.model, iterate.primals);
-      std::cout << "CONSTRAINT VALUES: " << evaluations.constraints << '\n';
       const double mu = this->barrier_parameter();
       const auto elastic_setting_function = [&](Iterate& iterate, size_t constraint_index, size_t elastic_index, double jacobian_coefficient) {
          // precomputations

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -178,7 +178,6 @@ namespace uno {
       // (mu_over_rho - jacobian_coefficient*this->barrier_constraints[j] + std::sqrt(radical))/2.
       // where jacobian_coefficient = -1 for p, +1 for n
       // Note: IPOPT uses a '+' sign because they define the Lagrangian as f(x) + \lambda^T c(x)
-      evaluations.are_constraints_computed = false;
       evaluations.evaluate_constraints(feasibility_problem.model, iterate.primals);
       const double mu = this->barrier_parameter();
       const auto elastic_setting_function = [&](Iterate& iterate, size_t constraint_index, size_t elastic_index, double jacobian_coefficient) {


### PR DESCRIPTION
- Use `HomogeneousEqualityConstrained` reformulation even if no inequalities/bounds: the restoration phase will thank you!
- Cap the LS step length *including the FTB scaling* to `minimum_step_length`
- Set bound duals to +/-1 when switching back. **TODO**: compute their values using the linearized complementarity equation
- Take the prox coefficient from the *feasibility* barrier method (the optimality inequality handling method may be `NoInequalityReformulation`)
- When switching back, reset the duals of the *trial iterate* (not the current iterate!)