### PR TITLE
Cache optimized computation of predicted reductions

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp
@@ -5,6 +5,7 @@
 #define UNO_CONSTRAINTRELAXATIONSTRATEGY_H
 
 #include <cstddef>
+#include "ingredients/globalization_strategies/PredictedReductionModels.hpp"
 #include "linear_algebra/Norm.hpp"
 #include "optimization/Evaluations.hpp"
 #include "optimization/Iterate.hpp"
@@ -49,9 +50,11 @@ namespace uno {
       virtual void update_second_order_corrections(const Iterate& trial_iterate, Evaluations& trial_evaluations) = 0;
 
       // trial iterate acceptance
+      [[nodiscard]] virtual PredictedReductionModels build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const = 0;
       [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, const Model& model, Iterate& current_iterate,
-         Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations, WarmstartInformation& warmstart_information,
+         Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region, Evaluations& current_evaluations,
+         Evaluations& trial_evaluations, const ProgressMeasures& predicted_reductions, WarmstartInformation& warmstart_information,
          UserCallbacks& user_callbacks) = 0;
 
       [[nodiscard]] virtual std::string get_name() const = 0;

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -235,15 +235,27 @@ namespace uno {
       this->initial_point.resize(this->original_problem.number_variables);
    }
 
-   bool FeasibilityRestoration::is_iterate_acceptable(Statistics& statistics, const Model& model,
-         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
-         bool uses_trust_region, Evaluations& current_evaluations, Evaluations& trial_evaluations,
-         WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) {
+   PredictedReductionModels FeasibilityRestoration::build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const {
+      if (this->current_phase == Phase::OPTIMALITY) {
+         return this->inequality_handling_method->build_predicted_reduction_models(current_iterate, direction,
+            current_evaluations);
+      }
+      else {
+         return this->feasibility_inequality_handling_method->build_predicted_reduction_models(current_iterate,
+            direction, current_evaluations);
+      }
+   }
+
+   bool FeasibilityRestoration::is_iterate_acceptable(Statistics& statistics, const Model& model, Iterate& current_iterate,
+         Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region, Evaluations& current_evaluations,
+         Evaluations& trial_evaluations, const ProgressMeasures& predicted_reductions, WarmstartInformation& warmstart_information,
+         UserCallbacks& user_callbacks) {
       bool accept_iterate = false;
       // determine acceptability, depending on the current phase
       if (this->current_phase == Phase::OPTIMALITY) {
          accept_iterate = this->inequality_handling_method->is_iterate_acceptable(statistics, *this->globalization_strategy,
-            current_iterate, trial_iterate, direction, step_length, current_evaluations, trial_evaluations);
+            current_iterate, trial_iterate, direction, trial_evaluations, predicted_reductions);
          if (uses_trust_region || accept_iterate) {
             this->inequality_handling_method->notify_trial_iterate(statistics, current_iterate, trial_iterate, current_evaluations,
                trial_evaluations);
@@ -251,8 +263,8 @@ namespace uno {
       }
       else {
          accept_iterate = this->feasibility_inequality_handling_method->is_iterate_acceptable(statistics,
-            *this->feasibility_globalization_strategy, current_iterate, trial_iterate, direction, step_length, current_evaluations,
-            trial_evaluations);
+            *this->feasibility_globalization_strategy, current_iterate, trial_iterate, direction, trial_evaluations,
+            predicted_reductions);
          if (uses_trust_region || accept_iterate) {
             this->feasibility_inequality_handling_method->notify_trial_iterate(statistics, current_iterate, trial_iterate,
                current_evaluations, trial_evaluations);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -44,9 +44,11 @@ namespace uno {
       void update_second_order_corrections(const Iterate& trial_iterate, Evaluations& trial_evaluations) override;
 
       // trial iterate acceptance
+      [[nodiscard]] PredictedReductionModels build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const Model& model, Iterate& current_iterate,
-         Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations, WarmstartInformation& warmstart_information,
+         Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region, Evaluations& current_evaluations,
+         Evaluations& trial_evaluations, const ProgressMeasures& predicted_reductions, WarmstartInformation& warmstart_information,
          UserCallbacks& user_callbacks) override;
 
       [[nodiscard]] std::string get_name() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -92,12 +92,17 @@ namespace uno {
       this->inequality_handling_method->update_second_order_corrections(trial_iterate, trial_evaluations);
    }
 
+   PredictedReductionModels NoRelaxation::build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const {
+      return this->inequality_handling_method->build_predicted_reduction_models(current_iterate, direction, current_evaluations);
+   }
+
    bool NoRelaxation::is_iterate_acceptable(Statistics& statistics, const Model& /*model*/, Iterate& current_iterate,
-         Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations, WarmstartInformation& warmstart_information,
+         Iterate& trial_iterate, const Direction& direction, double /*step_length*/, bool uses_trust_region, Evaluations& current_evaluations,
+         Evaluations& trial_evaluations, const ProgressMeasures& predicted_reductions, WarmstartInformation& warmstart_information,
          UserCallbacks& user_callbacks) {
       const bool accept_iterate = this->inequality_handling_method->is_iterate_acceptable(statistics, this->globalization_strategy,
-         current_iterate, trial_iterate, direction, step_length, current_evaluations, trial_evaluations);
+         current_iterate, trial_iterate, direction, trial_evaluations, predicted_reductions);
       this->compute_residuals(this->original_problem, trial_iterate, trial_evaluations);
       trial_iterate.status = this->check_termination(this->original_problem, trial_iterate, trial_evaluations);
       if (accept_iterate) {

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.hpp
@@ -37,9 +37,11 @@ namespace uno {
       void update_second_order_corrections(const Iterate& trial_iterate, Evaluations& trial_evaluations) override;
 
       // trial iterate acceptance
+      [[nodiscard]] PredictedReductionModels build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const Model& model, Iterate& current_iterate,
-         Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations, WarmstartInformation& warmstart_information,
+         Iterate& trial_iterate, const Direction& direction, double step_length, bool uses_trust_region, Evaluations& current_evaluations,
+         Evaluations& trial_evaluations, const ProgressMeasures& predicted_reductions, WarmstartInformation& warmstart_information,
          UserCallbacks& user_callbacks) override;
 
       [[nodiscard]] std::string get_name() const override;

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.cpp
@@ -396,45 +396,44 @@ namespace uno {
 
    // predicted reductions
 
-   double l1RelaxedProblem::compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
-         const Vector<double>& /*primal_direction*/, double step_length, Norm /*norm*/, Evaluations& current_evaluations) const {
+   PredictedInfeasibilityReduction l1RelaxedProblem::build_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& /*primal_direction*/, Norm /*norm*/, Evaluations& current_evaluations) const {
+      // r = c(x) − p + n ; since JΔx − Δp + Δn = −r (KKT), pred(α) = α‖r‖₁
       this->evaluate_constraints(current_iterate, this->constraints_buffer.view(), current_evaluations);
-      // Let r = c(x) − p + n
-      // r + α(JΔx − Δp + Δn) = r - α r = (1-α) r
-      // so pred(α) = ‖r‖ − ‖(1−α) r‖ = α ‖c(x) − p + n‖
-      // note: this assumes that JΔx − Δp + Δn = -r, which is the case for KKT systems
-      return step_length * this->model.constraint_violation(this->constraints_buffer, Norm::L1);
+      const double residual_violation = this->model.constraint_violation(this->constraints_buffer, Norm::L1);
+      return [residual_violation](double step_length) { return step_length * residual_violation; };
    }
 
-   std::function<double(double)> l1RelaxedProblem::compute_predicted_objective_reduction(const Iterate& /*current_iterate*/,
-         const Vector<double>& primal_direction, double step_length, Evaluations& /*current_evaluations*/,
-         double /*hessian_quadratic_form*/) const {
-      // −α ρ sum(Δp + Δn)
-      double predicted_reduction = 0.;
+   PredictedObjectiveReduction l1RelaxedProblem::build_predicted_objective_reduction(const Iterate& /*current_iterate*/,
+         const Vector<double>& primal_direction, Evaluations& /*current_evaluations*/, double /*hessian_quadratic_form*/) const {
+      // −α ρ̄ Σ(Δp + Δn). Currently independent of the objective multiplier; steer ρ here later.
+      double elastic_step_sum = 0.;
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.positive) {
-         predicted_reduction += primal_direction[elastic_index];
+         elastic_step_sum += primal_direction[elastic_index];
       }
       for (const auto [constraint_index, elastic_index]: this->elastic_variables.negative) {
-         predicted_reduction += primal_direction[elastic_index];
+         elastic_step_sum += primal_direction[elastic_index];
       }
-      predicted_reduction *= -step_length * this->constraint_violation_coefficient;
-      return [=](double /*objective_multiplier*/) {
-         return predicted_reduction;
+      const double coefficient = this->constraint_violation_coefficient;
+      return [elastic_step_sum, coefficient](double step_length, double /*objective_multiplier*/, bool /*use_curvature_information*/) {
+         return -step_length * coefficient * elastic_step_sum;
       };
    }
 
-   double l1RelaxedProblem::compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length) const {
-      double predicted_auxiliary_reduction = 0.;
-      // form the directional derivative zeta D_R^2 (x - x_R) d and scale it by the step length
+   PredictedAuxiliaryReduction l1RelaxedProblem::build_predicted_auxiliary_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction) const {
+      // proximal directional derivative ζ D_R² (x − x_R)ᵀd, cached once (0 when the proximal term is off)
+      double proximal_directional_derivative = 0.;
       if (this->proximal_center != nullptr && this->proximal_coefficient != 0.) {
          for (size_t variable_index: Range(this->model.number_variables)) {
             const double scaling = std::min(1., 1./std::abs(this->proximal_center[variable_index]));
             const double distance_to_center = current_iterate.primals[variable_index] - this->proximal_center[variable_index];
-            predicted_auxiliary_reduction += scaling * scaling * distance_to_center * primal_direction[variable_index];
+            proximal_directional_derivative += scaling * scaling * distance_to_center * primal_direction[variable_index];
          }
-         predicted_auxiliary_reduction *= step_length * (-this->proximal_coefficient);
       }
-      return predicted_auxiliary_reduction;
+      const double coefficient = this->proximal_coefficient;
+      return [proximal_directional_derivative, coefficient](double step_length) {
+         return step_length * (-coefficient) * proximal_directional_derivative;
+      };
    }
 } // namespace

--- a/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/relaxed_problems/l1RelaxedProblem.hpp
@@ -74,13 +74,12 @@ namespace uno {
       void set_auxiliary_measure(Iterate& iterate) const override;
 
       // predicted reductions
-      [[nodiscard]] double compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const override;
-      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
-         double hessian_quadratic_form) const override;
-      [[nodiscard]] double compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length) const override;
+      [[nodiscard]] PredictedInfeasibilityReduction build_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, Norm norm, Evaluations& current_evaluations) const override;
+      [[nodiscard]] PredictedObjectiveReduction build_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, Evaluations& current_evaluations, double hessian_quadratic_form) const override;
+      [[nodiscard]] PredictedAuxiliaryReduction build_predicted_auxiliary_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction) const override;
 
    protected:
       ElasticVariables elastic_variables;

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include "BacktrackingLineSearch.hpp"
 #include "ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.hpp"
+#include "ingredients/globalization_strategies/PredictedReductionModels.hpp"
 #include "ingredients/inertia_correction_strategies/UnstableInertiaCorrection.hpp"
 #include "model/Model.hpp"
 #include "optimization/Direction.hpp"
@@ -49,8 +50,11 @@ namespace uno {
             INF<double>, evaluation_cache.current_evaluations, warmstart_information);
          if (direction.status != SubproblemStatus::INFEASIBLE) {
             check_unboundedness(direction);
+            const PredictedReductionModels predicted_reduction_models =
+               this->constraint_relaxation_strategy->build_predicted_reduction_models(current_iterate, direction,
+               evaluation_cache.current_evaluations);
             const bool backtracking_success = this->backtrack_along_direction(statistics, model, current_iterate, trial_iterate,
-               direction, evaluation_cache, warmstart_information, user_callbacks);
+               direction, evaluation_cache, predicted_reduction_models, warmstart_information, user_callbacks);
             if (backtracking_success) {
                return;
             }
@@ -84,8 +88,11 @@ namespace uno {
       const Direction& direction = this->constraint_relaxation_strategy->compute_direction(statistics, current_iterate,
          INF<double>, evaluation_cache.current_evaluations, warmstart_information);
       check_unboundedness(direction);
+      const PredictedReductionModels predicted_reduction_models =
+         this->constraint_relaxation_strategy->build_predicted_reduction_models(current_iterate, direction,
+         evaluation_cache.current_evaluations);
       const bool backtracking_success = this->backtrack_along_direction(statistics, model, current_iterate,
-         trial_iterate, direction, evaluation_cache, warmstart_information, user_callbacks);
+         trial_iterate, direction, evaluation_cache, predicted_reduction_models, warmstart_information, user_callbacks);
       if (!backtracking_success) {
          throw std::runtime_error("The line search failed");
       }
@@ -112,7 +119,7 @@ namespace uno {
    // returns true upon success, false upon failure
    bool BacktrackingLineSearch::backtrack_along_direction(Statistics& statistics, const Model& model, Iterate& current_iterate,
          Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
-         WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) {
+         const PredictedReductionModels& predicted_reduction_models, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) {
       double step_length = 1.;
       bool termination = false;
       size_t number_iterations = 0;
@@ -121,6 +128,9 @@ namespace uno {
          DEBUG << "\n\tLine-search iteration " << number_iterations << ", step_length " << step_length << '\n';
          if (1 < number_iterations) { statistics.start_new_line(); }
          statistics.set("Steplength", step_length);
+         // the total step length is the step length scaled by the direction's step length
+         const double total_step_length = step_length * direction.primal_dual_step_length;
+         const ProgressMeasures predicted_reductions = predicted_reduction_models(total_step_length);
 
          bool is_acceptable = false;
          try {
@@ -129,8 +139,8 @@ namespace uno {
             statistics.set("||Step||", step_length * direction.norm);
 
             is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
-               trial_iterate, direction, step_length * direction.primal_dual_step_length, false, evaluation_cache.current_evaluations,
-               evaluation_cache.trial_evaluations, warmstart_information, user_callbacks);
+               trial_iterate, direction, total_step_length, false, evaluation_cache.current_evaluations,
+               evaluation_cache.trial_evaluations, predicted_reductions, warmstart_information, user_callbacks);
             set_primal_statistics(statistics, model, trial_iterate, evaluation_cache.trial_evaluations);
 
             // tiny direction test: if the primal direction is tiny over a certain number of successive iterations,
@@ -157,7 +167,7 @@ namespace uno {
                this->SOC_max_iterations >= 1 && trial_iterate.progress.infeasibility >= current_iterate.progress.infeasibility) {
             assert(step_length == 1.);
             is_acceptable = this->compute_second_order_directions(statistics, model, current_iterate, trial_iterate, direction,
-               evaluation_cache, warmstart_information, user_callbacks);
+               evaluation_cache, predicted_reductions, warmstart_information, user_callbacks);
          }
 
          if (is_acceptable) {
@@ -210,7 +220,7 @@ namespace uno {
 
    bool BacktrackingLineSearch::compute_second_order_directions(Statistics& statistics, const Model& model,
          Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
-         WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) const {
+         const ProgressMeasures& predicted_reductions, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) const {
       // enter second-order corrections
       DEBUG << "\nEntering second-order corrections\n";
 
@@ -231,7 +241,8 @@ namespace uno {
 
             is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
                trial_iterate, direction /* this is correct, see IPOPT paper */, direction.primal_dual_step_length, false,
-               evaluation_cache.current_evaluations, evaluation_cache.trial_evaluations, warmstart_information, user_callbacks);
+               evaluation_cache.current_evaluations, evaluation_cache.trial_evaluations, predicted_reductions,
+               warmstart_information, user_callbacks);
 
             if (is_acceptable) {
                // terminate the SOCs and the backtracking

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.hpp
@@ -10,6 +10,8 @@
 namespace uno {
    // forward declaration
    class Direction;
+   class PredictedReductionModels;
+   class ProgressMeasures;
 
    class BacktrackingLineSearch : public GlobalizationMechanism {
    public:
@@ -38,11 +40,12 @@ namespace uno {
          double step_length) const;
       [[nodiscard]] bool backtrack_along_direction(Statistics& statistics, const Model& model, Iterate& current_iterate,
          Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
-         WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks);
+         const PredictedReductionModels& predicted_reduction_models, WarmstartInformation& warmstart_information,
+         UserCallbacks& user_callbacks);
       [[nodiscard]] static bool is_tiny_direction(const Iterate& current_iterate, const Direction& direction);
       [[nodiscard]] bool compute_second_order_directions(Statistics& statistics, const Model& model, Iterate& current_iterate,
          Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
-         WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) const;
+         const ProgressMeasures& predicted_reductions, WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) const;
       [[nodiscard]] double decrease_step_length(double step_length) const;
       static void check_unboundedness(const Direction& direction);
    };

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -160,9 +160,13 @@ namespace uno {
    bool TrustRegionStrategy::is_iterate_acceptable(Statistics& statistics, const Model& model, Iterate& current_iterate,
          Iterate& trial_iterate, const Direction& direction, EvaluationCache& evaluation_cache,
          WarmstartInformation& warmstart_information, UserCallbacks& user_callbacks) {
+      const PredictedReductionModels predicted_reduction_models =
+         this->constraint_relaxation_strategy->build_predicted_reduction_models(current_iterate, direction,
+         evaluation_cache.current_evaluations);
+      const ProgressMeasures predicted_reductions = predicted_reduction_models(/* step_length = */ 1.);
       bool accept_iterate = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
          trial_iterate, direction, 1., true, evaluation_cache.current_evaluations, evaluation_cache.trial_evaluations,
-         warmstart_information, user_callbacks);
+         predicted_reductions, warmstart_information, user_callbacks);
       GlobalizationMechanism::set_primal_statistics(statistics, model, trial_iterate, evaluation_cache.trial_evaluations);
       if (accept_iterate) {
          // possibly increase the radius if trust region is active
@@ -172,6 +176,7 @@ namespace uno {
          accept_iterate = this->check_termination_with_small_step(trial_iterate);
       }
       return accept_iterate;
+      return true;
    }
 
    // check whether a rejected step with very small norm can be tolerated

--- a/uno/ingredients/globalization_strategies/GlobalizationStrategy.hpp
+++ b/uno/ingredients/globalization_strategies/GlobalizationStrategy.hpp
@@ -20,7 +20,7 @@ namespace uno {
 
       virtual void initialize(Statistics& statistics, const Iterate& initial_iterate) = 0;
       [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
-         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) = 0;
+         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reductions, double objective_multiplier) = 0;
       [[nodiscard]] virtual bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
          double reference_infeasibility) const = 0;
 

--- a/uno/ingredients/globalization_strategies/MeritFunction.cpp
+++ b/uno/ingredients/globalization_strategies/MeritFunction.cpp
@@ -20,9 +20,9 @@ namespace uno {
    }
 
    bool MeritFunction::is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
-         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) {
+         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reductions, double objective_multiplier) {
       // predicted reduction with all contributions. This quantity should be positive (= negative directional derivative)
-      double constrained_predicted_reduction = MeritFunction::constrained_merit_function(predicted_reduction, objective_multiplier);
+      double constrained_predicted_reduction = MeritFunction::constrained_merit_function(predicted_reductions, objective_multiplier);
       DEBUG << "Constrained predicted reduction: " << constrained_predicted_reduction << '\n';
       if (constrained_predicted_reduction <= 0.) {
          DEBUG  << "The direction is not a descent direction for the merit function. You should decrease the penalty parameter.\n";

--- a/uno/ingredients/globalization_strategies/MeritFunction.hpp
+++ b/uno/ingredients/globalization_strategies/MeritFunction.hpp
@@ -15,7 +15,7 @@ namespace uno {
 
       void initialize(Statistics& statistics, const Iterate& initial_iterate) override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
-            const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) override;
+            const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reductions, double objective_multiplier) override;
       [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double reference_infeasibility) const override;
       void reset() override;
       void notify_switch_to_feasibility(const ProgressMeasures& current_progress) override;

--- a/uno/ingredients/globalization_strategies/PredictedReductionModels.hpp
+++ b/uno/ingredients/globalization_strategies/PredictedReductionModels.hpp
@@ -9,16 +9,17 @@
 #include "ingredients/globalization_strategies/ProgressMeasures.hpp"
 
 namespace uno {
-   // Lazy local models of the predicted reductions. For a fixed (current iterate, direction), the
+   // lazy local models of the predicted reductions. For a fixed (current iterate, direction), the
    // step-independent quantities (Jacobian-direction product, directional derivatives, dᵀHd, ...) are
    // evaluated once when the model is built; each closure below only assembles the reduction for a given
-   // step length α (and, for the objective, penalty parameter ρ).
+   // step length (and, for the objective, objective parameter)
    using PredictedInfeasibilityReduction = std::function<double(double step_length)>;
    using PredictedObjectiveReduction = std::function<double(double step_length, double objective_multiplier,
       bool use_curvature_information)>;
    using PredictedAuxiliaryReduction = std::function<double(double step_length)>;
 
-   // Built once per (Subproblem, current iterate, direction); queried repeatedly along the line search.
+   // built once per (subproblem, current iterate, direction); queried once by the trust-region method, and repeatedly
+   // by the backtracking line search
    class PredictedReductionModels {
    public:
       PredictedReductionModels(PredictedInfeasibilityReduction infeasibility,

--- a/uno/ingredients/globalization_strategies/PredictedReductionModels.hpp
+++ b/uno/ingredients/globalization_strategies/PredictedReductionModels.hpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Charlie Vanaret
+// Licensed under the MIT license. See LICENSE file in the project directory for details.
+
+#ifndef UNO_PREDICTEDREDUCTIONMODELS_H
+#define UNO_PREDICTEDREDUCTIONMODELS_H
+
+#include <functional>
+#include <utility>
+#include "ingredients/globalization_strategies/ProgressMeasures.hpp"
+
+namespace uno {
+   // Lazy local models of the predicted reductions. For a fixed (current iterate, direction), the
+   // step-independent quantities (Jacobian-direction product, directional derivatives, dᵀHd, ...) are
+   // evaluated once when the model is built; each closure below only assembles the reduction for a given
+   // step length α (and, for the objective, penalty parameter ρ).
+   using PredictedInfeasibilityReduction = std::function<double(double step_length)>;
+   using PredictedObjectiveReduction = std::function<double(double step_length, double objective_multiplier,
+      bool use_curvature_information)>;
+   using PredictedAuxiliaryReduction = std::function<double(double step_length)>;
+
+   // Built once per (Subproblem, current iterate, direction); queried repeatedly along the line search.
+   class PredictedReductionModels {
+   public:
+      PredictedReductionModels(PredictedInfeasibilityReduction infeasibility,
+            PredictedObjectiveReduction objective, PredictedAuxiliaryReduction auxiliary):
+         infeasibility_model(std::move(infeasibility)),
+         objective_model(std::move(objective)),
+         auxiliary_model(std::move(auxiliary)) {
+      }
+
+      // assemble the predicted reductions for a given step length
+      [[nodiscard]] ProgressMeasures operator()(double step_length) const {
+         return {
+            this->infeasibility_model(step_length),
+            // predicted objective reduction left as a function of the objective multiplier
+            [objective = this->objective_model, step_length](double objective_multiplier) {
+               return objective(step_length, objective_multiplier, /* use_curvature_information = */ true);
+            },
+            this->auxiliary_model(step_length)
+         };
+      }
+
+   private:
+      PredictedInfeasibilityReduction infeasibility_model;
+      PredictedObjectiveReduction objective_model;
+      PredictedAuxiliaryReduction auxiliary_model;
+   };
+} // namespace
+
+#endif // UNO_PREDICTEDREDUCTIONMODELS_H

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.cpp
@@ -17,11 +17,11 @@ namespace uno {
    }
 
    bool FletcherFilterMethod::is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
-         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double /*objective_multiplier*/) {
+         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reductions, double /*objective_multiplier*/) {
       // in filter methods, we construct an unconstrained measure by ignoring infeasibility and scaling the objective measure by 1
       const double current_merit = FilterMethod::unconstrained_merit_function(current_progress);
       const double trial_merit = FilterMethod::unconstrained_merit_function(trial_progress);
-      const double merit_predicted_reduction = FilterMethod::unconstrained_merit_function(predicted_reduction);
+      const double merit_predicted_reduction = FilterMethod::unconstrained_merit_function(predicted_reductions);
       DEBUG << "Current: (infeasibility, objective + auxiliary) = (" << current_progress.infeasibility << ", " << current_merit << ")\n";
       DEBUG << "Trial:   (infeasibility, objective + auxiliary) = (" << trial_progress.infeasibility << ", " << trial_merit << ")\n";
       DEBUG << "Current filter:\n" << *this->filter << '\n';

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FletcherFilterMethod.hpp
@@ -13,7 +13,7 @@ namespace uno {
       ~FletcherFilterMethod() override = default;
 
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
-         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) override;
+         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reductions, double objective_multiplier) override;
       [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
          double reference_infeasibility) const override;
 

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.cpp
@@ -25,11 +25,11 @@ namespace uno {
    }
 
    bool WaechterFilterMethod::is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
-         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double /*objective_multiplier*/) {
+         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reductions, double /*objective_multiplier*/) {
       // in filter methods, we construct an unconstrained measure by ignoring infeasibility and scaling the objective measure by 1
       const double current_merit = FilterMethod::unconstrained_merit_function(current_progress);
       const double trial_merit = FilterMethod::unconstrained_merit_function(trial_progress);
-      const double merit_predicted_reduction = FilterMethod::unconstrained_merit_function(predicted_reduction);
+      const double merit_predicted_reduction = FilterMethod::unconstrained_merit_function(predicted_reductions);
       DEBUG << "Current (infeasibility, objective + auxiliary) = (" << current_progress.infeasibility << ", " << current_merit << ")\n";
       DEBUG << "Trial   (infeasibility, objective + auxiliary) = (" << trial_progress.infeasibility << ", " << trial_merit << ")\n";
       DEBUG << "Current filter:\n" << *this->filter;

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/WaechterFilterMethod.hpp
@@ -15,7 +15,7 @@ namespace uno {
 
       void initialize(Statistics& statistics, const Iterate& initial_iterate) override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, const ProgressMeasures& current_progress,
-         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) override;
+         const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reductions, double objective_multiplier) override;
       [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate,
          double reference_infeasibility) const override;
 

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.cpp
@@ -26,8 +26,8 @@ namespace uno {
    }
 
    bool InequalityHandlingMethod::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, const Iterate& current_iterate, Iterate& trial_iterate,
-         const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
+         const Subproblem& subproblem, const Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
+         Evaluations& trial_evaluations, const ProgressMeasures& predicted_reductions) const {
       subproblem.problem.postprocess_iterate(trial_iterate);
       const double objective_multiplier = subproblem.problem.get_objective_multiplier();
 
@@ -44,12 +44,10 @@ namespace uno {
       }
       else {
          // determine acceptance wrt the globalization strategy
-         const ProgressMeasures predicted_reductions = subproblem.compute_predicted_reductions(current_iterate, direction,
-            step_length, this->progress_norm, current_evaluations, solver_workspace);
          accept_iterate = globalization_strategy.is_iterate_acceptable(statistics, current_iterate.progress, trial_iterate.progress,
             predicted_reductions, objective_multiplier);
-         // check that the derivatives exist at the accepted trial iterate (an exception is thrown upon evaluation failure)
          if (accept_iterate) {
+            // check that the derivatives exist at the accepted trial iterate (an exception is thrown upon evaluation failure)
             trial_evaluations.evaluate_objective_gradient(this->problem.model, trial_iterate.primals);
             trial_evaluations.evaluate_jacobian(this->problem.model, trial_iterate.primals);
          }

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include "ingredients/globalization_strategies/PredictedReductionModels.hpp"
 #include "linear_algebra/Norm.hpp"
 
 namespace uno {
@@ -17,6 +18,7 @@ namespace uno {
    class l1RelaxedProblem;
    class OptimizationProblem;
    class Options;
+   class ProgressMeasures;
    class Statistics;
    class SolverWorkspace;
    class Subproblem;
@@ -49,9 +51,11 @@ namespace uno {
       virtual void compute_least_squares_multipliers(Iterate& iterate, Evaluations& evaluations) = 0;
 
       virtual void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const = 0;
+      [[nodiscard]] virtual PredictedReductionModels build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const = 0;
       [[nodiscard]] virtual bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations) const = 0;
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, Evaluations& trial_evaluations,
+         const ProgressMeasures& predicted_reductions) const = 0;
       virtual void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) = 0;
 
@@ -63,8 +67,8 @@ namespace uno {
 
       void evaluate_progress_measures(const OptimizationProblem& problem, Iterate& iterate, Evaluations& evaluations) const;
       bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         const Subproblem& subproblem, const SolverWorkspace& solver_workspace, const Iterate& current_iterate, Iterate& trial_iterate,
-         const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const;
+         const Subproblem& subproblem, const Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction,
+         Evaluations& trial_evaluations, const ProgressMeasures& predicted_reductions) const;
    };
 } // namespace
 

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -107,12 +107,17 @@ namespace uno {
       InequalityHandlingMethod::evaluate_progress_measures(this->problem, iterate, evaluations);
    }
 
+   PredictedReductionModels NoInequalityReformulation::build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const {
+      return this->subproblem->build_predicted_reduction_model(current_iterate, direction, this->progress_norm,
+         current_evaluations, this->subproblem_solver->get_workspace());
+   }
+
    bool NoInequalityReformulation::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, Evaluations& trial_evaluations,
+         const ProgressMeasures& predicted_reductions) const {
       return InequalityHandlingMethod::is_iterate_acceptable(statistics, globalization_strategy, *this->subproblem,
-         this->subproblem_solver->get_workspace(), current_iterate, trial_iterate, direction, step_length, current_evaluations,
-         trial_evaluations);
+         current_iterate, trial_iterate, direction, trial_evaluations, predicted_reductions);
    }
 
    void NoInequalityReformulation::notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate,

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
@@ -43,9 +43,11 @@ namespace uno {
       void compute_least_squares_multipliers(Iterate& iterate, Evaluations& evaluations) override;
 
       void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const override;
+      [[nodiscard]] PredictedReductionModels build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations) const override;
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, Evaluations& trial_evaluations,
+         const ProgressMeasures& predicted_reductions) const override;
       void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) override;
 

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -46,9 +46,11 @@ namespace uno {
       void compute_least_squares_multipliers(Iterate& iterate, Evaluations& evaluations) override;
 
       void evaluate_progress_measures(Iterate& iterate, Evaluations& evaluations) const override;
+      [[nodiscard]] PredictedReductionModels build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const override;
       [[nodiscard]] bool is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-        Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
-        Evaluations& current_evaluations, Evaluations& trial_evaluations) const override;
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, Evaluations& trial_evaluations,
+         const ProgressMeasures& predicted_reductions) const override;
       void notify_trial_iterate(Statistics& statistics, const Iterate& current_iterate, const Iterate& trial_iterate,
          Evaluations& current_evaluations, Evaluations& trial_evaluations) override;
 
