### PR TITLE
Tie trial evaluations reset to assembly of trial iterate

### DIFF
--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -124,7 +124,6 @@ namespace uno {
             // the trial iterate becomes the current iterate for the next iteration
             std::swap(current_iterate, trial_iterate);
             std::swap(evaluation_cache.current_evaluations, evaluation_cache.trial_evaluations);
-            evaluation_cache.trial_evaluations.reset();
          }
       }
       // catch errors during the optimization process

--- a/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
+++ b/uno/ingredients/globalization_mechanisms/BacktrackingLineSearch.cpp
@@ -176,6 +176,7 @@ namespace uno {
          try {
             // take a step as a fraction of the direction
             assemble_trial_iterate(model, current_iterate, trial_iterate, direction, step_length);
+            evaluation_cache.trial_evaluations.reset();
             statistics.set("||Step||", step_length * direction.norm);
 
             is_acceptable = this->constraint_relaxation_strategy->is_iterate_acceptable(statistics, model, current_iterate,
@@ -219,13 +220,9 @@ namespace uno {
          // from here on, the trial iterate is rejected
          else {
             step_length = this->decrease_step_length(step_length);
-            // note: if minimum_step_length = 0 and step_length reaches 0 by successive divisions, the strict inequality
+            // note: if minimum_step_length = 0 and step_length reaches 0 by successive divisions, this inequality
             // protects from an endless loop
-            if (step_length * direction.primal_dual_step_length > minimum_step_length) {
-               // keep going
-               evaluation_cache.trial_evaluations.reset();
-            }
-            else {
+            if (step_length * direction.primal_dual_step_length <= minimum_step_length) {
                // minimum step length reached
                DEBUG << "The line search failed with a step length <= " << minimum_step_length << '\n';
                // check if we can terminate at a first-order point
@@ -236,10 +233,10 @@ namespace uno {
                else {
                   // switch to solving the feasibility problem
                   statistics.set("Status", "small step length");
-                  evaluation_cache.trial_evaluations.reset();
                   return false;
                }
             }
+            // otherwise, keep going
          }
 
          if (is_acceptable) {

--- a/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
+++ b/uno/ingredients/globalization_mechanisms/TrustRegionStrategy.cpp
@@ -87,7 +87,7 @@ namespace uno {
                if (Logger::level == INFO) statistics.print_current_line();
                this->decrease_radius_aggressively();
                warmstart_information.trust_region_changed = true;
-               evaluation_cache.trial_evaluations.reset();
+
             }
             else if (direction.status == SubproblemStatus::ERROR) {
                statistics.set("Status", "solver error");
@@ -95,12 +95,12 @@ namespace uno {
                this->decrease_radius();
                // reset the Hessian representation of the subproblem solver
                warmstart_information.whole_problem_changed();
-               evaluation_cache.trial_evaluations.reset();
             }
             else {
                // take full primal-dual step
                assemble_trial_iterate(model, current_iterate, trial_iterate, direction, direction.primal_dual_step_length,
                   direction.primal_dual_step_length, direction.bound_dual_step_length);
+               evaluation_cache.trial_evaluations.reset();
                this->reset_active_trust_region_multipliers(model, direction, trial_iterate);
 
                is_acceptable = this->is_iterate_acceptable(statistics, model, current_iterate, trial_iterate, direction,
@@ -113,7 +113,6 @@ namespace uno {
                else {
                   this->decrease_radius(direction.norm);
                   warmstart_information.trust_region_changed = true;
-                  evaluation_cache.trial_evaluations.reset();
                }
                if (Logger::level == INFO) statistics.print_current_line();
             }
@@ -125,7 +124,6 @@ namespace uno {
             DEBUG << "A function could not be evaluated. The trust-region radius will be reduced\n";
             this->decrease_radius();
             warmstart_information.trust_region_changed = true;
-            evaluation_cache.trial_evaluations.reset();
          }
          if (!is_acceptable && this->radius < this->minimum_radius) {
             throw std::runtime_error("Small radius");


### PR DESCRIPTION
Resetting the trial evaluations should happen right after the trial iterate has been assembled