### PR TITLE
Reduced memory allocations

### DIFF
--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -116,7 +116,7 @@ namespace uno {
             warmstart_information.iterate_changed();
             this->globalization_mechanism->compute_next_iterate(statistics, model, current_iterate, trial_iterate,
                evaluation_cache, warmstart_information, user_callbacks);
-            termination = Uno::check_termination(trial_iterate, major_iterations, max_iterations,
+            termination = check_termination(trial_iterate, major_iterations, max_iterations,
                statistics.timers.wallclock.get_elapsed_time(), time_limit, optimization_status, user_callbacks);
 
             // the trial iterate becomes the current iterate for the next iteration

--- a/uno/Uno.cpp
+++ b/uno/Uno.cpp
@@ -135,11 +135,11 @@ namespace uno {
       }
       if (Logger::level == INFO) statistics.print_footer();
 
-      Uno::postprocess_solution(model, current_iterate, evaluation_cache.current_evaluations);
+      postprocess_solution(model, current_iterate, evaluation_cache.current_evaluations);
       statistics.timers.wallclock.stop();
-      Result result = this->create_result(model, optimization_status, current_iterate, evaluation_cache.current_evaluations,
-         major_iterations, statistics.timers);
-      Uno::postprocess_multipliers_signs(model, result);
+      Result result = this->create_result(model, optimization_status, std::move(current_iterate),
+         std::move(evaluation_cache.current_evaluations), major_iterations, statistics.timers);
+      postprocess_multipliers_signs(model, result);
       this->print_optimization_summary(result, options.get_bool("print_solution"));
       return result;
    }
@@ -246,17 +246,17 @@ namespace uno {
       DEBUG2 << "Final iterate:\n" << iterate;
    }
 
-   Result Uno::create_result(const Model& model, OptimizationStatus optimization_status, const Iterate& solution,
-         const Evaluations& evaluations, size_t major_iterations, const Timers& timers) const {
+   Result Uno::create_result(const Model& model, OptimizationStatus optimization_status, Iterate&& solution,
+         Evaluations&& evaluations, size_t major_iterations, const Timers& timers) const {
       const size_t number_subproblems_solved = (this->globalization_mechanism != nullptr) ?
          this->globalization_mechanism->get_number_subproblems_solved() : 0;
       return {model.number_variables, model.number_constraints, model.base_indexing, optimization_status, solution.status,
          evaluations.objective, solution.primal_infeasibility, solution.residuals.stationarity,
-         solution.residuals.complementarity, solution.primals, solution.multipliers.constraints,
-         solution.multipliers.lower_bounds, solution.multipliers.upper_bounds, evaluations.constraints, major_iterations,
-         timers, model.number_model_objective_evaluations(), model.number_model_constraints_evaluations(),
-         model.number_model_objective_gradient_evaluations(), model.number_model_jacobian_evaluations(),
-         model.number_model_hessian_evaluations(), number_subproblems_solved};
+         solution.residuals.complementarity, std::move(solution.primals), std::move(solution.multipliers.constraints),
+         std::move(solution.multipliers.lower_bounds), std::move(solution.multipliers.upper_bounds),
+         std::move(evaluations.constraints), major_iterations, timers, model.number_model_objective_evaluations(),
+         model.number_model_constraints_evaluations(), model.number_model_objective_gradient_evaluations(),
+         model.number_model_jacobian_evaluations(), model.number_model_hessian_evaluations(), number_subproblems_solved};
    }
 
    // flip the signs of the multipliers, depending on what the sign convention of the Lagrangian is, and whether

--- a/uno/Uno.hpp
+++ b/uno/Uno.hpp
@@ -40,8 +40,8 @@ namespace uno {
          double current_time, double time_limit, OptimizationStatus& optimization_status, UserCallbacks& user_callbacks);
       [[nodiscard]] Result uno_solve(const Model& model, Options& options, UserCallbacks& user_callbacks);
       static void postprocess_solution(const Model& model, Iterate& iterate, Evaluations& evaluations);
-      [[nodiscard]] Result create_result(const Model& model, OptimizationStatus optimization_status, const Iterate& solution,
-         const Evaluations& evaluations, size_t major_iterations, const Timers& timers) const;
+      [[nodiscard]] Result create_result(const Model& model, OptimizationStatus optimization_status, Iterate&& solution,
+         Evaluations&& evaluations, size_t major_iterations, const Timers& timers) const;
       static void postprocess_multipliers_signs(const Model& model, Result& result);
       void print_optimization_summary(const Result& result, bool print_solution) const;
    };

