### PR TITLE
Relax linear constraints as well in `l1RelaxedProblem`

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -196,6 +196,7 @@ namespace uno {
             return true;
          }
          // compute the linearized constraint violation
+         this->constraints_buffer.fill(0.);
          current_evaluations.compute_jacobian_vector_product(model, view(direction.primals, 0, model.number_variables),
             this->constraints_buffer.view());
          const double trial_linearized_constraint_violation = model.constraint_violation(current_evaluations.constraints +

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -24,12 +24,12 @@
 #include "tools/UserCallbacks.hpp"
 
 namespace uno {
-   FeasibilityRestoration::FeasibilityRestoration(const Model& model, bool use_trust_region, Options& options) :
+   FeasibilityRestoration::FeasibilityRestoration(const Model& model, bool /*use_trust_region*/, Options& options) :
          ConstraintRelaxationStrategy(options),
          constraint_violation_coefficient(options.get_double("l1_constraint_violation_coefficient")),
          original_problem(model),
          // relax the linear constraints in the l1 relaxed problem only if we are using a trust-region constraint
-         feasibility_problem(model, 0., this->constraint_violation_coefficient, use_trust_region),
+         feasibility_problem(model, 0., this->constraint_violation_coefficient, true /* relax linear constraints */),
          globalization_strategy(GlobalizationStrategyFactory::create(model, options)),
          feasibility_globalization_strategy(GlobalizationStrategyFactory::create(model, options)),
          linear_feasibility_tolerance(options.get_double("primal_tolerance")),

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -33,7 +33,8 @@ namespace uno {
          globalization_strategy(GlobalizationStrategyFactory::create(model, options)),
          feasibility_globalization_strategy(GlobalizationStrategyFactory::create(model, options)),
          linear_feasibility_tolerance(options.get_double("primal_tolerance")),
-         switch_to_optimality_requires_linearized_feasibility(options.get_bool("switch_to_optimality_requires_linearized_feasibility")) {
+         switch_to_optimality_requires_linearized_feasibility(options.get_bool("switch_to_optimality_requires_linearized_feasibility")),
+         constraints_buffer(model.number_constraints) {
    }
 
    FeasibilityRestoration::~FeasibilityRestoration() = default;
@@ -195,11 +196,10 @@ namespace uno {
             return true;
          }
          // compute the linearized constraint violation
-         // TODO preallocate
-         Vector<double> result(model.number_constraints);
-         current_evaluations.compute_jacobian_vector_product(model, view(direction.primals, 0, model.number_variables), result.view());
+         current_evaluations.compute_jacobian_vector_product(model, view(direction.primals, 0, model.number_variables),
+            this->constraints_buffer.view());
          const double trial_linearized_constraint_violation = model.constraint_violation(current_evaluations.constraints +
-            step_length * result, this->residual_norm);
+            step_length * this->constraints_buffer, this->residual_norm);
          const bool switch_back = (trial_linearized_constraint_violation <= this->linear_feasibility_tolerance);
          if (!switch_back) {
             this->feasibility_inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -71,6 +71,8 @@ namespace uno {
       Vector<double> reference_optimality_primals{};
       bool first_switch_to_feasibility{true};
 
+      mutable Vector<double> constraints_buffer;
+
       const Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information);

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/ElasticVariables.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/ElasticVariables.cpp
@@ -11,7 +11,7 @@ namespace uno {
          positive(number_positive_variables), negative(number_negative_variables) { }
 
    ElasticVariables ElasticVariables::generate(const Model& model, bool relax_linear_constraints) {
-      const ElasticVariablesSizes sizes = ElasticVariables::count(model, relax_linear_constraints);
+      const ElasticVariablesSizes sizes = count(model, relax_linear_constraints);
       ElasticVariables elastic_variables(sizes.positive, sizes.negative);
 
       // generate elastic variables to relax the constraints

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -32,7 +32,8 @@ namespace uno {
          variables_lower_bounds(this->number_variables, 0.),
          variables_upper_bounds(this->number_variables, INF<double>),
          jacobian_row_indices(this->model.number_jacobian_nonzeros() + this->elastic_variables.size()),
-         jacobian_column_indices(this->model.number_jacobian_nonzeros() + this->elastic_variables.size()) {
+         jacobian_column_indices(this->model.number_jacobian_nonzeros() + this->elastic_variables.size()),
+         constraints_buffer(this->number_constraints) {
       // copy the original variables. The elastic variables have bounds [0, inf)
       view(this->variables_lower_bounds, 0, model.number_variables) = model.get_variables_lower_bounds();
       view(this->variables_upper_bounds, 0, model.number_variables) = model.get_variables_upper_bounds();
@@ -359,9 +360,8 @@ namespace uno {
    // progress measures
 
    void l1RelaxedProblem::set_infeasibility_measure(Iterate& iterate, Evaluations& evaluations, Norm /*norm*/) const {
-      Vector<double> constraints(this->number_constraints); // TODO preallocate
-      this->evaluate_constraints(iterate, constraints.view(), evaluations);
-      iterate.progress.infeasibility = this->model.constraint_violation(constraints, Norm::L1);
+      this->evaluate_constraints(iterate, this->constraints_buffer.view(), evaluations);
+      iterate.progress.infeasibility = this->model.constraint_violation(this->constraints_buffer, Norm::L1);
    }
 
    // rho * sum(p + n)
@@ -398,13 +398,12 @@ namespace uno {
 
    double l1RelaxedProblem::compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
          const Vector<double>& /*primal_direction*/, double step_length, Norm /*norm*/, Evaluations& current_evaluations) const {
-      Vector<double> constraints(this->number_constraints); // TODO preallocate
-      this->evaluate_constraints(current_iterate, constraints.view(), current_evaluations);
+      this->evaluate_constraints(current_iterate, this->constraints_buffer.view(), current_evaluations);
       // Let r = c(x) − p + n
       // r + α(JΔx − Δp + Δn) = r - α r = (1-α) r
       // so pred(α) = ‖r‖ − ‖(1−α) r‖ = α ‖c(x) − p + n‖
       // note: this assumes that JΔx − Δp + Δn = -r, which is the case for KKT systems
-      return step_length * this->model.constraint_violation(constraints, Norm::L1);
+      return step_length * this->model.constraint_violation(this->constraints_buffer, Norm::L1);
    }
 
    std::function<double(double)> l1RelaxedProblem::compute_predicted_objective_reduction(const Iterate& /*current_iterate*/,

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -97,6 +97,8 @@ namespace uno {
       Vector<uno_int> jacobian_row_indices;
       Vector<uno_int> jacobian_column_indices;
 
+      mutable Vector<double> constraints_buffer;
+
       // delegating constructor
       l1RelaxedProblem(const Model& model, ElasticVariables&& elastic_variables, double objective_multiplier,
          double constraint_violation_coefficient);

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -177,7 +177,6 @@ namespace uno {
       // analytical expression for p and n:
       // (mu_over_rho - jacobian_coefficient*this->barrier_constraints[j] + std::sqrt(radical))/2.
       // where jacobian_coefficient = -1 for p, +1 for n
-      // Note: IPOPT uses a '+' sign because they define the Lagrangian as f(x) + \lambda^T c(x)
       evaluations.evaluate_constraints(feasibility_problem.model, iterate.primals);
       const double mu = this->barrier_parameter();
       const auto elastic_setting_function = [&](size_t constraint_index, size_t elastic_index, ElasticType elastic_type) {


### PR DESCRIPTION
The idea *not* to relax the linear constraints in `l1RelaxedProblem` in the presence of a trust-region constraint deserves to be investigated, but for the elastic initialization of the IPM, this messes things up completely (if the current point is infeasible wrt the linear constraints, there's no elastics to catch this)