### PR TITLE
BLAS-friendly View operators

### DIFF
--- a/uno/linear_algebra/BLAS.hpp
+++ b/uno/linear_algebra/BLAS.hpp
@@ -9,6 +9,7 @@
 #define dcopy FC_GLOBAL_(dcopy, DCOPY)
 #define dscal FC_GLOBAL_(dscal, DSCAL)
 #define daxpy FC_GLOBAL_(daxpy, DAXPY)
+//#define daxpby FC_GLOBAL_(daxpby, DAXPBY)
 #define ddot FC_GLOBAL_(ddot, DDOT)
 #define dgemv FC_GLOBAL_(dgemv, DGEMV)
 #define dtrsm FC_GLOBAL_(dtrsm, DTRSM)
@@ -26,6 +27,9 @@ extern "C" {
 
    // y := alpha x + y
    void daxpy(const int* n, const double* alpha, const double* x, const int* incx, double* y, const int* incy);
+
+   // y := alpha x + beta y
+   void daxpby(const int* n, const double* alpha, const double* x, const int* incx, const double* beta, double* y, const int* incy);
 
    // x^T y
    double ddot(const int* n, const double* x, const int* incx, const double* y, const int* incy);
@@ -92,6 +96,15 @@ namespace uno {
          constexpr int increment = 1;
          daxpy(&n, &alpha, x, &increment, y, &increment);
       }
+
+      /*
+      // y := alpha x + beta y
+      inline void scale_and_add(size_t size, double alpha, const double* x, double beta, double* y) {
+         const int n = static_cast<int>(size);
+         constexpr int increment = 1;
+         daxpby(&n, &alpha, x, &increment, &beta, y, &increment);
+      }
+      */
 
       // x^T y
       inline double dot(size_t size, const double* x, const double* y) {

--- a/uno/linear_algebra/BLAS.hpp
+++ b/uno/linear_algebra/BLAS.hpp
@@ -29,7 +29,8 @@ extern "C" {
    void daxpy(const int* n, const double* alpha, const double* x, const int* incx, double* y, const int* incy);
 
    // y := alpha x + beta y
-   void daxpby(const int* n, const double* alpha, const double* x, const int* incx, const double* beta, double* y, const int* incy);
+   // not portable
+   // void daxpby(const int* n, const double* alpha, const double* x, const int* incx, const double* beta, double* y, const int* incy);
 
    // x^T y
    double ddot(const int* n, const double* x, const int* incx, const double* y, const int* incy);

--- a/uno/linear_algebra/DenseMatrix.hpp
+++ b/uno/linear_algebra/DenseMatrix.hpp
@@ -9,11 +9,12 @@
 #include "linear_algebra/BLASMatrix.hpp"
 #include "View.hpp"
 #include "symbolic/Range.hpp"
+#include "symbolic/symbolic_traits.hpp"
 
 namespace uno {
    // DenseMatrix is an m x n matrix in column-major order where the columns are concatenated in a long vector
    template <typename T>
-   class DenseMatrix: public BLASMatrix<T> {
+   class DenseMatrix: public BLASMatrix<T>, SymbolicExpression {
    public:
       using value_type = T;
 

--- a/uno/linear_algebra/Vector.hpp
+++ b/uno/linear_algebra/Vector.hpp
@@ -9,10 +9,11 @@
 #include <initializer_list>
 #include "View.hpp"
 #include "symbolic/Range.hpp"
+#include "symbolic/symbolic_traits.hpp"
 
 namespace uno {
    template <typename T>
-   class Vector {
+   class Vector: public SymbolicExpression {
    public:
       using value_type = typename std::vector<T>::value_type;
       // iterators

--- a/uno/linear_algebra/View.hpp
+++ b/uno/linear_algebra/View.hpp
@@ -44,6 +44,9 @@ namespace uno {
       View(View&& other) = default;
       View<T>& operator=(const View<T>& other) {
          if (&other != this) {
+            if (this->size() != other.size()) {
+               throw std::runtime_error("Dimension mismatch");
+            }
             blas1::copy(this->size(), other.data(), this->data());
          }
          return *this;
@@ -92,7 +95,7 @@ namespace uno {
                                                         decltype(std::declval<const Vector&>().size())>>
       View& operator=(const Vector& other) {
          if (other.size() != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between x and y");
+            throw std::invalid_argument("Dimension mismatch");
          }
          // dispatch copy function on type of elements
          if constexpr (std::is_same_v<value_type, double>) {
@@ -108,38 +111,29 @@ namespace uno {
       template <typename Vector>
       View& operator=(UnaryNegation<Vector>&& expression) {
          const auto& x = expression.get_expression();
-         // y := -1 * x + 0 * y
-         //blas1::scale_and_add(this->size(), -1., x.data(), 0., this->data());
+         // note: this operation can be written as axpby: y := -1 * x + 0 * y
+         // for portability reasons, we prefer to decompose it as copy + scale by -1
+         // blas1::scale_and_add(this->size(), -1., x.data(), 0., this->data());
          *this = x;
          this->scale(-1.);
          return *this;
       }
 
-      // specialized operation y = a * x (note: no BLAS operation available)
+      // specialized operation y = a * x
       template <typename Vector>
       View& operator=(ScalarMultiple<Vector>&& expression) {
          const auto& a = expression.get_factor();
          const auto& x = expression.get_expression();
-         if (x.size() != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between x and y");
-         }
          *this = x;
          this->scale(a);
          return *this;
       }
 
       // specialized operation y = x - z
-      // note: no BLAS operation available
       template <typename Vector1, typename Vector2>
       View& operator=(Subtraction<Vector1, Vector2>&& expression) {
          const auto& x = expression.get_left();
          const auto& z = expression.get_right();
-         if (x.size() != z.size()) {
-            throw std::invalid_argument("Dimension mismatch between x and z");
-         }
-         if (x.size() != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between x and y");
-         }
          *this = x;
          *this -= z;
          return *this;
@@ -154,10 +148,10 @@ namespace uno {
          }
          const auto& A = expression.get_left();
          if (A.number_columns != x.size()) {
-            throw std::invalid_argument("Dimension mismatch between A and x");
+            throw std::invalid_argument("Dimension mismatch");
          }
          if (A.number_rows != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between A and y");
+            throw std::invalid_argument("Dimension mismatch");
          }
          blas2::matrix_vector_product('N', A.number_rows, A.number_columns, 1., A.data(), A.leading_dimension, x.data(),
             0., this->data());
@@ -170,7 +164,7 @@ namespace uno {
          const auto& a = expression.get_factor();
          const auto& x = expression.get_expression();
          if (x.size() != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between x and y");
+            throw std::invalid_argument("Dimension mismatch");
          }
          blas1::add(this->size(), a, x.data(), this->data());
          return *this;
@@ -180,7 +174,7 @@ namespace uno {
       template <typename Vector>
       View& operator+=(const Vector& other) {
          if (other.size() != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between x and y");
+            throw std::invalid_argument("Dimension mismatch");
          }
          blas1::add(this->size(), 1., other.data(), this->data());
          return *this;
@@ -192,7 +186,10 @@ namespace uno {
          const auto& x = expression.get_left();
          const double a = expression.get_right().get_factor();
          const auto& y = expression.get_right().get_expression();
-         *this = x; // blas copy
+         if (this->size() != y.size()) {
+            throw std::runtime_error("Dimension mismatch");
+         }
+         *this = x; // blas copy (tests this->size() == x.size())
          blas1::add(this->size(), a, y.data(), this->data()); // axpy
          return *this;
       }
@@ -203,7 +200,10 @@ namespace uno {
          const auto& x = expression.get_left();
          const double a = expression.get_right().get_factor();
          const auto& y = expression.get_right().get_expression();
-         *this = x; // blas copy
+         if (this->size() != y.size()) {
+            throw std::runtime_error("Dimension mismatch");
+         }
+         *this = x; // blas copy (tests this->size() == x.size())
          blas1::add(this->size(), -a, y.data(), this->data()); // axpy
          return *this;
       }
@@ -212,7 +212,7 @@ namespace uno {
       template <typename Vector>
       View& operator-=(const Vector& other) {
          if (other.size() != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between x and y");
+            throw std::invalid_argument("Dimension mismatch");
          }
          blas1::add(this->size(), -1., other.data(), this->data());
          return *this;
@@ -224,7 +224,7 @@ namespace uno {
          const auto& U = expression.get_left().get_matrix().get_matrix().get_matrix();
          const auto& y = expression.get_right();
          if (this->size() != U.number_columns) {
-            throw std::runtime_error("Dimension mismatch in BLASVector::operator=");
+            throw std::runtime_error("Dimension mismatch");
          }
          // copy the RHS into this
          blas1::copy(this->size(), y.data(), this->data());
@@ -239,7 +239,7 @@ namespace uno {
          const auto& U = expression.get_left().get_matrix().get_matrix();
          const auto& y = expression.get_right();
          if (this->size() != U.number_columns) {
-            throw std::runtime_error("Dimension mismatch in BLASVector::operator=");
+            throw std::runtime_error("Dimension mismatch");
          }
          // copy the RHS into this
          blas1::copy(this->size(), y.data(), this->data());
@@ -254,10 +254,10 @@ namespace uno {
          const auto& A = expression.get_left().get_matrix();
          const auto& x = expression.get_right();
          if (A.number_rows != x.size()) {
-            throw std::invalid_argument("Dimension mismatch between A and x");
+            throw std::invalid_argument("Dimension mismatch");
          }
          if (A.number_columns != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between A and y");
+            throw std::invalid_argument("Dimension mismatch");
          }
          blas2::matrix_vector_product('T', A.number_rows, A.number_columns, 1., A.data(), A.leading_dimension, x.data(),
             0., this->data());
@@ -270,10 +270,10 @@ namespace uno {
          const auto& A = expression.get_left();
          const auto& x = expression.get_right();
          if (A.number_columns != x.size()) {
-            throw std::invalid_argument("Dimension mismatch between A and x");
+            throw std::invalid_argument("Dimension mismatch");
          }
          if (A.number_rows != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between A and y");
+            throw std::invalid_argument("Dimension mismatch");
          }
          blas2::matrix_vector_product('N', A.number_rows, A.number_columns, 1., A.data(), A.leading_dimension, x.data(),
             1., this->data());
@@ -286,10 +286,10 @@ namespace uno {
          const auto& A = expression.get_left();
          const auto& x = expression.get_right();
          if (A.number_columns != x.size()) {
-            throw std::invalid_argument("Dimension mismatch between A and x");
+            throw std::invalid_argument("Dimension mismatch");
          }
          if (A.number_rows != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between A and y");
+            throw std::invalid_argument("Dimension mismatch");
          }
          blas2::matrix_vector_product('N', A.number_rows, A.number_columns, -1., A.data(), A.leading_dimension, x.data(),
             1., this->data());
@@ -347,7 +347,7 @@ namespace uno {
    template <typename Vector1, typename Vector2>
    double dot(const Vector1& x, const Vector2& y) {
       if (x.size() != y.size()) {
-         throw std::invalid_argument("Dimension mismatch between x and y");
+         throw std::invalid_argument("Dimension mismatch");
       }
       return blas1::dot(x.size(), x.data(), y.data());
    }

--- a/uno/linear_algebra/View.hpp
+++ b/uno/linear_algebra/View.hpp
@@ -104,36 +104,14 @@ namespace uno {
          return *this;
       }
 
-      // specialized operation y = -x (note: no BLAS operation available)
+      // specialized operation y = -x
       template <typename Vector>
       View& operator=(UnaryNegation<Vector>&& expression) {
          const auto& x = expression.get_expression();
+         // y := -1 * x + 0 * y
+         //blas1::scale_and_add(this->size(), -1., x.data(), 0., this->data());
          *this = x;
          this->scale(-1.);
-         return *this;
-      }
-
-      // specialized operation z = x + a * y (note: no BLAS operation available)
-      template <typename Vector1, typename Vector2>
-      View& operator=(Sum<Vector1, ScalarMultiple<Vector2>>&& expression) {
-         const auto& x = expression.get_left();
-         const double a = expression.get_right().get_factor();
-         const auto& y = expression.get_right().get_expression();
-         *this = y;
-         this->scale(a);
-         *this += x;
-         return *this;
-      }
-
-      // specialized operation z = x - a * y (note: no BLAS operation available)
-      template <typename Vector1, typename Vector2>
-      View& operator=(Subtraction<Vector1, ScalarMultiple<Vector2>>&& expression) {
-         const auto& x = expression.get_left();
-         const double a = expression.get_right().get_factor();
-         const auto& y = expression.get_right().get_expression();
-         *this = y;
-         this->scale(-a);
-         *this += x;
          return *this;
       }
 
@@ -205,6 +183,28 @@ namespace uno {
             throw std::invalid_argument("Dimension mismatch between x and y");
          }
          blas1::add(this->size(), 1., other.data(), this->data());
+         return *this;
+      }
+
+      // specialized operation z = x + a * y
+      template <typename Vector1, typename Vector2>
+      View& operator=(Sum<Vector1, ScalarMultiple<Vector2>>&& expression) {
+         const auto& x = expression.get_left();
+         const double a = expression.get_right().get_factor();
+         const auto& y = expression.get_right().get_expression();
+         *this = x; // blas copy
+         blas1::add(this->size(), a, y.data(), this->data()); // axpy
+         return *this;
+      }
+
+      // specialized operation z = x - a * y
+      template <typename Vector1, typename Vector2>
+      View& operator=(Subtraction<Vector1, ScalarMultiple<Vector2>>&& expression) {
+         const auto& x = expression.get_left();
+         const double a = expression.get_right().get_factor();
+         const auto& y = expression.get_right().get_expression();
+         *this = x; // blas copy
+         blas1::add(this->size(), -a, y.data(), this->data()); // axpy
          return *this;
       }
 

--- a/uno/linear_algebra/View.hpp
+++ b/uno/linear_algebra/View.hpp
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <iostream>
 #include <vector>
 #include "BLAS.hpp"
 #include "symbolic/Inverse.hpp"
@@ -13,13 +14,16 @@
 #include "symbolic/Range.hpp"
 #include "symbolic/ScalarMultiple.hpp"
 #include "symbolic/Subtraction.hpp"
+#include "symbolic/symbolic_traits.hpp"
+#include "symbolic/Sum.hpp"
 #include "symbolic/Transpose.hpp"
 #include "symbolic/Triangular.hpp"
+#include "symbolic/UnaryNegation.hpp"
 
 namespace uno {
    // constant contiguous array in memory on which BLAS can be called
    template <typename T>
-   class View {
+   class View: public SymbolicExpression {
    protected:
       T* pointer;
       size_t view_size;
@@ -83,26 +87,53 @@ namespace uno {
          return this->pointer[index];
       }
 
-      // specialized operation y = x, when the other vector has the member function data()
-      template <typename Vector, decltype(Vector{}.data()) = true>
+      // specialized operation y = x, when the other vector has the member functions data() and size()
+      template <typename Vector, typename = std::void_t<decltype(std::declval<const Vector&>().data()),
+                                                        decltype(std::declval<const Vector&>().size())>>
       View& operator=(const Vector& other) {
          if (other.size() != this->size()) {
             throw std::invalid_argument("Dimension mismatch between x and y");
          }
-         blas1::copy(this->size(), other.data(), this->data());
+         // dispatch copy function on type of elements
+         if constexpr (std::is_same_v<value_type, double>) {
+            blas1::copy(this->size(), other.data(), this->data());
+         }
+         else {
+            std::copy(other.data(), other.data() + other.size(), this->data());
+         }
          return *this;
       }
 
-      // generic operation y = expression
-      template <typename Expression>
-      View& operator=(const Expression& expression) {
-         // static_assert(std::is_same_v<typename Expression::value_type, T>);
-         if (expression.size() != this->size()) {
-            throw std::invalid_argument("Dimension mismatch between expression and y");
-         }
-         for (size_t index: Range(expression.size())) {
-            this->operator[](index) = expression[index];
-         }
+      // specialized operation y = -x (note: no BLAS operation available)
+      template <typename Vector>
+      View& operator=(UnaryNegation<Vector>&& expression) {
+         const auto& x = expression.get_expression();
+         *this = x;
+         this->scale(-1.);
+         return *this;
+      }
+
+      // specialized operation z = x + a * y (note: no BLAS operation available)
+      template <typename Vector1, typename Vector2>
+      View& operator=(Sum<Vector1, ScalarMultiple<Vector2>>&& expression) {
+         const auto& x = expression.get_left();
+         const double a = expression.get_right().get_factor();
+         const auto& y = expression.get_right().get_expression();
+         *this = y;
+         this->scale(a);
+         *this += x;
+         return *this;
+      }
+
+      // specialized operation z = x - a * y (note: no BLAS operation available)
+      template <typename Vector1, typename Vector2>
+      View& operator=(Subtraction<Vector1, ScalarMultiple<Vector2>>&& expression) {
+         const auto& x = expression.get_left();
+         const double a = expression.get_right().get_factor();
+         const auto& y = expression.get_right().get_expression();
+         *this = y;
+         this->scale(-a);
+         *this += x;
          return *this;
       }
 
@@ -114,16 +145,15 @@ namespace uno {
          if (x.size() != this->size()) {
             throw std::invalid_argument("Dimension mismatch between x and y");
          }
-         for (size_t index: Range(this->size())) {
-            this->operator[](index) = a * x[index];
-         }
+         *this = x;
+         this->scale(a);
          return *this;
       }
 
       // specialized operation y = x - z
       // note: no BLAS operation available
-      template <typename Vector>
-      View& operator=(Subtraction<Vector, Vector>&& expression) {
+      template <typename Vector1, typename Vector2>
+      View& operator=(Subtraction<Vector1, Vector2>&& expression) {
          const auto& x = expression.get_left();
          const auto& z = expression.get_right();
          if (x.size() != z.size()) {
@@ -314,8 +344,8 @@ namespace uno {
       return stream;
    }
 
-   template <typename V1, typename V2>
-   double dot(const V1& x, const V2& y) {
+   template <typename Vector1, typename Vector2>
+   double dot(const Vector1& x, const Vector2& y) {
       if (x.size() != y.size()) {
          throw std::invalid_argument("Dimension mismatch between x and y");
       }

--- a/uno/symbolic/Inverse.hpp
+++ b/uno/symbolic/Inverse.hpp
@@ -8,7 +8,7 @@
 
 namespace uno {
    template <typename Matrix>
-   class Inverse {
+   class Inverse: public SymbolicExpression {
    public:
       using value_type = typename std::remove_reference_t<Matrix>::value_type;
 

--- a/uno/symbolic/Multiplication.hpp
+++ b/uno/symbolic/Multiplication.hpp
@@ -9,7 +9,7 @@
 namespace uno {
    // stores the expression (left * right) symbolically
    template <typename L, typename R>
-   class Multiplication {
+   class Multiplication: public SymbolicExpression {
    public:
       using value_type = typename std::remove_reference_t<L>::value_type;
 

--- a/uno/symbolic/ScalarMultiple.hpp
+++ b/uno/symbolic/ScalarMultiple.hpp
@@ -9,7 +9,7 @@
 namespace uno {
    // stores the expression (factor * expression) symbolically
    template <typename Expression>
-   class ScalarMultiple {
+   class ScalarMultiple: public SymbolicExpression {
    public:
       using value_type = typename std::remove_reference_t<Expression>::value_type;
 

--- a/uno/symbolic/Subtraction.hpp
+++ b/uno/symbolic/Subtraction.hpp
@@ -14,7 +14,7 @@ namespace uno {
    template <typename L, typename R,
       std::enable_if_t<std::is_same_v<typename std::remove_reference_t<L>::value_type,
                                       typename std::remove_reference_t<R>::value_type>, int> = 0>
-   class Subtraction {
+   class Subtraction: public SymbolicExpression {
    public:
       using value_type = typename std::remove_reference_t<L>::value_type;
 

--- a/uno/symbolic/Sum.hpp
+++ b/uno/symbolic/Sum.hpp
@@ -13,7 +13,7 @@ namespace uno {
    template <typename E1, typename E2,
       std::enable_if_t<std::is_same_v<typename std::remove_reference_t<E1>::value_type,
                                       typename std::remove_reference_t<E2>::value_type>, int> = 0>
-   class Sum {
+   class Sum: public SymbolicExpression {
    public:
       using value_type = typename std::remove_reference_t<E1>::value_type;
 
@@ -37,7 +37,8 @@ namespace uno {
    };
 
    // free function
-   template <typename L, typename R>
+   template <typename L, typename R,
+             std::enable_if_t<is_symbolic_v<L> && is_symbolic_v<R>, int> = 0>
    Sum<L, R> operator+(L&& left, R&& right) {
       return {std::forward<L>(left), std::forward<R>(right)};
    }

--- a/uno/symbolic/Transpose.hpp
+++ b/uno/symbolic/Transpose.hpp
@@ -8,7 +8,7 @@
 
 namespace uno {
    template <typename Matrix>
-   class Transpose {
+   class Transpose: public SymbolicExpression {
    public:
       using value_type = typename std::remove_reference_t<Matrix>::value_type;
 

--- a/uno/symbolic/Triangular.hpp
+++ b/uno/symbolic/Triangular.hpp
@@ -8,7 +8,7 @@
 
 namespace uno {
    template <typename Matrix>
-   class LowerTriangular {
+   class LowerTriangular: public SymbolicExpression {
    public:
       using value_type = typename std::remove_reference_t<Matrix>::value_type;
 

--- a/uno/symbolic/UnaryNegation.hpp
+++ b/uno/symbolic/UnaryNegation.hpp
@@ -12,7 +12,7 @@ namespace uno {
    // limited to types that possess value_type
    // https://stackoverflow.com/questions/11055923/stdenable-if-parameter-vs-template-parameter
    template <typename Expression>
-   class UnaryNegation {
+   class UnaryNegation: public SymbolicExpression {
    public:
       using value_type = typename std::remove_reference_t<Expression>::value_type;
 
@@ -25,6 +25,8 @@ namespace uno {
       [[nodiscard]] constexpr value_type operator[](size_t index) const noexcept {
          return -this->expression[index];
       }
+
+      UNO_FORWARD_ACCESSOR(get_expression, this->expression)
 
    protected:
       storage_t<Expression> expression;

--- a/uno/symbolic/symbolic_traits.hpp
+++ b/uno/symbolic/symbolic_traits.hpp
@@ -26,22 +26,22 @@ namespace uno {
    template<class T>
    using storage_t = std::conditional_t<std::is_lvalue_reference_v<T>, T, std::decay_t<T> >;
 
-#define UNO_FORWARD_ACCESSOR(name, member)                     \
-constexpr decltype(auto) name() & noexcept {                   \
-return (member);                                            \
-}                                                              \
-\
-constexpr decltype(auto) name() const& noexcept {              \
-return (member);                                            \
-}                                                              \
-\
-constexpr decltype(auto) name() && noexcept {                  \
-return std::move(member);                                   \
-}                                                              \
-\
-constexpr decltype(auto) name() const&& noexcept {             \
-return std::move(member);                                   \
-}
+   #define UNO_FORWARD_ACCESSOR(name, member)                     \
+   constexpr decltype(auto) name() & noexcept {                   \
+      return (member);                                            \
+   }                                                              \
+   \
+   constexpr decltype(auto) name() const& noexcept {              \
+      return (member);                                            \
+   }                                                              \
+   \
+   constexpr decltype(auto) name() && noexcept {                  \
+      return std::move(member);                                   \
+   }                                                              \
+   \
+   constexpr decltype(auto) name() const&& noexcept {             \
+      return std::move(member);                                   \
+   }
 } // namespace
 
 #endif // UNO_SYMBOLIC_TRAITS_H

--- a/uno/symbolic/symbolic_traits.hpp
+++ b/uno/symbolic/symbolic_traits.hpp
@@ -8,31 +8,40 @@
 #include <utility>
 
 namespace uno {
-    template<typename T, typename = void>
-    struct has_value_type: std::false_type {};
+   // empty marker base for all symbolic expression templates
+   struct SymbolicExpression {
+   };
 
-    template<typename T>
-    struct has_value_type<T, std::void_t<typename T::value_type>>: std::true_type {};
+   template<typename T>
+   inline constexpr bool is_symbolic_v = std::is_base_of_v<SymbolicExpression, std::remove_cv_t<std::remove_reference_t<T>>>;
 
-    template<class T>
-    using storage_t = std::conditional_t<std::is_lvalue_reference_v<T>, T, std::decay_t<T>>;
+   template<typename T, typename = void>
+   struct has_value_type : std::false_type {
+   };
 
-    #define UNO_FORWARD_ACCESSOR(name, member)                     \
-    constexpr decltype(auto) name() & noexcept {                   \
-      return (member);                                            \
-    }                                                              \
-    \
-    constexpr decltype(auto) name() const& noexcept {              \
-      return (member);                                            \
-    }                                                              \
-    \
-    constexpr decltype(auto) name() && noexcept {                  \
-      return std::move(member);                                   \
-    }                                                              \
-    \
-    constexpr decltype(auto) name() const&& noexcept {             \
-      return std::move(member);                                   \
-    }
+   template<typename T>
+   struct has_value_type<T, std::void_t<typename T::value_type> > : std::true_type {
+   };
+
+   template<class T>
+   using storage_t = std::conditional_t<std::is_lvalue_reference_v<T>, T, std::decay_t<T> >;
+
+#define UNO_FORWARD_ACCESSOR(name, member)                     \
+constexpr decltype(auto) name() & noexcept {                   \
+return (member);                                            \
+}                                                              \
+\
+constexpr decltype(auto) name() const& noexcept {              \
+return (member);                                            \
+}                                                              \
+\
+constexpr decltype(auto) name() && noexcept {                  \
+return std::move(member);                                   \
+}                                                              \
+\
+constexpr decltype(auto) name() const&& noexcept {             \
+return std::move(member);                                   \
+}
 } // namespace
 
 #endif // UNO_SYMBOLIC_TRAITS_H

--- a/unotest/unit_tests/SumTests.cpp
+++ b/unotest/unit_tests/SumTests.cpp
@@ -2,16 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project directory for details.
 
 #include <gtest/gtest.h>
-#include <vector>
+#include "linear_algebra/Vector.hpp"
 #include "symbolic/Sum.hpp"
 #include "symbolic/Range.hpp"
 
 using namespace uno;
 
 TEST(Sum, Test) {
-   const std::vector<double> x{100., 200., 300., 400.};
-   const std::vector<double> y{2., 3., 4., 5.};
-   const std::vector<double> reference_result{102., 203., 304., 405.};
+   const Vector<double> x{100., 200., 300., 400.};
+   const Vector<double> y{2., 3., 4., 5.};
+   const Vector<double> reference_result{102., 203., 304., 405.};
    const auto sum = x + y;
    for (size_t i: Range(x.size())) {
       ASSERT_EQ(sum[i], reference_result[i]);


### PR DESCRIPTION
Replaced generic (and inefficient) `View::operator=(Expression&& expression)` with specialized, BLAS-friendly operators.