--- a/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
+++ b/uno/ingredients/constraint_relaxation_strategies/ConstraintRelaxationStrategy.cpp
@@ -50,10 +50,8 @@ namespace uno {
       iterate.primal_infeasibility = problem.model.constraint_violation(evaluations.constraints, this->residual_norm);
 
       // complementarity error
-      // TODO preallocate constraints
-      Vector<double> constraints(problem.number_constraints);
-      problem.evaluate_constraints(iterate, constraints.view(), evaluations);
-      iterate.residuals.complementarity = problem.complementarity_error(iterate.primals, constraints,
+      problem.evaluate_constraints(iterate, iterate.residuals.constraints_buffer.view(), evaluations);
+      iterate.residuals.complementarity = problem.complementarity_error(iterate.primals, iterate.residuals.constraints_buffer,
          iterate.multipliers, 0., this->residual_norm);
 
       // scaling factors

--- a/uno/optimization/DualResiduals.hpp
+++ b/uno/optimization/DualResiduals.hpp
@@ -10,7 +10,10 @@
 namespace uno {
    class DualResiduals {
    public:
-      explicit DualResiduals(size_t number_variables): lagrangian_gradient(number_variables) { }
+      DualResiduals(size_t number_variables, size_t number_constraints):
+         lagrangian_gradient(number_variables),
+         constraints_buffer(number_constraints) {
+      }
 
       double stationarity{INF<double>};
       double complementarity{INF<double>};
@@ -19,6 +22,7 @@ namespace uno {
       double complementarity_scaling{INF<double>};
 
       Vector<double> lagrangian_gradient;
+      Vector<double> constraints_buffer;
    };
 } // namespace
 

--- a/uno/optimization/Iterate.cpp
+++ b/uno/optimization/Iterate.cpp
@@ -9,7 +9,7 @@ namespace uno {
    Iterate::Iterate(size_t number_variables, size_t number_constraints) :
          number_variables(number_variables), number_constraints(number_constraints),
          primals(number_variables), multipliers(number_variables, number_constraints),
-         residuals(number_variables) {
+         residuals(number_variables, number_constraints) {
    }
 
    void Iterate::set_number_variables(size_t new_number_variables) {

--- a/uno/optimization/OptimizationProblem.cpp
+++ b/uno/optimization/OptimizationProblem.cpp
@@ -295,14 +295,12 @@ namespace uno {
       const double current_constraint_violation = this->model.constraint_violation(current_evaluations.constraints, norm);
 
       // cache the (expensive) Jacobian–direction product Jd and snapshot the current constraints
-      Vector<double> Jv(this->number_constraints);
-      Jv.fill(0.);
-      current_evaluations.compute_jacobian_vector_product(this->model, primal_direction.view(), Jv.view());
-      Vector<double> constraints = current_evaluations.constraints;
+      this->Jv_buffer.fill(0.);
+      current_evaluations.compute_jacobian_vector_product(this->model, primal_direction.view(), this->Jv_buffer.view());
 
-      return [this, norm, current_constraint_violation, Jv = std::move(Jv), constraints = std::move(constraints)]
-            (double step_length) {
-         return current_constraint_violation - this->model.constraint_violation(constraints + step_length * Jv, norm);
+      return [this, &current_evaluations, norm, current_constraint_violation](double step_length) {
+         return current_constraint_violation - this->model.constraint_violation(current_evaluations.constraints +
+            step_length * this->Jv_buffer, norm);
       };
    }
 


### PR DESCRIPTION
- Reduced memory allocations in `ConstraintRelaxationStrategy::compute_residuals` and `OptimizationProblem::build_predicted_infeasibility_reduction`
- Move (and destroy) the solution and the evaluations into the Result instead of copying them