@@ -241,12 +243,18 @@ namespace uno {
    }
 
    template <typename BarrierProblem>
+   PredictedReductionModels InteriorPointMethod<BarrierProblem>::build_predicted_reduction_models(const Iterate& current_iterate,
+         const Direction& direction, Evaluations& current_evaluations) const {
+      return this->subproblem->build_predicted_reduction_model(current_iterate, direction, this->progress_norm,
+         current_evaluations, this->subproblem_solver->get_workspace());
+   }
+
+   template <typename BarrierProblem>
    bool InteriorPointMethod<BarrierProblem>::is_iterate_acceptable(Statistics& statistics, GlobalizationStrategy& globalization_strategy,
-         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, double step_length,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations) const {
+         Iterate& current_iterate, Iterate& trial_iterate, const Direction& direction, Evaluations& trial_evaluations,
+         const ProgressMeasures& predicted_reductions) const {
       return InequalityHandlingMethod::is_iterate_acceptable(statistics, globalization_strategy, *this->subproblem,
-         this->subproblem_solver->get_workspace(), current_iterate, trial_iterate, direction, step_length, current_evaluations,
-         trial_evaluations);
+         current_iterate, trial_iterate, direction, trial_evaluations, predicted_reductions);
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -427,30 +427,25 @@ namespace uno {
 
    // predicted reductions
 
-   double PrimalDualInteriorPointProblem::compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const {
-      return this->inner.compute_predicted_infeasibility_reduction(current_iterate, primal_direction, step_length, norm,
-         current_evaluations);
+   PredictedInfeasibilityReduction PrimalDualInteriorPointProblem::build_predicted_infeasibility_reduction(
+         const Iterate& current_iterate, const Vector<double>& primal_direction, Norm norm, Evaluations& current_evaluations) const {
+      return this->inner.build_predicted_infeasibility_reduction(current_iterate, primal_direction, norm, current_evaluations);
    }
 
-   std::function<double(double)> PrimalDualInteriorPointProblem::compute_predicted_objective_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
-         double hessian_quadratic_form) const {
-      return this->inner.compute_predicted_objective_reduction(current_iterate, primal_direction, step_length,
+   PredictedObjectiveReduction PrimalDualInteriorPointProblem::build_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, Evaluations& current_evaluations, double hessian_quadratic_form) const {
+      return this->inner.build_predicted_objective_reduction(current_iterate, primal_direction,
          current_evaluations, hessian_quadratic_form);
    }
 
-   double PrimalDualInteriorPointProblem::compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length) const {
-      // start with the auxiliary measure of the initial problem
-      double predicted_auxiliary_reduction = this->inner.compute_predicted_auxiliary_reduction(current_iterate,
-         primal_direction, step_length);
-
-      // add the contribution of the barrier terms
-      const double directional_derivative = this->compute_barrier_term_directional_derivative(current_iterate, primal_direction);
-      predicted_auxiliary_reduction += step_length * (-directional_derivative);
-      // }, "α*(μ*X^{-1} e^T d)"};
-      return predicted_auxiliary_reduction;
+   PredictedAuxiliaryReduction PrimalDualInteriorPointProblem::build_predicted_auxiliary_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction) const {
+      // inner auxiliary model + barrier term  α ↦ α(−μ Xˉ¹eᵀd)
+      PredictedAuxiliaryReduction inner_model = this->inner.build_predicted_auxiliary_reduction(current_iterate, primal_direction);
+      const double barrier_directional_derivative = this->compute_barrier_term_directional_derivative(current_iterate, primal_direction);
+      return [inner_model = std::move(inner_model), barrier_directional_derivative](double step_length) {
+         return inner_model(step_length) + step_length * (-barrier_directional_derivative);
+      };
    }
 
    // protected member functions

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.hpp
@@ -75,13 +75,12 @@ namespace uno {
       void set_auxiliary_measure(Iterate& iterate) const override;
 
       // predicted reductions
-      [[nodiscard]] double compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const override;
-      [[nodiscard]] std::function<double(double)> compute_predicted_objective_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
-         double hessian_quadratic_form) const override;
-      [[nodiscard]] double compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length) const override;
+      [[nodiscard]] PredictedInfeasibilityReduction build_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, Norm norm, Evaluations& current_evaluations) const override;
+      [[nodiscard]] PredictedObjectiveReduction build_predicted_objective_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, Evaluations& current_evaluations, double hessian_quadratic_form) const override;
+      [[nodiscard]] PredictedAuxiliaryReduction build_predicted_auxiliary_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction) const override;
 
    protected:
       const OptimizationProblem& inner;

