### PR TITLE
Improve phase switching

### DIFF
--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -97,7 +97,7 @@ namespace uno {
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
       DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
-      this->globalization_strategy->notify_switch_to_feasibility(current_iterate.progress);
+      this->globalization_strategy->avoid_cycling_back_to(current_iterate.progress);
       this->feasibility_globalization_strategy->initialize(statistics, current_iterate);
       this->feasibility_globalization_strategy->reset();
 

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -214,25 +214,17 @@ namespace uno {
       return false;
    }
 
-   void FeasibilityRestoration::switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate,
-         Evaluations& current_evaluations, Evaluations& trial_evaluations) {
+   void FeasibilityRestoration::switch_back_to_optimality_phase(Iterate& trial_iterate, Evaluations& trial_evaluations) {
       DEBUG << "\nSwitching from restoration back to optimality phase\n";
       this->current_phase = Phase::OPTIMALITY;
-      this->inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
       this->inequality_handling_method->evaluate_progress_measures(trial_iterate, trial_evaluations);
-      this->globalization_strategy->notify_switch_to_optimality(current_iterate.progress);
 
-      // swap the iterate's multipliers and the optimality multipliers maintained by the class, and possibly compute
-      // least-squares multipliers for the original problem
+      // swap the iterate's multipliers and the optimality multipliers maintained by the class
       std::swap(trial_iterate.multipliers, this->other_phase_multipliers);
-      // this->inequality_handling_method->compute_least_squares_multipliers(trial_iterate, trial_evaluations);
       trial_iterate.multipliers.constraints.fill(0.);
-      //trial_iterate.multipliers.lower_bounds.fill(1.); // TODO compute based on the linearized complementarity equation
-      //trial_iterate.multipliers.upper_bounds.fill(-1.);
 
-      current_iterate.set_number_variables(this->original_problem.number_variables);
       trial_iterate.set_number_variables(this->original_problem.number_variables);
-      current_iterate.objective_multiplier = trial_iterate.objective_multiplier = 1.;
+      trial_iterate.objective_multiplier = 1.;
       this->initial_point.resize(this->original_problem.number_variables);
    }
 
@@ -275,7 +267,7 @@ namespace uno {
       // possibly go from restoration phase to optimality phase
       if (accept_iterate && this->current_phase == Phase::FEASIBILITY_RESTORATION && this->can_switch_to_optimality_phase(model,
             trial_iterate, direction, step_length, current_evaluations, trial_evaluations)) {
-         this->switch_back_to_optimality_phase(current_iterate, trial_iterate, current_evaluations, trial_evaluations);
+         this->switch_back_to_optimality_phase(trial_iterate, trial_evaluations);
          // set a cold start in the subproblem solver
          warmstart_information.whole_problem_changed();
       }

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -97,35 +97,34 @@ namespace uno {
          Evaluations& current_evaluations, WarmstartInformation& warmstart_information) {
       DEBUG << "\nSwitching from optimality to restoration phase\n";
       this->current_phase = Phase::FEASIBILITY_RESTORATION;
-      this->globalization_strategy->avoid_cycling_back_to(current_iterate.progress);
-      this->feasibility_globalization_strategy->initialize(statistics, current_iterate);
-      this->feasibility_globalization_strategy->reset();
 
+      this->globalization_strategy->avoid_cycling_back_to(current_iterate.progress);
       // save the current point (infeasibility and primals) upon switching
       this->reference_infeasibility = current_iterate.primal_infeasibility;
       this->reference_optimality_primals = current_iterate.primals;
       this->feasibility_problem.set_proximal_center(this->reference_optimality_primals.data());
 
+      // resize the iterate and retrieve the feasibility multipliers (stored locally)
       current_iterate.set_number_variables(this->feasibility_problem.number_variables);
-      this->initial_point.resize(this->feasibility_problem.number_variables);
-      // swap the iterate's multipliers and the feasibility multipliers maintained by the class
       if (this->first_switch_to_feasibility) {
-         this->other_phase_multipliers.constraints.resize(this->feasibility_problem.number_constraints);
-         this->other_phase_multipliers.lower_bounds.resize(this->feasibility_problem.number_variables);
-         this->other_phase_multipliers.upper_bounds.resize(this->feasibility_problem.number_variables);
+         this->other_phase_multipliers.resize(this->feasibility_problem.number_variables, this->feasibility_problem.number_constraints);
          this->first_switch_to_feasibility = false;
       }
       std::swap(current_iterate.multipliers, this->other_phase_multipliers);
 
+      // initialize the feasibility inequality handling method
       this->feasibility_inequality_handling_method->initialize_feasibility_problem(current_iterate);
       const double proximal_coefficient = this->feasibility_inequality_handling_method->proximal_coefficient();
       this->feasibility_problem.set_proximal_coefficient(proximal_coefficient);
       DEBUG << "Proximal coefficient set to " << proximal_coefficient << '\n';
       this->feasibility_inequality_handling_method->set_elastic_variable_values(this->feasibility_problem, current_iterate,
          current_evaluations);
+
       // re-evaluate the progress measures at the current iterate
       this->feasibility_inequality_handling_method->evaluate_progress_measures(current_iterate, current_evaluations);
+      this->feasibility_globalization_strategy->initialize(statistics, current_iterate);
 
+      this->initial_point.resize(this->feasibility_problem.number_variables);
       DEBUG2 << "\nCurrent iterate to start feasibility restoration:\n" << current_iterate << '\n';
 
       if (Logger::level == INFO) statistics.print_current_line();

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.cpp
@@ -54,7 +54,8 @@ namespace uno {
          uses_trust_region, 0., options);
 
       // initial iterate
-      this->inequality_handling_method->generate_initial_iterate(initial_iterate, evaluation_cache.current_evaluations);
+      this->inequality_handling_method->create_iterate(initial_iterate, evaluation_cache.current_evaluations,
+         1000. /* TODO use option */);
       this->inequality_handling_method->evaluate_progress_measures(initial_iterate, evaluation_cache.current_evaluations);
       this->compute_residuals(this->original_problem, initial_iterate, evaluation_cache.current_evaluations);
       this->globalization_strategy->initialize(statistics, initial_iterate);

--- a/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
+++ b/uno/ingredients/constraint_relaxation_strategies/FeasibilityRestoration.hpp
@@ -78,8 +78,7 @@ namespace uno {
       const Direction& solve_subproblem(Statistics& statistics, InequalityHandlingMethod& inequality_handling_method,
          GlobalizationStrategy& globalization_strategy, Iterate& current_iterate, double trust_region_radius,
          Evaluations& current_evaluations, const WarmstartInformation& warmstart_information);
-      void switch_back_to_optimality_phase(Iterate& current_iterate, Iterate& trial_iterate, Evaluations& current_evaluations,
-         Evaluations& trial_evaluations);
+      void switch_back_to_optimality_phase(Iterate& trial_iterate, Evaluations& trial_evaluations);
 
       [[nodiscard]] bool can_switch_to_optimality_phase(const Model& model, Iterate& trial_iterate,
          const Direction& direction, double step_length, Evaluations& current_evaluations, Evaluations& trial_evaluations) const;

--- a/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/NoRelaxation.cpp
@@ -37,7 +37,8 @@ namespace uno {
       //initial_iterate.set_number_variables(this->reformulated_problem->number_variables);
 
       // initial iterate
-      this->inequality_handling_method->generate_initial_iterate(initial_iterate, evaluation_cache.current_evaluations);
+      this->inequality_handling_method->create_iterate(initial_iterate, evaluation_cache.current_evaluations,
+         1000. /* TODO use option */);
       this->inequality_handling_method->evaluate_progress_measures(initial_iterate, evaluation_cache.current_evaluations);
       this->compute_residuals(this->original_problem, initial_iterate, evaluation_cache.current_evaluations);
       this->globalization_strategy.initialize(statistics, initial_iterate);

--- a/uno/ingredients/globalization_strategies/GlobalizationStrategy.hpp
+++ b/uno/ingredients/globalization_strategies/GlobalizationStrategy.hpp
@@ -26,8 +26,7 @@ namespace uno {
 
       virtual void reset() = 0;
 
-      virtual void notify_switch_to_feasibility(const ProgressMeasures& current_progress) = 0;
-      virtual void notify_switch_to_optimality(const ProgressMeasures& current_progress) = 0;
+      virtual void avoid_cycling_back_to(const ProgressMeasures& current_progress) = 0;
 
       [[nodiscard]] virtual std::string get_name() const = 0;
 

--- a/uno/ingredients/globalization_strategies/MeritFunction.cpp
+++ b/uno/ingredients/globalization_strategies/MeritFunction.cpp
@@ -57,10 +57,7 @@ namespace uno {
    void MeritFunction::reset() {
    }
 
-   void MeritFunction::notify_switch_to_feasibility(const ProgressMeasures& /*current_progress*/) {
-   }
-
-   void MeritFunction::notify_switch_to_optimality(const ProgressMeasures& /*current_progress*/) {
+   void MeritFunction::avoid_cycling_back_to(const ProgressMeasures& /*current_progress*/) {
    }
 
    std::string MeritFunction::get_name() const {

--- a/uno/ingredients/globalization_strategies/MeritFunction.hpp
+++ b/uno/ingredients/globalization_strategies/MeritFunction.hpp
@@ -18,8 +18,7 @@ namespace uno {
             const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reductions, double objective_multiplier) override;
       [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double reference_infeasibility) const override;
       void reset() override;
-      void notify_switch_to_feasibility(const ProgressMeasures& current_progress) override;
-      void notify_switch_to_optimality(const ProgressMeasures& current_progress) override;
+      void avoid_cycling_back_to(const ProgressMeasures& current_progress) override;
 
       [[nodiscard]] std::string get_name() const override;
 

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FilterMethod.cpp
@@ -29,13 +29,8 @@ namespace uno {
       this->filter->reset();
    }
 
-   void FilterMethod::notify_switch_to_feasibility(const ProgressMeasures& current_progress) {
-      const double current_objective_measure = SwitchingMethod::unconstrained_merit_function(current_progress);
-      this->filter->add(current_progress.infeasibility, current_objective_measure);
-   }
-
-   void FilterMethod::notify_switch_to_optimality(const ProgressMeasures& current_progress) {
-      const double current_objective_measure = SwitchingMethod::unconstrained_merit_function(current_progress);
+   void FilterMethod::avoid_cycling_back_to(const ProgressMeasures& current_progress) {
+      const double current_objective_measure = unconstrained_merit_function(current_progress);
       this->filter->add(current_progress.infeasibility, current_objective_measure);
    }
 

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FilterMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FilterMethod.cpp
@@ -23,6 +23,7 @@ namespace uno {
       // set the filter upper bound
       const double upper_bound = std::max(this->parameters.upper_bound, this->parameters.infeasibility_factor * initial_iterate.progress.infeasibility);
       this->filter->set_infeasibility_upper_bound(upper_bound);
+      this->reset();
    }
 
    void FilterMethod::reset() {

--- a/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FilterMethod.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/filter_methods/FilterMethod.hpp
@@ -24,8 +24,7 @@ namespace uno {
 
       void initialize(Statistics& statistics, const Iterate& initial_iterate) override;
       void reset() override;
-      void notify_switch_to_feasibility(const ProgressMeasures& current_progress) override;
-      void notify_switch_to_optimality(const ProgressMeasures& current_progress) override;
+      void avoid_cycling_back_to(const ProgressMeasures& current_progress) override;
 
    protected:
       // pointer to allow polymorphism

--- a/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.cpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.cpp
@@ -105,11 +105,8 @@ namespace uno {
       // do nothing
    }
 
-   void FunnelMethod::notify_switch_to_feasibility(const ProgressMeasures& /*current_progress_measures*/) {
-   }
-
-   void FunnelMethod::notify_switch_to_optimality(const ProgressMeasures& current_progress_measures) {
-      DEBUG << "Funnel is reduced after restoration phase\n";
+   void FunnelMethod::avoid_cycling_back_to(const ProgressMeasures& current_progress_measures) {
+      DEBUG << "Funnel is reduced\n";
       this->funnel.update_restoration(current_progress_measures.infeasibility);
    }
 

--- a/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.hpp
+++ b/uno/ingredients/globalization_strategies/switching_methods/funnel_methods/FunnelMethod.hpp
@@ -30,8 +30,7 @@ namespace uno {
          const ProgressMeasures& trial_progress, const ProgressMeasures& predicted_reduction, double objective_multiplier) override;
       [[nodiscard]] bool is_infeasibility_sufficiently_reduced(const Iterate& trial_iterate, double reference_infeasibility) const override;
       void reset() override;
-      void notify_switch_to_feasibility(const ProgressMeasures& current_progress_measures) override;
-      void notify_switch_to_optimality(const ProgressMeasures& current_progress_measures) override;
+      void avoid_cycling_back_to(const ProgressMeasures& current_progress_measures) override;
 
       [[nodiscard]] bool acceptable_wrt_current_iterate(double current_infeasibility, double current_objective, double trial_infeasibility,
          double trial_objective) const;

--- a/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/InequalityHandlingMethod.hpp
@@ -30,7 +30,7 @@ namespace uno {
       InequalityHandlingMethod(const OptimizationProblem& problem, const Options& options);
       virtual ~InequalityHandlingMethod() = default;
 
-      virtual void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const = 0;
+      virtual void create_iterate(Iterate& initial_iterate, Evaluations& evaluations, double multipliers_threshold) const = 0;
       virtual void initialize_statistics(Statistics& statistics) = 0;
       [[nodiscard]] virtual bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) = 0;
       [[nodiscard]] virtual const Direction& solve(Statistics& statistics, const Iterate& current_iterate,

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.cpp
@@ -22,9 +22,11 @@ namespace uno {
       this->subproblem_solver->initialize_memory(*this->subproblem);
    }
 
-   void NoInequalityReformulation::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
+   void NoInequalityReformulation::create_iterate(Iterate& initial_iterate, Evaluations& evaluations,
+         double multipliers_threshold) const {
       this->problem.generate_initial_iterate(initial_iterate, evaluations);
-      this->subproblem_solver->generate_initial_iterate(*this->subproblem, initial_iterate, evaluations);
+      this->subproblem_solver->compute_least_squares_multipliers(*this->subproblem, initial_iterate, evaluations,
+         multipliers_threshold);
    }
 
    void NoInequalityReformulation::initialize_statistics(Statistics& statistics) {

--- a/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
+++ b/uno/ingredients/inequality_handling_methods/NoInequalityReformulation.hpp
@@ -23,7 +23,7 @@ namespace uno {
          double objective_multiplier, Options& options);
       ~NoInequalityReformulation() override = default;
 
-      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
+      void create_iterate(Iterate& initial_iterate, Evaluations& evaluations, double multipliers_threshold) const override;
       void initialize_statistics(Statistics& statistics) override;
       [[nodiscard]] bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) override;
       [[nodiscard]] const Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/InteriorPointMethod.hpp
@@ -27,7 +27,7 @@ namespace uno {
    public:
       InteriorPointMethod(const OptimizationProblem& problem, bool uses_trust_region, double objective_multiplier, Options& options);
 
-      void generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const override;
+      void create_iterate(Iterate& initial_iterate, Evaluations& evaluations, double multipliers_threshold) const override;
       void initialize_statistics(Statistics& statistics) override;
       [[nodiscard]] bool update_parameterization(Statistics& statistics, const Iterate& current_iterate) override;
       [[nodiscard]] const Direction& solve(Statistics& statistics, const Iterate& current_iterate, double trust_region_radius,
@@ -108,9 +108,11 @@ namespace uno {
    }
 
    template <typename BarrierProblem>
-   void InteriorPointMethod<BarrierProblem>::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
+   void InteriorPointMethod<BarrierProblem>::create_iterate(Iterate& initial_iterate, Evaluations& evaluations,
+         double multipliers_threshold) const {
       this->barrier_problem.generate_initial_iterate(initial_iterate, evaluations);
-      this->subproblem_solver->generate_initial_iterate(*this->subproblem, initial_iterate, evaluations);
+      this->subproblem_solver->compute_least_squares_multipliers(*this->subproblem, initial_iterate, evaluations,
+         multipliers_threshold);
    }
 
    template <typename BarrierProblem>

--- a/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
+++ b/uno/ingredients/inequality_handling_methods/interior_point_methods/barrier_problems/PrimalDualInteriorPointProblem.cpp
@@ -47,9 +47,17 @@ namespace uno {
 
    void PrimalDualInteriorPointProblem::generate_initial_iterate(Iterate& initial_iterate, Evaluations& evaluations) const {
       // make the initial point strictly feasible wrt the bounds
+      bool iterate_changed = false;
       for (size_t variable_index: Range(this->number_variables)) {
+         const double old_value = initial_iterate.primals[variable_index];
          initial_iterate.primals[variable_index] = this->push_variable_to_interior(initial_iterate.primals[variable_index],
             this->variables_lower_bounds[variable_index], this->variables_upper_bounds[variable_index]);
+         if (initial_iterate.primals[variable_index] != old_value) {
+            iterate_changed = true;
+         }
+      }
+      if (iterate_changed) {
+         evaluations.reset();
       }
 
       // set the slack variables (if any)
@@ -60,10 +68,8 @@ namespace uno {
             initial_iterate.primals[slack_index] = this->push_variable_to_interior(evaluations.constraints[constraint_index],
                this->variables_lower_bounds[slack_index], this->variables_upper_bounds[slack_index]);
          }
-         // since the slacks have been set, the function evaluations should also be updated
+         // since the slacks have been set, the constraints should be updated
          evaluations.are_constraints_computed = false;
-         evaluations.is_objective_gradient_computed = false;
-         evaluations.is_jacobian_computed = false;
       }
 
       // set the bound multipliers

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.cpp
@@ -15,11 +15,6 @@ namespace uno {
       this->workspace.objective_gradient.resize(subproblem.number_variables);
    }
 
-   void BoxLPSolver::generate_initial_iterate(const Subproblem& /*subproblem*/, Iterate& /*initial_iterate*/,
-         Evaluations& /*evaluations*/) {
-      // do nothing
-   }
-
    void BoxLPSolver::compute_least_squares_multipliers(const Subproblem& /*subproblem*/, Iterate& /*iterate*/,
          Evaluations& /*evaluations*/, double /*multipliers_threshold*/) {
       DEBUG << "The box LP solver does not compute least-squares multipliers, keeping existing multipliers\n";

--- a/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/BoxLPSolver.hpp
@@ -29,7 +29,6 @@ namespace uno {
       ~BoxLPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 

--- a/uno/ingredients/subproblem_solvers/EQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.cpp
@@ -29,10 +29,6 @@ namespace uno {
       this->linear_solver->initialize_memory();
    }
 
-   void EQPSolver::generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) {
-      compute_least_squares_multipliers(subproblem, initial_iterate, evaluations, 1000. /* TODO add option */);
-   }
-
    void EQPSolver::compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) {
       DEBUG << "Computing least-squares multipliers\n";

--- a/uno/ingredients/subproblem_solvers/EQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/EQPSolver.hpp
@@ -20,7 +20,6 @@ namespace uno {
       ~EQPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 

--- a/uno/ingredients/subproblem_solvers/IQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.cpp
@@ -21,11 +21,6 @@ namespace uno {
       this->qp_solver->initialize_memory(subproblem);
    }
 
-   void IQPSolver::generate_initial_iterate(const Subproblem& /*subproblem*/, Iterate& /*initial_iterate*/,
-         Evaluations& /*evaluations*/) {
-      // do nothing
-   }
-
    void IQPSolver::compute_least_squares_multipliers(const Subproblem& /*subproblem*/, Iterate& /*iterate*/,
          Evaluations& /*evaluations*/, double /*multipliers_threshold*/) {
       DEBUG << "The IQP solver does not compute least-squares multipliers, keeping existing multipliers\n";

--- a/uno/ingredients/subproblem_solvers/IQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/IQPSolver.hpp
@@ -26,7 +26,6 @@ namespace uno {
       ~IQPSolver() override;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.cpp
@@ -20,11 +20,6 @@ namespace uno {
       this->rhs.resize(subproblem.number_variables);
    }
 
-   void InverseNewtonSolver::generate_initial_iterate(const Subproblem& /*subproblem*/, Iterate& /*initial_iterate*/,
-         Evaluations& /*evaluations*/) {
-      // do nothing
-   }
-
    void InverseNewtonSolver::compute_least_squares_multipliers(const Subproblem& /*subproblem*/, Iterate& /*iterate*/,
          Evaluations& /*evaluations*/, double /*multipliers_threshold*/) {
       DEBUG << "The inverse Newton solver does not compute least-squares multipliers, keeping existing multipliers\n";

--- a/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/InverseNewtonSolver.hpp
@@ -31,7 +31,6 @@ namespace uno {
       ~InverseNewtonSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 

--- a/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/SubproblemSolver.hpp
@@ -23,7 +23,6 @@ namespace uno {
       virtual ~SubproblemSolver() = default;
 
       virtual void initialize_memory(const Subproblem& subproblem) = 0;
-      virtual void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) = 0;
       virtual void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) = 0;
 

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.cpp
@@ -31,11 +31,6 @@ namespace uno {
       this->linear_solver->initialize_memory();
    }
 
-   void WoodburyEQPSolver::generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate,
-         Evaluations& evaluations) {
-      compute_least_squares_multipliers(subproblem, initial_iterate, evaluations, 1000. /* TODO add option */);
-   }
-
    void WoodburyEQPSolver::compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate,
          Evaluations& evaluations, double multipliers_threshold) {
       DEBUG << "Computing least-squares multipliers\n";

--- a/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
+++ b/uno/ingredients/subproblem_solvers/WoodburyEQPSolver.hpp
@@ -36,7 +36,6 @@ namespace uno {
       ~WoodburyEQPSolver() override = default;
 
       void initialize_memory(const Subproblem& subproblem) override;
-      void generate_initial_iterate(const Subproblem& subproblem, Iterate& initial_iterate, Evaluations& evaluations) override;
       void compute_least_squares_multipliers(const Subproblem& subproblem, Iterate& iterate, Evaluations& evaluations,
          double multipliers_threshold) override;
 

--- a/uno/optimization/Multipliers.cpp
+++ b/uno/optimization/Multipliers.cpp
@@ -9,6 +9,12 @@ namespace uno {
          upper_bounds(number_variables), constraints(number_constraints) {
    }
 
+   void Multipliers::resize(size_t number_variables, size_t number_constraints) {
+      this->constraints.resize(number_constraints);
+      this->lower_bounds.resize(number_variables);
+      this->upper_bounds.resize(number_variables);
+   }
+
    void Multipliers::reset() {
       this->constraints.fill(0.);
       this->lower_bounds.fill(0.);

--- a/uno/optimization/Multipliers.hpp
+++ b/uno/optimization/Multipliers.hpp
@@ -20,6 +20,7 @@ namespace uno {
       Multipliers& operator=(const Multipliers& other) = default;
       Multipliers& operator=(Multipliers&& other) noexcept = default;
 
+      void resize(size_t number_variables, size_t number_constraints);
       void reset();
       [[nodiscard]] bool not_all_zero(size_t number_variables, double tolerance) const;
    };


### PR DESCRIPTION
- **[bug]** Proper way to reset evaluations upon creation of initial point: reset only if iterate was updated
- Have the constraint relax strategy control the multiplier threshold
- Switch back: do not add the current point to the filter (pretend that the restoration iterations where one single h-type step)
- Renamed `notify_switch_to_feasibility`/`notify_switch_to_optimality` to `avoid_cycling_back_to`
- **[bug]** Initialize the feasibility globalization strategy only after evaluating the progress measures wrt the feasibility problem