### PR TITLE
Use a filter method for globalizing the ipopt restoration phase

### DIFF
--- a/.github/julia/runtests_uno_filterslp_highs.jl
+++ b/.github/julia/runtests_uno_filterslp_highs.jl
@@ -62,6 +62,6 @@ Optimizer_Uno_filterslp() = Optimizer(["logger=SILENT", "preset=filterslp", "LP_
         primal_target,
         objective_tol = 1e-4,
         primal_tol = 1e-3,
-        exclude = ["501_010", "501_011"],  # Iteration limit
+        exclude = ["105_013", "501_010", "501_011"],  # Iteration limit
     )
 end

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -189,6 +189,7 @@ namespace uno {
    bool FeasibilityRestoration::can_switch_to_optimality_phase(const Model& model, Iterate& trial_iterate,
          const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
       this->inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);
+      compute_residuals(this->original_problem, trial_iterate, trial_evaluations);
       if (this->globalization_strategy->is_infeasibility_sufficiently_reduced(trial_iterate, this->reference_infeasibility)) {
          if (!this->switch_to_optimality_requires_linearized_feasibility) {
             return true;
@@ -202,10 +203,12 @@ namespace uno {
          const bool switch_back = (trial_linearized_constraint_violation <= this->linear_feasibility_tolerance);
          if (!switch_back) {
             this->feasibility_inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);
+            compute_residuals(this->feasibility_problem, trial_iterate, trial_evaluations);
          }
          return switch_back;
       }
       this->feasibility_inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);
+      compute_residuals(this->feasibility_problem, trial_iterate, trial_evaluations);
       return false;
    }
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -97,6 +97,7 @@ namespace uno {
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
       this->feasibility_globalization_strategy->initialize(statistics, current_iterate);
+      this->feasibility_globalization_strategy->reset();
 
       // save the current point (infeasibility and primals) upon switching
       this->reference_infeasibility = current_iterate.primal_infeasibility;

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -60,7 +60,7 @@ namespace uno {
 
       // statistics
       this->inequality_handling_method->initialize_statistics(statistics);
-      // this->feasibility_inequality_handling_method->initialize_statistics(statistics);
+      this->feasibility_inequality_handling_method->initialize_statistics(statistics);
       statistics.add_column("Phase", Statistics::int_width - 1, 3);
       statistics.set("Phase", "OPT");
    }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -31,7 +31,7 @@ namespace uno {
          // relax the linear constraints in the l1 relaxed problem only if we are using a trust-region constraint
          feasibility_problem(model, 0., this->constraint_violation_coefficient, use_trust_region),
          globalization_strategy(GlobalizationStrategyFactory::create(model, options)),
-         feasibility_globalization_strategy(options),
+         feasibility_globalization_strategy(GlobalizationStrategyFactory::create(model, options)),
          linear_feasibility_tolerance(options.get_double("primal_tolerance")),
          switch_to_optimality_requires_linearized_feasibility(options.get_bool("switch_to_optimality_requires_linearized_feasibility")) {
    }
@@ -57,7 +57,6 @@ namespace uno {
       this->inequality_handling_method->evaluate_progress_measures(initial_iterate, evaluation_cache.current_evaluations);
       this->compute_residuals(this->original_problem, initial_iterate, evaluation_cache.current_evaluations);
       this->globalization_strategy->initialize(statistics, initial_iterate);
-      this->feasibility_globalization_strategy.initialize(statistics, initial_iterate);
 
       // statistics
       this->inequality_handling_method->initialize_statistics(statistics);
@@ -82,7 +81,7 @@ namespace uno {
          DEBUG << "Solving the feasibility subproblem\n";
          statistics.set("Phase", "FEAS");
          return this->solve_subproblem(statistics, *this->feasibility_inequality_handling_method,
-            this->feasibility_globalization_strategy, current_iterate, trust_region_radius, current_evaluations,
+            *this->feasibility_globalization_strategy, current_iterate, trust_region_radius, current_evaluations,
             warmstart_information);
       }
    }
@@ -97,6 +96,7 @@ namespace uno {
       DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
       this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
+      this->feasibility_globalization_strategy->initialize(statistics, current_iterate);
 
       // save the current point (infeasibility and primals) upon switching
       this->reference_infeasibility = current_iterate.primal_infeasibility;
@@ -246,7 +246,7 @@ namespace uno {
       }
       else {
          accept_iterate = this->feasibility_inequality_handling_method->is_iterate_acceptable(statistics,
-            this->feasibility_globalization_strategy, current_iterate, trial_iterate, direction, step_length, current_evaluations,
+            *this->feasibility_globalization_strategy, current_iterate, trial_iterate, direction, step_length, current_evaluations,
             trial_evaluations);
          if (uses_trust_region || accept_iterate) {
             this->feasibility_inequality_handling_method->notify_trial_iterate(statistics, current_iterate, trial_iterate,

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -59,7 +59,7 @@ namespace uno {
       std::unique_ptr<InequalityHandlingMethod> inequality_handling_method;
       std::unique_ptr<InequalityHandlingMethod> feasibility_inequality_handling_method;
       std::unique_ptr<GlobalizationStrategy> globalization_strategy;
-      MeritFunction feasibility_globalization_strategy;
+      std::unique_ptr<GlobalizationStrategy> feasibility_globalization_strategy;
       Vector<double> initial_point;
 
       // the class maintains multipliers for the other phase (feasibility multipliers if we are in the optimality phase,

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/ElasticVariables.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/ElasticVariables.hpp
@@ -15,6 +15,8 @@ namespace uno {
       size_t negative{0};
    };
 
+   enum class ElasticType {POSITIVE, NEGATIVE};
+
    class ElasticVariables {
    public:
       SparseVector<size_t> positive{};

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -361,7 +361,7 @@ namespace uno {
    void l1RelaxedProblem::set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm /*norm*/) const {
       Vector<double> constraints(this->number_constraints); // TODO preallocate
       this->evaluate_constraints(iterate, constraints.view(), evaluations);
-      iterate.progress.infeasibility = norm_1(constraints);
+      iterate.progress.infeasibility = this->model.constraint_violation(constraints, Norm::L1);
    }
 
    // rho * sum(p + n)
@@ -404,7 +404,7 @@ namespace uno {
       // r + α(JΔx − Δp + Δn) = r - α r = (1-α) r
       // so pred(α) = ‖r‖ − ‖(1−α) r‖ = α ‖c(x) − p + n‖
       // note: this assumes that JΔx − Δp + Δn = -r, which is the case for KKT systems
-      return step_length * norm_1(constraints);
+      return step_length * this->model.constraint_violation(constraints, Norm::L1);
    }
 
    std::function<double(double)> l1RelaxedProblem::compute_predicted_objective_reduction(const Iterate& /*current_iterate*/,

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -346,14 +346,13 @@ namespace uno {
       return {this->model.number_variables, this->number_constraints, this->elastic_variables.size()};
    }
 
-   void l1RelaxedProblem::set_elastic_variable_values(Iterate& iterate, const std::function<void(Iterate&, size_t, size_t,
-         double)>& elastic_setting_function) const {
-      iterate.set_number_variables(this->number_variables);
+   void l1RelaxedProblem::set_elastic_variable_values(const std::function<void(size_t, size_t, ElasticType)>&
+         elastic_setting_function) const {
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.positive) {
-         elastic_setting_function(iterate, constraint_index, elastic_index, -1.);
+         elastic_setting_function(constraint_index, elastic_index, ElasticType::POSITIVE); // Jacobian coefficient -1
       }
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.negative) {
-         elastic_setting_function(iterate, constraint_index, elastic_index, 1.);
+         elastic_setting_function(constraint_index, elastic_index, ElasticType::NEGATIVE); // Jacobian coefficient 1
       }
    }
 

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -359,16 +359,24 @@ namespace uno {
 
    // progress measures
 
-   void l1RelaxedProblem::set_infeasibility_measure(Iterate& iterate, Evaluations& /*evaluations*/, Norm /*norm*/) const {
-      iterate.progress.infeasibility = 0.;
+   void l1RelaxedProblem::set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm /*norm*/) const {
+      Vector<double> constraints(this->number_constraints); // TODO preallocate
+      this->evaluate_constraints(iterate, constraints.view(), evaluations);
+      iterate.progress.infeasibility = norm_1(constraints);
    }
 
-   void l1RelaxedProblem::set_objective_measure(Iterate& iterate, Evaluations& evaluations) const {
-      evaluations.evaluate_constraints(this->model, iterate.primals);
-      const double scaled_constraint_violation = this->constraint_violation_coefficient *
-         this->model.constraint_violation(evaluations.constraints, Norm::L1);
+   // rho * sum(p + n)
+   void l1RelaxedProblem::set_objective_measure(Iterate& iterate, Evaluations& /*evaluations*/) const {
+      double objective_measure = 0.;
+      for (const auto [constraint_index, elastic_index]: this->elastic_variables.positive) {
+         objective_measure += iterate.primals[elastic_index];
+      }
+      for (const auto [constraint_index, elastic_index]: this->elastic_variables.negative) {
+         objective_measure += iterate.primals[elastic_index];
+      }
+      objective_measure *= this->constraint_violation_coefficient;
       iterate.progress.objective = [=](double /*objective_multiplier*/) {
-         return scaled_constraint_violation;
+         return objective_measure;
       };
    }
 
@@ -389,26 +397,29 @@ namespace uno {
 
    // predicted reductions
 
-   double l1RelaxedProblem::compute_predicted_infeasibility_reduction(const Iterate& /*current_iterate*/,
-         const Vector<double>& /*primal_direction*/, double /*step_length*/, Norm /*norm*/, Evaluations& /*current_evaluations*/) const {
-      return 0.;
+   double l1RelaxedProblem::compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& /*primal_direction*/, double step_length, Norm /*norm*/, Evaluations& current_evaluations) const {
+      Vector<double> constraints(this->number_constraints); // TODO preallocate
+      this->evaluate_constraints(current_iterate, constraints.view(), current_evaluations);
+      // Let r = c(x) − p + n
+      // r + α(JΔx − Δp + Δn) = r - α r = (1-α) r
+      // so pred(α) = ‖r‖ − ‖(1−α) r‖ = α ‖c(x) − p + n‖
+      // note: this assumes that JΔx − Δp + Δn = -r, which is the case for KKT systems
+      return step_length * norm_1(constraints);
    }
 
-   std::function<double(double)> l1RelaxedProblem::compute_predicted_objective_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
+   std::function<double(double)> l1RelaxedProblem::compute_predicted_objective_reduction(const Iterate& /*current_iterate*/,
+         const Vector<double>& primal_direction, double step_length, Evaluations& /*current_evaluations*/,
          double /*hessian_quadratic_form*/) const {
-      // predicted infeasibility reduction: "‖c(x)‖ - ‖c(x) + ∇c(x)^T (αd)‖"
-      current_evaluations.evaluate_constraints(this->model, current_iterate.primals);
-      current_evaluations.evaluate_jacobian(this->model, current_iterate.primals);
-
-      const double current_constraint_violation = this->model.constraint_violation(current_evaluations.constraints, Norm::L1);
-      // TODO preallocate
-      Vector<double> result(this->model.number_constraints);
-      current_evaluations.compute_jacobian_vector_product(this->model, primal_direction.view(), result.view());
-      const double trial_linearized_constraint_violation = this->model.constraint_violation(current_evaluations.constraints +
-         step_length * result, Norm::L1);
-      const double predicted_reduction = this->constraint_violation_coefficient * (current_constraint_violation -
-         trial_linearized_constraint_violation);
+      // −α ρ sum(Δp + Δn)
+      double predicted_reduction = 0.;
+      for (const auto [constraint_index, elastic_index]: this->elastic_variables.positive) {
+         predicted_reduction += primal_direction[elastic_index];
+      }
+      for (const auto [constraint_index, elastic_index]: this->elastic_variables.negative) {
+         predicted_reduction += primal_direction[elastic_index];
+      }
+      predicted_reduction *= -step_length * this->constraint_violation_coefficient;
       return [=](double /*objective_multiplier*/) {
          return predicted_reduction;
       };
@@ -417,7 +428,7 @@ namespace uno {
    double l1RelaxedProblem::compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
          const Vector<double>& primal_direction, double step_length) const {
       double predicted_auxiliary_reduction = 0.;
-      // form the directional derivative -zeta D_R^2 (x - x_R) and scale it by the step length
+      // form the directional derivative zeta D_R^2 (x - x_R) d and scale it by the step length
       if (this->proximal_center != nullptr && this->proximal_coefficient != 0.) {
          for (size_t variable_index: Range(this->model.number_variables)) {
             const double scaling = std::min(1., 1./std::abs(this->proximal_center[variable_index]));

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -66,7 +66,7 @@ namespace uno {
       [[nodiscard]] SolutionStatus check_first_order_convergence(const Iterate& current_iterate, double primal_tolerance,
          double dual_tolerance) const override;
 
-      void set_elastic_variable_values(Iterate& iterate, const std::function<void(Iterate&, size_t, size_t, double)>& elastic_setting_function) const;
+      void set_elastic_variable_values(const std::function<void(size_t, size_t, ElasticType)>& elastic_setting_function) const;
 
       // progress measures
       void set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm norm) const override;

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
@@ -74,11 +74,9 @@ namespace uno {
 
    bool FletcherFilterMethod::is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
          double reference_infeasibility) const {
-      // use the infeasibility in the residual norm here (inf norm for IPOPT implementation)
-      DEBUG << "Testing whether " << trial_iterate.primal_infeasibility << " <= " << this->sufficient_infeasibility_decrease_factor
-         << "*" << reference_infeasibility << " = " << this->sufficient_infeasibility_decrease_factor * reference_infeasibility << '\n';
+      // if the trial infeasibility improves upon the best known infeasibility
       return trial_iterate.primal_infeasibility <= this->sufficient_infeasibility_decrease_factor * reference_infeasibility &&
-         this->filter->filter_acceptable(trial_iterate.progress.infeasibility, unconstrained_merit_function(trial_iterate.progress));
+         this->filter->infeasibility_sufficient_reduction(this->filter->get_smallest_infeasibility(), trial_iterate.progress.infeasibility);
    }
 
    std::string FletcherFilterMethod::get_name() const {

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
@@ -5,12 +5,16 @@
 #include "filters/Filter.hpp"
 #include "ingredients/globalization_strategies/ProgressMeasures.hpp"
 #include "optimization/Iterate.hpp"
+#include "options/Options.hpp"
 #include "tools/Logger.hpp"
 #include "tools/Statistics.hpp"
 #include "tools/Symbols.hpp"
 
 namespace uno {
-   FletcherFilterMethod::FletcherFilterMethod(const Options& options): FilterMethod(options) { }
+   FletcherFilterMethod::FletcherFilterMethod(const Options& options):
+         FilterMethod(options),
+         sufficient_infeasibility_decrease_factor(options.get_double("filter_sufficient_infeasibility_decrease_factor")) {
+   }
 
    bool FletcherFilterMethod::is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
          const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double /*objective_multiplier*/) {
@@ -69,10 +73,12 @@ namespace uno {
    }
 
    bool FletcherFilterMethod::is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
-      double /*reference_infeasibility*/) const {
-      // if the trial infeasibility improves upon the best known infeasibility
-      return this->filter->infeasibility_sufficient_reduction(this->filter->get_smallest_infeasibility(),
-         trial_iterate.progress.infeasibility);
+         double reference_infeasibility) const {
+      // use the infeasibility in the residual norm here (inf norm for IPOPT implementation)
+      DEBUG << "Testing whether " << trial_iterate.primal_infeasibility << " <= " << this->sufficient_infeasibility_decrease_factor
+         << "*" << reference_infeasibility << " = " << this->sufficient_infeasibility_decrease_factor * reference_infeasibility << '\n';
+      return trial_iterate.primal_infeasibility <= this->sufficient_infeasibility_decrease_factor * reference_infeasibility &&
+         this->filter->filter_acceptable(trial_iterate.progress.infeasibility, unconstrained_merit_function(trial_iterate.progress));
    }
 
    std::string FletcherFilterMethod::get_name() const {

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.hpp
@@ -18,6 +18,9 @@ namespace uno {
          double reference_infeasibility) const override;
 
       [[nodiscard]] std::string get_name() const override;
+
+   protected:
+      const double sufficient_infeasibility_decrease_factor;
    };
 } // namespace
 

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
@@ -58,6 +58,7 @@ namespace uno {
          // unconstrained Armijo sufficient decrease condition: predicted reduction should be positive (f-type)
          if (sufficient_decrease) {
             DEBUG << "Trial iterate (f-type) was accepted by satisfying Armijo condition\n";
+            statistics.set("Status", std::string(symbols::check) + " (f-type)");
          }
          else {
             DEBUG << "Armijo condition not satisfied\n";
@@ -71,6 +72,7 @@ namespace uno {
          if (this->filter->acceptable_wrt_current_iterate(current_progress.infeasibility, current_merit,
                trial_progress.infeasibility, trial_merit)) {
             DEBUG << "Trial iterate (h-type) acceptable with respect to current point\n";
+            statistics.set("Status", std::string(symbols::check) + " (h-type)");
          }
          else {
             DEBUG << "Trial iterate (h-type) not acceptable with respect to current point\n";
@@ -113,7 +115,6 @@ namespace uno {
          DEBUG << "Adding current iterate to the filter\n";
          this->filter->add(current_progress.infeasibility, current_merit);
       }
-      statistics.set("Status", std::string(symbols::check) + " (filter)");
       return true;
    }
 

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -49,27 +49,28 @@ namespace uno {
 
    void NoInequalityReformulation::set_elastic_variable_values(const l1RelaxedProblem& feasibility_problem,
          Iterate& current_iterate, Evaluations& evaluations) {
+      current_iterate.set_number_variables(feasibility_problem.number_variables);
       // l <= c(x) - p + n <= u
       evaluations.evaluate_constraints(feasibility_problem.model, current_iterate.primals);
-      feasibility_problem.set_elastic_variable_values(current_iterate, [&](Iterate& iterate, size_t constraint_index,
-            size_t elastic_index, double jacobian_coefficient) {
+      feasibility_problem.set_elastic_variable_values([&](size_t constraint_index,
+            size_t elastic_index, ElasticType elastic_type) {
          // by default
-         iterate.primals[elastic_index] = 0.;
-         iterate.multipliers.lower_bounds[elastic_index] = 1.;
-         iterate.multipliers.upper_bounds[elastic_index] = 0.;
+         current_iterate.primals[elastic_index] = 0.;
+         current_iterate.multipliers.lower_bounds[elastic_index] = 1.;
+         current_iterate.multipliers.upper_bounds[elastic_index] = 0.;
 
          // violated lower bound: set n
          if (evaluations.constraints[constraint_index] < feasibility_problem.get_constraints_lower_bounds()[constraint_index]) {
-            if (jacobian_coefficient == 1.) { // n
-               iterate.primals[elastic_index] = feasibility_problem.get_constraints_lower_bounds()[constraint_index] - evaluations.constraints[constraint_index];
-               iterate.multipliers.lower_bounds[elastic_index] = 0.;
+            if (elastic_type == ElasticType::NEGATIVE) {
+               current_iterate.primals[elastic_index] = feasibility_problem.get_constraints_lower_bounds()[constraint_index] - evaluations.constraints[constraint_index];
+               current_iterate.multipliers.lower_bounds[elastic_index] = 0.;
             }
          }
          // violated upper bound: set p
          else if (feasibility_problem.get_constraints_upper_bounds()[constraint_index] < evaluations.constraints[constraint_index]) {
-            if (jacobian_coefficient == -1.) { // p
-               iterate.primals[elastic_index] = evaluations.constraints[constraint_index] - feasibility_problem.get_constraints_upper_bounds()[constraint_index];
-               iterate.multipliers.lower_bounds[elastic_index] = 0.;
+            if (elastic_type == ElasticType::POSITIVE) {
+               current_iterate.primals[elastic_index] = evaluations.constraints[constraint_index] - feasibility_problem.get_constraints_upper_bounds()[constraint_index];
+               current_iterate.multipliers.lower_bounds[elastic_index] = 0.;
             }
          }
       });

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -8,6 +8,7 @@
 #include "ingredients/inertia_correction_strategies/InertiaCorrectionStrategy.hpp"
 #include "ingredients/subproblem_solvers/SubproblemSolver.hpp"
 #include "optimization/Direction.hpp"
+#include "optimization/Evaluations.hpp"
 #include "tools/Infinity.hpp"
 
 namespace uno {
@@ -46,14 +47,31 @@ namespace uno {
       // do nothing
    }
 
-   void NoInequalityReformulation::set_elastic_variable_values(const l1RelaxedProblem& problem, Iterate& current_iterate,
-         Evaluations& /*evaluations*/) {
-      // c(x) - p + n = 0
-      // TODO set (one of) the elastic variables to +/- the value of the constraint if violated
-      problem.set_elastic_variable_values(current_iterate, [&](Iterate& iterate, size_t /*j*/, size_t elastic_index, double /*jacobian_coefficient*/) {
+   void NoInequalityReformulation::set_elastic_variable_values(const l1RelaxedProblem& feasibility_problem,
+         Iterate& current_iterate, Evaluations& evaluations) {
+      // l <= c(x) - p + n <= u
+      evaluations.evaluate_constraints(feasibility_problem.model, current_iterate.primals);
+      feasibility_problem.set_elastic_variable_values(current_iterate, [&](Iterate& iterate, size_t constraint_index,
+            size_t elastic_index, double jacobian_coefficient) {
+         // by default
          iterate.primals[elastic_index] = 0.;
          iterate.multipliers.lower_bounds[elastic_index] = 1.;
          iterate.multipliers.upper_bounds[elastic_index] = 0.;
+
+         // violated lower bound: set n
+         if (evaluations.constraints[constraint_index] < feasibility_problem.get_constraints_lower_bounds()[constraint_index]) {
+            if (jacobian_coefficient == 1.) { // n
+               iterate.primals[elastic_index] = feasibility_problem.get_constraints_lower_bounds()[constraint_index] - evaluations.constraints[constraint_index];
+               iterate.multipliers.lower_bounds[elastic_index] = 0.;
+            }
+         }
+         // violated upper bound: set p
+         else if (feasibility_problem.get_constraints_upper_bounds()[constraint_index] < evaluations.constraints[constraint_index]) {
+            if (jacobian_coefficient == -1.) { // p
+               iterate.primals[elastic_index] = evaluations.constraints[constraint_index] - feasibility_problem.get_constraints_upper_bounds()[constraint_index];
+               iterate.multipliers.lower_bounds[elastic_index] = 0.;
+            }
+         }
       });
    }
 

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
@@ -30,7 +30,8 @@ namespace uno {
          const Vector<double>& initial_point, Evaluations& current_evaluations, const WarmstartInformation& warmstart_information) override;
 
       void initialize_feasibility_problem(Iterate& current_iterate) override;
-      void set_elastic_variable_values(const l1RelaxedProblem& problem, Iterate& current_iterate, Evaluations& evaluations) override;
+      void set_elastic_variable_values(const l1RelaxedProblem& feasibility_problem, Iterate& current_iterate,
+         Evaluations& evaluations) override;
       [[nodiscard]] double proximal_coefficient() const override;
 
       [[nodiscard]] bool has_second_order_corrections() const override;

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -180,13 +180,14 @@ namespace uno {
       // Note: IPOPT uses a '+' sign because they define the Lagrangian as f(x) + \lambda^T c(x)
       evaluations.evaluate_constraints(feasibility_problem.model, iterate.primals);
       const double mu = this->barrier_parameter();
-      const auto elastic_setting_function = [&](Iterate& iterate, size_t constraint_index, size_t elastic_index, double jacobian_coefficient) {
+      const auto elastic_setting_function = [&](size_t constraint_index, size_t elastic_index, ElasticType elastic_type) {
          // precomputations
          const double constraint_j = evaluations.constraints[constraint_index];
          const double rho = this->l1_constraint_violation_coefficient;
          const double mu_over_rho = mu / rho;
          const double radical = std::pow(constraint_j, 2) + std::pow(mu_over_rho, 2);
          const double sqrt_radical = std::sqrt(radical);
+         const double jacobian_coefficient = (elastic_type == ElasticType::POSITIVE) ? -1. : 1.;
 
          iterate.primals[elastic_index] = (mu_over_rho - jacobian_coefficient * constraint_j + sqrt_radical) / 2.;
          iterate.multipliers.lower_bounds[elastic_index] = mu / iterate.primals[elastic_index];
@@ -198,8 +199,7 @@ namespace uno {
             throw std::runtime_error("The elastic dual is not strictly positive.");
          }
       };
-      feasibility_problem.set_elastic_variable_values(iterate, elastic_setting_function);
-      //throw std::runtime_error("STOP HERE");
+      feasibility_problem.set_elastic_variable_values(elastic_setting_function);
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -401,9 +401,6 @@ namespace uno {
          throw std::runtime_error("Barrier parameter is infinite");
       }
 
-      // if the primals are too close to their bounds, push the bounds away by a small fraction (Section 3.5)
-
-
       // add the contribution of the barrier terms
       double barrier_terms = 0.;
       for (size_t variable_index: Range(this->inner.number_variables)) {

--- a/uno/options/DefaultOptions.cpp
+++ b/uno/options/DefaultOptions.cpp
@@ -139,7 +139,7 @@ namespace uno {
       /** feasibility restoration options **/
       // test linearized feasibility when switching back to the optimality phase
       options.set_bool("switch_to_optimality_requires_linearized_feasibility", true);
-      options.set_double("l1_constraint_violation_coefficient", 1);
+      options.set_double("l1_constraint_violation_coefficient", 1.);
 
       /** barrier subproblem options **/
       options.set_string("barrier_function", "log");


### PR DESCRIPTION
- use a filter method for globalizing the `ipopt` restoration phase
- properly define the l1 relaxation progress measures and local models
- properly initialize the elastics for SQP restoration
- [WIP] use the same `is_infeasibility_sufficiently_reduced` in `FletcherFilterMethod` as in `WaechterFilterMethod`: require 10% of decrease compared to infeasibility at reference point + filter acceptability.

This should have a **large** impact on robustness.