--- a/uno/ingredients/subproblem/Subproblem.cpp
+++ b/uno/ingredients/subproblem/Subproblem.cpp
@@ -282,6 +282,7 @@ namespace uno {
 
    // predicted reductions
 
+   /*
    ProgressMeasures Subproblem::compute_predicted_reductions(const Iterate& current_iterate, const Direction& direction,
          double step_length, Norm norm, Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const {
       return {
@@ -289,6 +290,17 @@ namespace uno {
          this->problem.compute_predicted_objective_reduction(current_iterate, direction.primals, step_length, current_evaluations,
             solver_workspace.compute_hessian_quadratic_form(*this, current_iterate, direction.primals)),
          this->problem.compute_predicted_auxiliary_reduction(current_iterate, direction.primals, step_length)
+      };
+   }
+   */
+
+   PredictedReductionModels Subproblem::build_predicted_reduction_model(const Iterate& current_iterate, const Direction& direction,
+         Norm norm, Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const {
+      const double hessian_quadratic_form = solver_workspace.compute_hessian_quadratic_form(*this, current_iterate, direction.primals);
+      return {
+         this->problem.build_predicted_infeasibility_reduction(current_iterate, direction.primals, norm, current_evaluations),
+         this->problem.build_predicted_objective_reduction(current_iterate, direction.primals, current_evaluations, hessian_quadratic_form),
+         this->problem.build_predicted_auxiliary_reduction(current_iterate, direction.primals)
       };
    }
 } // namespace

--- a/uno/ingredients/subproblem/Subproblem.hpp
+++ b/uno/ingredients/subproblem/Subproblem.hpp
@@ -4,7 +4,7 @@
 #ifndef UNO_SUBPROBLEM_H
 #define UNO_SUBPROBLEM_H
 
-#include "ingredients/globalization_strategies/ProgressMeasures.hpp"
+#include "ingredients/globalization_strategies/PredictedReductionModels.hpp"
 #include "linear_algebra/Vector.hpp"
 #include "linear_algebra/View.hpp"
 #include "optimization/OptimizationProblem.hpp"
@@ -80,8 +80,8 @@ namespace uno {
       [[nodiscard]] double dual_regularization_factor() const;
 
       // local models of progress measures
-      [[nodiscard]] ProgressMeasures compute_predicted_reductions(const Iterate& current_iterate, const Direction& direction,
-         double step_length, Norm norm, Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const;
+      [[nodiscard]] PredictedReductionModels build_predicted_reduction_model(const Iterate& current_iterate,
+         const Direction& direction, Norm norm, Evaluations& current_evaluations, const SolverWorkspace& solver_workspace) const;
 
       const OptimizationProblem& problem;
 

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -287,33 +287,42 @@ namespace uno {
 
    // predicted reductions
 
-   double OptimizationProblem::compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
-         const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const {
-      // predicted infeasibility reduction: "‖c(x)‖ - ‖c(x) + ∇c(x)^T (αd)‖"
+   PredictedInfeasibilityReduction OptimizationProblem::build_predicted_infeasibility_reduction(const Iterate& current_iterate,
+         const Vector<double>& primal_direction, Norm norm, Evaluations& current_evaluations) const {
+      // α ↦ ‖c(x)‖ − ‖c(x) + ∇c(x)ᵀ(αd)‖
       current_evaluations.evaluate_constraints(this->model, current_iterate.primals);
       current_evaluations.evaluate_jacobian(this->model, current_iterate.primals);
-
       const double current_constraint_violation = this->model.constraint_violation(current_evaluations.constraints, norm);
-      this->Jv_buffer.fill(0.);
-      current_evaluations.compute_jacobian_vector_product(this->model, primal_direction.view(), this->Jv_buffer.view());
-      const double trial_linearized_constraint_violation = this->model.constraint_violation(current_evaluations.constraints +
-         step_length * this->Jv_buffer, norm);
-      return current_constraint_violation - trial_linearized_constraint_violation;
-   }
 
-   std::function<double(double)> OptimizationProblem::compute_predicted_objective_reduction(const Iterate& /*current_iterate*/,
-         const Vector<double>& primal_direction, double step_length, Evaluations& current_evaluations,
-         double hessian_quadratic_form) const {
-      // predicted objective reduction: "-∇f(x)^T (αd) - α^2/2 d^T H d"
-      const double directional_derivative = dot(view(primal_direction, 0, this->model.number_variables),
-         current_evaluations.objective_gradient);
-      return [=](double objective_multiplier) {
-         return step_length * (-objective_multiplier*directional_derivative) - step_length*step_length/2. * hessian_quadratic_form;
+      // cache the (expensive) Jacobian–direction product Jd and snapshot the current constraints
+      Vector<double> Jv(this->number_constraints);
+      Jv.fill(0.);
+      current_evaluations.compute_jacobian_vector_product(this->model, primal_direction.view(), Jv.view());
+      Vector<double> constraints = current_evaluations.constraints;
+
+      return [this, norm, current_constraint_violation, Jv = std::move(Jv), constraints = std::move(constraints)]
+            (double step_length) {
+         return current_constraint_violation - this->model.constraint_violation(constraints + step_length * Jv, norm);
       };
    }
 
-   double OptimizationProblem::compute_predicted_auxiliary_reduction(const Iterate& /*current_iterate*/,
-         const Vector<double>& /*primal_direction*/, double /*step_length*/) const {
-      return 0.;
+   PredictedObjectiveReduction OptimizationProblem::build_predicted_objective_reduction(
+         const Iterate& /*current_iterate*/, const Vector<double>& primal_direction,
+         Evaluations& current_evaluations, double hessian_quadratic_form) const {
+      // (α, ρ) ↦ −ρ ∇f(x)ᵀ(αd) − α²/2 dᵀHd   (ρ scales only the gradient term; H already carries ρ)
+      const double directional_derivative = dot(view(primal_direction, 0, this->model.number_variables),
+         current_evaluations.objective_gradient);
+      return [directional_derivative, hessian_quadratic_form](double step_length, double objective_multiplier, bool use_curvature_information) {
+         double reduction = -objective_multiplier * step_length * directional_derivative;
+         if (use_curvature_information) {
+            reduction -= step_length * step_length / 2. * hessian_quadratic_form;
+         }
+         return reduction;
+      };
+   }
+
+   PredictedAuxiliaryReduction OptimizationProblem::build_predicted_auxiliary_reduction(
+         const Iterate& /*current_iterate*/, const Vector<double>& /*primal_direction*/) const {
+      return [](double /*step_length*/) { return 0.; };
    }
 } // namespace

--- a/uno/optimization/OptimizationProblem.hpp
+++ b/uno/optimization/OptimizationProblem.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include "ingredients/globalization_strategies/PredictedReductionModels.hpp"
 #include "ingredients/inertia_correction_strategies/Inertia.hpp"
 #include "linear_algebra/Norm.hpp"
 #include "linear_algebra/Vector.hpp"
@@ -104,6 +105,7 @@ namespace uno {
       virtual void set_auxiliary_measure(Iterate& iterate) const;
 
       // predicted reductions
+      /*
       [[nodiscard]] virtual double compute_predicted_infeasibility_reduction(const Iterate& current_iterate,
          const Vector<double>& primal_direction, double step_length, Norm norm, Evaluations& current_evaluations) const;
       [[nodiscard]] virtual std::function<double(double)> compute_predicted_objective_reduction(const Iterate& current_iterate,
@@ -111,6 +113,15 @@ namespace uno {
          double hessian_quadratic_form) const;
       [[nodiscard]] virtual double compute_predicted_auxiliary_reduction(const Iterate& current_iterate,
          const Vector<double>& primal_direction, double step_length) const;
+      */
+      [[nodiscard]] virtual PredictedInfeasibilityReduction build_predicted_infeasibility_reduction(
+         const Iterate& current_iterate, const Vector<double>& primal_direction, Norm norm,
+         Evaluations& current_evaluations) const;
+      [[nodiscard]] virtual PredictedObjectiveReduction build_predicted_objective_reduction(
+         const Iterate& current_iterate, const Vector<double>& primal_direction,
+         Evaluations& current_evaluations, double hessian_quadratic_form) const;
+      [[nodiscard]] virtual PredictedAuxiliaryReduction build_predicted_auxiliary_reduction(
+         const Iterate& current_iterate, const Vector<double>& primal_direction) const;
 
    protected:
       const IntegerRange primal_regularization_variables;


### PR DESCRIPTION
- build predicted reduction models for a given direction: this precomputes and caches the expensive quantities ($\nabla f(x_k)^T d$, $\nabla c(x_k)^T d$, ...)
- compute the predicted reductions for a given step length $\alpha$ ($||c(x_k) + \alpha \nabla c(x_k)^T d||_1$, ...)